### PR TITLE
fix: scroll measure not work fine on ff of win #579

### DIFF
--- a/components/vc-table/src/utils.js
+++ b/components/vc-table/src/utils.js
@@ -9,7 +9,6 @@ const scrollbarMeasure = {
   top: '-9999px',
   width: '50px',
   height: '50px',
-  overflow: 'scroll',
 };
 
 export function measureScrollbar(direction = 'vertical') {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> scroll measure not work fine on ff of win #579 

### API Realization (Optional if not new feature)

> 1. from https://github.com/react-component/table/commit/12335c2aab534eb8beaeb2223a90a35372b208dc#diff-2b4ca49d4bb0a774c4d4c1672d7aa781

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
>  fix scroll measure not work fine on ff of win
> 2. Chinese description (optional)
> 修正滚动条计算在 windows 下 firefox 无法正确计算的问题

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.

windwos firefix bug:

```
// 有 overflow: 'scroll' 时，ff 下 offsetHeight  与 clientHeight 同高
size = scrollDiv.offsetHeight - scrollDiv.clientHeight; 
```

![20190325010906](https://user-images.githubusercontent.com/5404542/54883135-35be3280-4e9d-11e9-98a0-9f94be1de131.png)
