### PR TITLE
Menu API Document Update

### DIFF
--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -29,6 +29,7 @@
 | subMenuCloseDelay | delay time to hide submenu when mouse leave, unit: second | number | 0.1 |
 | subMenuOpenDelay | delay time to show submenu when mouse enter, unit: second | number | 0 |
 | theme | color theme of the menu | string: `light` `dark` | `light` |
+| overflowedIndicator | Customized icon when menu is collapsed | DOM | `<span>···</span>` |
 
 ### Menu Events
 

--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -28,6 +28,7 @@
 | subMenuCloseDelay | 用户鼠标离开子菜单后关闭延时，单位：秒 | number | 0.1 |
 | subMenuOpenDelay | 用户鼠标进入子菜单后开启延时，单位：秒 | number | 0 |
 | theme | 主题颜色 | string: `light` `dark` | `light` |
+| overflowedIndicator | 自定义 Menu 折叠时的图标 | DOM | `<span>···</span>` |
 
 ### Menu 事件
 


### PR DESCRIPTION
### This is a ...
Site / document update

### What's the background?

Help to add `overflowedIndicator` parameter description.
the English & Chinese description is copied from the React version.
I have tested it and it works.

帮忙补充Menu的参数API说明.
中文、英文描述来自于React版本的说明.
有测试过可以作用, 且追查源码是存在其功能的.

source code: 

> ant-design-vue/components/vc-menu/Menu.jsx

> line 162
```
        overflowedIndicator: getComponentFromProp(this, 'overflowedIndicator', props) || (
          <span>···</span>
        ),
```
### Self Check before Merge

Doc is updated/provided
