### PR TITLE
feat: add closable option for confirm dialog

### DIFF
--- a/components/modal/ConfirmDialog.jsx
+++ b/components/modal/ConfirmDialog.jsx
@@ -21,6 +21,7 @@ export default {
       maskStyle,
       okButtonProps,
       cancelButtonProps,
+      closable = false,
     } = props;
     const iconType = props.iconType || 'question-circle';
     const okType = props.okType || 'primary';
@@ -62,6 +63,7 @@ export default {
         wrapClassName={classNames({ [`${contentPrefixCls}-centered`]: !!centered })}
         onCancel={e => close({ triggerCancel: true }, e)}
         visible={visible}
+        closable={closable}
         title=""
         transitionName="zoom"
         footer=""

--- a/components/modal/index.en-US.md
+++ b/components/modal/index.en-US.md
@@ -53,6 +53,7 @@ The properties of the object are follows:
 | autoFocusButton | Specify which button to autofocus | null\|string: `ok` `cancel` | `ok` |
 | cancelText | Text of the Cancel button | string | `Cancel` |
 | centered | Centered Modal | Boolean | `false` |
+| closable | Whether a close (x) button is visible on top right of the modal dialog or not | boolean | `false` |
 | class | class of container | string | - |
 | content | Content | string\|vNode | - |
 | iconType | Icon `type` of the Icon component | string | `question-circle` |

--- a/components/modal/index.zh-CN.md
+++ b/components/modal/index.zh-CN.md
@@ -52,6 +52,7 @@
 | autoFocusButton | 指定自动获得焦点的按钮 | null\|string: `ok` `cancel` | `ok` |
 | cancelText | 取消按钮文字 | string | 取消 |
 | centered | 垂直居中展示 Modal | Boolean | `false` |
+| closable | 是否显示右上角的关闭按钮 | boolean | `false` |
 | class | 容器类名 | string | - |
 | content | 内容 | string\|vNode | 无 |
 | iconType | 图标 Icon 类型 | string | question-circle |

--- a/components/modal/style/confirm.less
+++ b/components/modal/style/confirm.less
@@ -7,10 +7,6 @@
     display: none;
   }
 
-  .@{ant-prefix}-modal-close {
-    display: none;
-  }
-
   .@{ant-prefix}-modal-body {
     padding: 32px 32px 24px;
   }


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

For `Modal` component, when use it like [Modal.method()](https://vue.ant.design/components/modal/#Modal.method()), `close icon` will not display, but in practical, people may need a `close icon` for this dialog, so I made `closable` option for it, and default value is `false`.

### API Realization (Optional if not new feature)

As the background say, we can show `close icon` like below:

```js
Modal.info({
    title: 'This is a notification message',
    content: 'Hello Confirm Modal',
    closable: true,
})
```

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed