### PR TITLE
Update list-item.d.ts

### DIFF
--- a/types/list/list-item.d.ts
+++ b/types/list/list-item.d.ts
@@ -6,7 +6,7 @@ import { AntdComponent } from '../component';
 import { Meta } from '../meta';
 
 export declare class ListItem extends AntdComponent {
-  static Meta: Meta;
+  static Meta: typeof Meta;
 
   /**
    * The actions content of list item. If itemLayout is vertical, shows the content on bottom,


### PR DESCRIPTION
### 这个变动的性质是
- [*] TypeScript 定义更新

### 需求背景

> 1. 在做TS项目引用定义文件的时候报错。
> 2. 检查后发现List.Item中对Meta的定义有问题。
> 3. 目前还没有相关的 issue 讨论链接。

### 实现方案和 API（非新功能可选）

> 1. list-item.d.ts文件第9行加上typeof即可

### 请求合并前的自查清单

- [ * ] 文档无须补充
- [ * ] 代码演示无须提供
- [ * ] TypeScript 定义已补充
- [ * ] Changelog 未补充