### PR TITLE
fix: Input box does not need to be verified until Chinese input is co…

### DIFF
--- a/components/input/Input.jsx
+++ b/components/input/Input.jsx
@@ -39,7 +39,7 @@ export default {
     const { value, defaultValue } = this.$props;
     return {
       stateValue: !hasProp(this, 'value') ? defaultValue : value,
-      isComposing: false
+      isComposing: false,
     };
   },
   watch: {
@@ -123,7 +123,9 @@ export default {
     },
 
     handleChange(e) {
-      this.setValue(e.target.value, e);
+      if (!e.target.composing) {
+        this.setValue(e.target.value, e);
+      }
     },
     handleComposition(e) {
       if (e.type === 'compositionstart') {
@@ -247,7 +249,7 @@ export default {
           input: handleChange,
           change: noop,
           compositionstart: handleComposition,
-          compositionend: handleComposition
+          compositionend: handleComposition,
         },
         class: getInputClassName(prefixCls),
         ref: 'input',
@@ -270,7 +272,7 @@ export default {
           change: handleChange,
           keydown: handleKeyDown,
           compositionstart: handleComposition,
-          compositionend: handleComposition
+          compositionend: handleComposition,
         },
         directives: [
           {


### PR DESCRIPTION
…mpleted

First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
输入框输入中文，在没输入完之前表单验证还是会生效。这就在一些场景下会出现一些问题，比如输入框验证规则是`不能输入空格`, 那么输入中文期间，会临时以字母的形式显示在输入框，且每个字母之间存在空格，而这个时候表单验证还是会走，那么就会出现验证错误提示。
> 2. Resolve what problem.
使用`compositionstart`和 `compositionend`原生事件处理中文输入问题，在中文输入期间，不需要走验证。
> 3. Related issue link.

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
