### PR TITLE
fix: statistic countdown typings

### DIFF
--- a/types/statistic/statistic-countdown.d.ts
+++ b/types/statistic/statistic-countdown.d.ts
@@ -5,7 +5,7 @@
 import { AntdComponent } from '../component';
 import { VNode } from 'vue';
 
-export declare class AStatisticCountdown extends AntdComponent {
+export declare class StatisticCountdown extends AntdComponent {
   format: string;
   /**
    * prefix node of value

--- a/types/statistic/statistic.d.ts
+++ b/types/statistic/statistic.d.ts
@@ -4,10 +4,10 @@
 
 import { AntdComponent } from '../component';
 import { VNode } from 'vue';
-import AStatisticCountdown from './statistic-countdown';
+import { StatisticCountdown } from './statistic-countdown';
 
 export declare class Statistic extends AntdComponent {
-  static AStatisticCountdown: typeof AStatisticCountdown;
+  static Countdown: typeof StatisticCountdown;
   /**
    * decimal separator
    * @default '.'


### PR DESCRIPTION

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.

Remove typings error in the console when using ant-design-vue in my project. 

> 2. Resolve what problem.

There is some inconsistancy in the typings of statistic-counted definition file, and that produce the following error during type checking:

`ant-design-vue/types/statistic/statistic-countdown"' has no default export.`

> 3. Related issue link.

Should I create a separate issue ?

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
