### PR TITLE
fix: no ConfigProvider's TypeScript definition

### DIFF
--- a/types/ant-design-vue.d.ts
+++ b/types/ant-design-vue.d.ts
@@ -20,6 +20,7 @@ import { Carousel } from './carousel';
 import { Cascader } from './cascader';
 import { Checkbox } from './checkbox/checkbox';
 import { Col } from './grid/col';
+import { ConfigProvider } from './config-provider';
 import { DatePicker } from './date-picker/date-picker';
 import { Divider } from './divider';
 import { Drawer } from './drawer';
@@ -86,6 +87,7 @@ export {
   Cascader,
   Checkbox,
   Col,
+  ConfigProvider,
   DatePicker,
   Divider,
   Dropdown,

--- a/types/config-provider.d.ts
+++ b/types/config-provider.d.ts
@@ -1,0 +1,5 @@
+import { AntdComponent } from './component';
+
+export declare class ConfigProvider extends AntdComponent {
+  getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
+}


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> Project build failed with `Module 'ant-design-vue/types' has no exported member 'ConfigProvider'` in Typescript.

### API Realization (Optional if not new feature)

> Add a definition.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. Add ConfigProvider's TypeScript definition
> 2. 补充 ConfigProvider TypeScript 定义

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.