### PR TITLE
fix: treeNodeLabelProp have no effect

### DIFF
--- a/components/vc-tree-select/src/util.js
+++ b/components/vc-tree-select/src/util.js
@@ -7,7 +7,7 @@ import {
 } from '../../vc-tree/src/util';
 import SelectNode from './SelectNode';
 import { SHOW_CHILD, SHOW_PARENT } from './strategies';
-import { getSlots, getPropsData, isEmptyElement } from '../../_util/props-util';
+import { getSlots, getPropsData, isEmptyElement, getAttrs } from '../../_util/props-util';
 
 let warnDeprecatedLabel = false;
 
@@ -251,9 +251,9 @@ export function getLabel(wrappedValue, entity, treeNodeLabelProp) {
   }
 
   if (entity) {
-    const props = getPropsData(entity.node);
+    const props = Object.assign(getPropsData(entity.node), getAttrs(entity.node));
     if (Object.keys(props).length) {
-      return props[treeNodeLabelProp];
+      return props[treeNodeLabelProp] || props.dataRef[treeNodeLabelProp];
     }
   }
 


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
> 2. Resolve what problem.
when use treedata or treenode ele, the treeNodeLabelProp have no effect
reason:
when the treeNodeLabelProp value not in node prop, it will be in $attrs or dataRef
原因及复现：treeNodeLabelProp指定一个不在prop里的属性
treeNodeLabelProp不在prop里的情况：
指定a-tree-select-node的情况下，treeNodeLabelProp值在$attrs中
指定treeNode的情况下，treeNodeLabelProp值在dataRef中
> 3. Related issue link.
https://github.com/vueComponent/ant-design-vue/issues/1161


### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.