### PR TITLE
fix: sFileList will be 'undefined' when run `form.resetFields()`

### DIFF
--- a/components/upload/Upload.jsx
+++ b/components/upload/Upload.jsx
@@ -40,7 +40,7 @@ export default {
   },
   watch: {
     fileList(val) {
-      this.sFileList = val;
+      this.sFileList = val || [];
     },
   },
   beforeDestroy() {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. If combining Upload Component with Form Component,The Upload component will ocurr Error When running `form.resetFields()`. This is because that the code `form.resetFields()` will make `fileList` to `undefined` and Upload componenet watching `fileList` props to updatae `sFileList`.
> 2. Resolve what problem.
> 3. Issue: https://github.com/vueComponent/ant-design-vue/issues/925