### PR TITLE
add reject event for drag not accepted files to upload component

### DIFF
--- a/components/upload/Upload.jsx
+++ b/components/upload/Upload.jsx
@@ -136,6 +136,9 @@ export default {
         fileList,
       });
     },
+    onReject(fileList) {
+      this.$emit('reject', fileList);
+    },
     handleRemove(file) {
       const { remove } = getOptionProps(this);
       const { status } = file;
@@ -232,6 +235,7 @@ export default {
         error: this.onError,
         progress: this.onProgress,
         success: this.onSuccess,
+        reject: this.onReject,
       },
       ref: 'uploadRef',
       class: `${prefixCls}-btn`,

--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -28,6 +28,7 @@
 | --- | --- | --- |
 | change | A callback function, can be executed when uploading state is changing. See [change](#change) | Function | - |
 | preview | A callback function, will be executed when file link or preview icon is clicked. | Function(file) | - |
+| reject | A callback function, will be executed when drop files is not accept. | Function(fileList) | - |
 
 
 ### change

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -28,6 +28,7 @@
 | --- | --- | --- |
 | change | 上传文件改变时的状态，详见 [change](#change) | Function | 无 |
 | preview | 点击文件链接或预览图标时的回调 | Function(file) | 无 |
+| reject | 拖拽文件不符合accept类型时的回调 | Function(fileList) | 无 |
 
 ### change
 

--- a/components/vc-upload/src/AjaxUploader.jsx
+++ b/components/vc-upload/src/AjaxUploader.jsx
@@ -1,5 +1,6 @@
 import PropTypes from '../../_util/vue-types';
 import BaseMixin from '../../_util/BaseMixin';
+import partition from 'lodash/partition';
 import classNames from 'classnames';
 import defaultRequest from './request';
 import getUid from './uid';
@@ -74,10 +75,13 @@ const AjaxUploader = {
           attrAccept(_file, this.accept),
         );
       } else {
-        const files = Array.prototype.slice
-          .call(e.dataTransfer.files)
-          .filter(file => attrAccept(file, this.accept));
-        this.uploadFiles(files);
+        const files = partition(Array.prototype.slice.call(e.dataTransfer.files), file =>
+          attrAccept(file, this.accept),
+        );
+        this.uploadFiles(files[0]);
+        if (files[1].length) {
+          this.$emit('reject', files[1]);
+        }
       }
     },
     uploadFiles(files) {


### PR DESCRIPTION
### 这个变动的性质是

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 拖拽文件到upload组件中，如果文件格式不匹配accept，需要给与用户一定的提示

### 实现方案和 API（非新功能可选）

> 1.  增加 reject event ，当文件格式不匹配时执行。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 不break 已有功能

### Changelog 描述（非新功能可选）

> 1. 英文描述
add reject event for drag not accepted files to upload component
> 2. 中文描述（可选）

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）
> 