### PR TITLE
docs(form-cn): Remove duplicate brace

### DIFF
--- a/components/form/index.zh-CN.md
+++ b/components/form/index.zh-CN.md
@@ -150,7 +150,7 @@ validateFields(['field1', 'field2'], options, (errors, values) => {
 | --- | --- | --- | --- |
 | id | 必填输入控件唯一标志。支持嵌套式的写法。 | string |  |
 | options.getValueFromEvent | 可以把 onChange 的参数（如 event）转化为控件的值 | function(..args) | [reference](https://github.com/react-component/form#option-object) |
-| options.initialValue | 子节点的初始值，类型、可选值均由子节点决定(注意：由于内部校验时使用 `===` 判断是否变化，建议使用变量缓存所需设置的值而非直接使用字面量)) |  |  |
+| options.initialValue | 子节点的初始值，类型、可选值均由子节点决定(注意：由于内部校验时使用 `===` 判断是否变化，建议使用变量缓存所需设置的值而非直接使用字面量) |  |  |
 | options.normalize | 转换默认的 value 给控件，[一个选择全部的例子](https://codesandbox.io/s/kw4l2vqqmv) | function(value, prevValue, allValues): any | - |
 | options.preserve | 即便字段不再使用，也保留该字段的值 | boolean | false |
 | options.rules | 校验规则，参考下方文档 | object\[] |  |


### PR DESCRIPTION
### This is a document update

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

There is duplicate brace in the document of form.

### Self Check before Merge

- [x] Doc is updated
- [x] Demo is not needed
- [x] TypeScript definition is not needed
- [x] Changelog is not needed
