### PR TITLE
Change vue cli 3 way of customizing theme

### DIFF
--- a/docs/vue/customize-theme.en-US.md
+++ b/docs/vue/customize-theme.en-US.md
@@ -90,27 +90,17 @@ Create a new file `vue.config.js` in the project directory.
 ```
 // vue.config.js
 module.exports = {
-  configureWebpack: {
-    module: {
-      rules: [{
-        test: /\.less$/,
-        use: [{
-          loader: 'style-loader',
-        }, {
-          loader: 'css-loader',
-        }, {
-          loader: 'less-loader',
-          options: {
-            modifyVars: {
-              'primary-color': '#1DA57A',
-              'link-color': '#1DA57A',
-              'border-radius-base': '2px',
-            },
-            javascriptEnabled: true,
-          },
-        }],
-      }],
-    },
+  css: {
+    loaderOptions: {
+      less: {
+        modifyVars: {
+          'primary-color': '#1DA57A',
+          'link-color': '#1DA57A',
+          'border-radius-base': '2px',
+        },
+        javascriptEnabled: true
+      }
+    }
   }
 }
 ```

--- a/docs/vue/customize-theme.zh-CN.md
+++ b/docs/vue/customize-theme.zh-CN.md
@@ -92,27 +92,17 @@ module.exports = {
 ```
 // vue.config.js
 module.exports = {
-  configureWebpack: {
-    module: {
-      rules: [{
-        test: /\.less$/,
-        use: [{
-          loader: 'style-loader',
-        }, {
-          loader: 'css-loader',
-        }, {
-          loader: 'less-loader',
-          options: {
-            modifyVars: {
-              'primary-color': '#1DA57A',
-              'link-color': '#1DA57A',
-              'border-radius-base': '2px',
-            },
-            javascriptEnabled: true,
-          },
-        }],
-      }],
-    },
+  css: {
+    loaderOptions: {
+      less: {
+        modifyVars: {
+          'primary-color': '#1DA57A',
+          'link-color': '#1DA57A',
+          'border-radius-base': '2px',
+        },
+        javascriptEnabled: true
+      }
+    }
   }
 }
 ```


### PR DESCRIPTION
According to [the vue cli documentation](https://cli.vuejs.org/guide/css.html#passing-options-to-pre-processor-loaders) and my own try, it looks like that the solution proposed before gave an issue, or needed the user to install all loaders.

This solution, however, works like a charm out of the box!

You still have to load the `.less` file instead of `.css`, but that is described lower in the documentation.