### PR TITLE
dropdown添加minOverlayWidthMatchTrigger属性

### DIFF
--- a/components/dropdown/getDropdownProps.js
+++ b/components/dropdown/getDropdownProps.js
@@ -21,4 +21,5 @@ export default () => ({
   forceRender: PropTypes.bool,
   mouseEnterDelay: PropTypes.number,
   mouseLeaveDelay: PropTypes.number,
+  minOverlayWidthMatchTrigger: PropTypes.bool
 });

--- a/components/dropdown/getDropdownProps.js
+++ b/components/dropdown/getDropdownProps.js
@@ -21,5 +21,5 @@ export default () => ({
   forceRender: PropTypes.bool,
   mouseEnterDelay: PropTypes.number,
   mouseLeaveDelay: PropTypes.number,
-  minOverlayWidthMatchTrigger: PropTypes.bool
+  minOverlayWidthMatchTrigger: PropTypes.bool,
 });


### PR DESCRIPTION
### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

在某个列表上使用dropdown作为右键菜单弹出的菜单宽度与列表一样宽。
查看了vc-dropdown中有minOverlayWidthMatchTrigger属性可以控制。
ant-design-vue中现在无法设置这个属性，添加了这个属性。
```
<a-dropdown :minOverlayWidthMatchTrigger="false" :trigger="['contextmenu']">
....
</a-dropdown>
```