### PR TITLE
textarea默认值功能

### DIFF
--- a/components/input/TextArea.jsx
+++ b/components/input/TextArea.jsx
@@ -173,11 +173,10 @@ export default {
     return (
       <textarea
         {...textareaProps}
-        value={stateValue}
         class={getTextAreaClassName()}
         style={textareaStyles}
         ref="textArea"
-      />
+      >{{ stateValue }}</textarea>
     );
   },
 };


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. textarea 的 ```defaultValue``` 无法正常使用，因为<textarea>的默认值必须写在标签中间，在属性```value```上设置默认值无效。

