### PR TITLE
Patch 1

### DIFF
--- a/components/style/core/base.less
+++ b/components/style/core/base.less
@@ -238,7 +238,7 @@ a {
 
   &:focus {
     text-decoration: underline;
-    text-decoration-skip: ink;
+    text-decoration-skip-ink: auto;
   }
 
   &:hover {

--- a/site/theme/static/common.less
+++ b/site/theme/static/common.less
@@ -18,7 +18,7 @@ a {
   transition: color 0.3s ease;
   &:focus {
     text-decoration: underline;
-    text-decoration-skip: ink;
+    text-decoration-skip-ink: auto;
   }
 }
 


### PR DESCRIPTION
As per spec change https://www.chromestatus.com/feature/5631679087509504

When compiling via vue-cli and webpack, autoprefixer linter throws a warning

```
Replace text-decoration-skip: ink to text-decoration-skip-ink: auto, because spec had been changed
``` 