### PR TITLE
Add documentation for "rowKey" property of List component

### DIFF
--- a/components/list/index.en-US.md
+++ b/components/list/index.en-US.md
@@ -14,7 +14,8 @@
 | loadMore | Shows a load more content | string\|slot | - |
 | pagination | Pagination [config](https://vuecomponent.github.io/ant-design-vue/components/pagination/#API), hide it by setting it to false | boolean \| object | false |
 | split | Toggles rendering of the split under the list item | boolean | true |
-| renderItem | Custom item renderer, slot="renderItem" and slot-scope="item, index"  | (item, index) => vNode |  | - |
+| renderItem | Custom item renderer, slot="renderItem" and slot-scope="item, index"  | (item, index) => vNode |  |
+| rowKey | Specify the key that will be used for uniquely identify each element  | item => string\|number |  |
 
 ### List grid props
 

--- a/components/list/index.en-US.md
+++ b/components/list/index.en-US.md
@@ -14,7 +14,7 @@
 | loadMore | Shows a load more content | string\|slot | - |
 | pagination | Pagination [config](https://vuecomponent.github.io/ant-design-vue/components/pagination/#API), hide it by setting it to false | boolean \| object | false |
 | split | Toggles rendering of the split under the list item | boolean | true |
-| renderItem | Custom item renderer, slot="renderItem" and slot-scope="item, index"  | (item, index) => vNode |  |
+| renderItem | Custom item renderer, slot="renderItem" and slot-scope="item, index"  | (item, index) => vNode |  | - |
 | rowKey | Specify the key that will be used for uniquely identify each element  | item => string\|number |  |
 
 ### List grid props

--- a/components/list/index.zh-CN.md
+++ b/components/list/index.zh-CN.md
@@ -16,7 +16,7 @@
 | size | list 的尺寸 | `default` \| `middle` \| `small` | `default` |
 | split | 是否展示分割线 | boolean | true |
 | renderItem | 自定义`Item`函数，也可使用slot="renderItem" 和 slot-scope="item, index" | (item, index) => vNode |  | - |
-| rowKey | 指定将用于唯一标识每个项目的密钥  | item => string\|number |  |
+| rowKey | 各项 key 的取值，可以是字符串或一个函数  | item => string\|number |  |
 
 ### List grid props
 

--- a/components/list/index.zh-CN.md
+++ b/components/list/index.zh-CN.md
@@ -16,6 +16,7 @@
 | size | list 的尺寸 | `default` \| `middle` \| `small` | `default` |
 | split | 是否展示分割线 | boolean | true |
 | renderItem | 自定义`Item`函数，也可使用slot="renderItem" 和 slot-scope="item, index" | (item, index) => vNode |  | - |
+| rowKey | 指定将用于唯一标识每个项目的密钥  | item => string\|number |  |
 
 ### List grid props
 


### PR DESCRIPTION
```rowKey``` is briefly mentioned in the Transfer component documentation, but it also is available on the List component. This property is very useful when you have to perform reordering operations on a list. The provided "index" slot scope does not work when you need to change the order of the items provided to the "dataSource" property, so the ability to define an alternate key for the items is necessary.