### PR TITLE
列表配置项改为全非必填

### DIFF
--- a/types/table/column.d.ts
+++ b/types/table/column.d.ts
@@ -20,119 +20,119 @@ export declare class Column extends AntdComponent {
    * @default 'left'
    * @type string
    */
-  align: 'left' | 'right' | 'center';
+  align?: 'left' | 'right' | 'center';
 
   /**
    * Span of this column's title
    * @type number
    */
-  colSpan: number;
+  colSpan?: number;
 
   /**
    * Display field of the data record, could be set like a.b.c
    * @type string
    */
-  dataIndex: string;
+  dataIndex?: string;
 
   /**
    * Default order of sorted values: 'ascend' 'descend' null
    * @type string
    */
-  defaultSortOrder: SortOrder;
+  defaultSortOrder?: SortOrder;
 
   /**
    * Customized filter overlay
    * @type any (slot)
    */
-  filterDropdown: any;
+  filterDropdown?: any;
 
   /**
    * Whether filterDropdown is visible
    * @type boolean
    */
-  filterDropdownVisible: boolean;
+  filterDropdownVisible?: boolean;
 
   /**
    * Whether the dataSource is filtered
    * @default false
    * @type boolean
    */
-  filtered: boolean;
+  filtered?: boolean;
 
   /**
    * Controlled filtered value, filter icon will highlight
    * @type string[]
    */
-  filteredValue: string[];
+  filteredValue?: string[];
 
   /**
    * Customized filter icon
    * @default false
    * @type any
    */
-  filterIcon: any;
+  filterIcon?: any;
 
   /**
    * Whether multiple filters can be selected
    * @default true
    * @type boolean
    */
-  filterMultiple: boolean;
+  filterMultiple?: boolean;
 
   /**
    * Filter menu config
    * @type object[]
    */
-  filters: ColumnFilterItem[];
+  filters?: ColumnFilterItem[];
 
   /**
    * Set column to be fixed: true(same as left) 'left' 'right'
    * @default false
    * @type boolean | string
    */
-  fixed: boolean | 'left' | 'right';
+  fixed?: boolean | 'left' | 'right';
 
   /**
    * Unique key of this column, you can ignore this prop if you've set a unique dataIndex
    * @type string
    */
-  key: string;
+  key?: string;
 
   /**
    * Renderer of the table cell. The return value should be a VNode, or an object for colSpan/rowSpan config
    * @type Function | ScopedSlot
    */
-  customRender: Function | ScopedSlot;
+  customRender?: Function | ScopedSlot;
 
   /**
    * Sort function for local sort, see Array.sort's compareFunction. If you need sort buttons only, set to true
    * @type boolean | Function
    */
-  sorter: boolean | Function;
+  sorter?: boolean | Function;
 
   /**
    * Order of sorted values: 'ascend' 'descend' false
    * @type boolean | string
    */
-  sortOrder: boolean | SortOrder;
+  sortOrder?: boolean | SortOrder;
 
   /**
    * Title of this column
    * @type any (string | slot)
    */
-  title: any;
+  title?: any;
 
   /**
    * Width of this column
    * @type string | number
    */
-  width: string | number;
+  width?: string | number;
 
   /**
    * Set props on per cell
    * @type Function
    */
-  customCell: (
+  customCell?: (
     record: any,
     rowIndex: number,
   ) => {
@@ -148,7 +148,7 @@ export declare class Column extends AntdComponent {
    * Set props on per header cell
    * @type
    */
-  customHeaderCell: (
+  customHeaderCell?: (
     column: any,
   ) => {
     props: object;
@@ -163,25 +163,25 @@ export declare class Column extends AntdComponent {
    * Callback executed when the confirm filter button is clicked, Use as a filter event when using template or jsx
    * @type Function
    */
-  onFilter: Function;
+  onFilter?: Function;
 
   /**
    * Callback executed when filterDropdownVisible is changed, Use as a filterDropdownVisible event when using template or jsx
    * @type Function
    */
-  onFilterDropdownVisibleChange: (visible: boolean) => void;
+  onFilterDropdownVisibleChange?: (visible: boolean) => void;
 
   /**
    * When using columns, you can use this property to configure the properties that support the slot,
    * such as slots: { filterIcon: 'XXX'}
    * @type object
    */
-  slots: object;
+  slots?: object;
 
   /**
    * When using columns, you can use this property to configure the properties that support the slot-scope,
    * such as scopedSlots: { customRender: 'XXX'}
    * @type object
    */
-  scopedSlots: object;
+  scopedSlots?: object;
 }


### PR DESCRIPTION
### 这个变动的性质是

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [x] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 描述相关需求的来源。
Table.Column
如果不设置成非必填 再使用的时候 必须包一层非必填的映射 不符合组件文档的说明
> 2. 要解决的问题。
每个字段都要填写
> 3. 相关的 issue 讨论链接。
无
### 请求合并前的自查清单

- [x] 文档无须补充
- [x] 代码演示无须提供
- [x] TypeScript 定义已补充
- [x] Changelog 无须提供