### PR TITLE
fix(input): fixes #685

### DIFF
--- a/components/input/Input.jsx
+++ b/components/input/Input.jsx
@@ -124,9 +124,18 @@ export default {
       const { prefixCls, size } = this.$props;
       let prefix = getComponentFromProp(this, 'prefix');
       let suffix = getComponentFromProp(this, 'suffix');
-      if (!prefix && !suffix) {
-        return children;
-      }
+
+      // if (!prefix && !suffix) {
+      //   return children;
+      // }
+
+      /**
+       * 注释掉上面的代码是因为
+       * https://github.com/vueComponent/ant-design-vue/issues/685
+       * 当 prevfix 和 suffix 都不存在的时候 最终render出来的 dom 结构发生了变化 （ 少了一个 span 包裹 ）
+       * 当 prevfix 或者 suffix 从隐藏到现实 render 出来的 dom 缺少一个span包裹, vue 应该会替换掉整个dom，从而导致第一次变化的时候，input是个全新的并且没有聚焦
+       *
+       */
 
       prefix = prefix ? <span class={`${prefixCls}-prefix`}>{prefix}</span> : null;
 


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在一个维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> https://github.com/vueComponent/ant-design-vue/issues/685
> fixes #685

### 实现方案和 API（非新功能可选）
input.jsx
![image](https://user-images.githubusercontent.com/25676164/57222794-71b8eb80-7036-11e9-84dc-56e0e6451813.png)

### 对用户的影响和可能的风险（非新功能可选）
无

### Changelog 描述（非新功能可选）

> 1. 修复点那个input 存在一个并且可以控制现实隐藏的 prevfix或者 suffix的时候，prevfix从隐藏到显示的那次变化，input框会失去焦点.


### 请求合并前的自查清单

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。