### PR TITLE
fix: add typings for Empty component

### DIFF
--- a/types/ant-design-vue.d.ts
+++ b/types/ant-design-vue.d.ts
@@ -26,6 +26,7 @@ import { DatePicker } from './date-picker/date-picker';
 import { Divider } from './divider';
 import { Drawer } from './drawer';
 import { Dropdown } from './dropdown/dropdown';
+import { Empty } from './empty';
 import { Form } from './form/form';
 import { Icon } from './icon';
 import { Input } from './input/input';
@@ -93,6 +94,7 @@ export {
   DatePicker,
   Divider,
   Dropdown,
+  Empty,
   Form,
   Icon,
   Input,

--- a/types/empty.d.ts
+++ b/types/empty.d.ts
@@ -1,0 +1,22 @@
+// Project: https://github.com/vueComponent/ant-design-vue
+// Definitions by: Svreber <https://github.com/Svreber>
+// Definitions: https://github.com/vueComponent/ant-design-vue/types
+
+import { AntdComponent } from './component';
+import { VNode } from 'vue';
+
+export declare class Empty extends AntdComponent {
+  /**
+   * customize description
+   * @type string | VNode
+   */
+  description: string | VNode;
+
+  /**
+   * customize image. Will tread as image url when string provided
+   * @default false
+   * @type string | VNode
+   */
+  image: string | VNode;
+
+}


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [X] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.

The Empty component (added in 1.4.0) has no type def in the ant-design-vue project.

> 2. Resolve what problem.

The Empty component had no typings definition and could not be imported independentely using the Typescript approach.

> 3. Related issue link.

I didn't find any issue regarding this.

### Changelog description (Optional if not new feature)

> 1. English description

Added type definition for Empty component.

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed