### PR TITLE
Update getDropdownProps.js

### DIFF
--- a/components/dropdown/getDropdownProps.js
+++ b/components/dropdown/getDropdownProps.js
@@ -21,4 +21,5 @@ export default () => ({
   forceRender: PropTypes.bool,
   mouseEnterDelay: PropTypes.number,
   mouseLeaveDelay: PropTypes.number,
+  minOverlayWidthMatchTrigger: PropTypes.bool
 });


### PR DESCRIPTION
dropdown组件增加minOverlayWidthMatchTrigger属性

在某个比较宽的组件上使用dropdown作为右键菜单弹出的右键菜单太宽了。
查看了vc-dropdown中有minOverlayWidthMatchTrigger属性可以控制。
ant-design-vue中现在无法设置这个属性，添加了这个属性。