### PR TITLE
fix: table style

### DIFF
--- a/components/table/style/index.less
+++ b/components/table/style/index.less
@@ -386,6 +386,13 @@
     .@{table-prefix-cls}-tbody > tr > td {
       border-right: @border-width-base @border-style-base @border-color-split;
     }
+
+    .@{table-prefix-cls}-title + .@{table-prefix-cls}-content {
+      .@{table-prefix-cls}-fixed-left,
+      .@{table-prefix-cls}-fixed-right {
+        border-radius: 0;
+      }
+    }
   }
 
   &-placeholder {


### PR DESCRIPTION
当 table 有 border，title，并且columns左右有fixed，那thead应该是直角的。
![image](https://user-images.githubusercontent.com/50480095/68034920-96e49900-fcfd-11e9-865c-fc9125dc8517.png)