### PR TITLE
add builtinPlacements prop in shared props

### DIFF
--- a/components/tooltip/abstractTooltipProps.js
+++ b/components/tooltip/abstractTooltipProps.js
@@ -30,4 +30,5 @@ export default () => ({
   autoAdjustOverflow: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]).def(true),
   destroyTooltipOnHide: PropTypes.bool.def(false),
   align: PropTypes.object.def({}),
+  builtinPlacements: PropTypes.object.def({})
 });

--- a/components/tooltip/abstractTooltipProps.js
+++ b/components/tooltip/abstractTooltipProps.js
@@ -30,5 +30,5 @@ export default () => ({
   autoAdjustOverflow: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]).def(true),
   destroyTooltipOnHide: PropTypes.bool.def(false),
   align: PropTypes.object.def({}),
-  builtinPlacements: PropTypes.object.def({})
+  builtinPlacements: PropTypes.object.def({}),
 });


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在一个维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 描述相关需求的来源。
在使用popover过程中，发现不能更精细化的定制overlay的位置
> 2. 要解决的问题。
更精细的控制overlay的位置
> 3. 相关的 issue 讨论链接。
[#1020 ]
### 实现方案和 API（非新功能可选）

> 1. 基本的解决思路和其他可选方案。
因为popover是基于tooltip的，而tooltip内部已经支持[builtinPalcements属性](https://github.com/vueComponent/ant-design-vue/blob/7b3897305bbecefced568e3be0ed850e9807b8a4/components/tooltip/Tooltip.jsx#L64)，仅需要修改
`ant-design-vue/components/tooltip/abstractTooltipProps.js`文件，即可实现需求
> 2. 列出最终的 API 实现和用法。
a-popover(:builtinPlacements='customizedPlacements')
> 3. 涉及UI/交互变动需要有截图或 GIF。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
无影响，因为tooltip的公开文档中并没有说明此方法
> 2. 是否有可能隐含的 break change 和其他风险？
无
### Changelog 描述（非新功能可选）

> 1. 英文描述
> 2. 中文描述（可选）

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。