### PR TITLE
fix: tabs trigger nextClick event

### DIFF
--- a/components/vc-tabs/src/ScrollableTabBarNode.jsx
+++ b/components/vc-tabs/src/ScrollableTabBarNode.jsx
@@ -260,8 +260,8 @@ export default {
       this.setOffset(offset + navWrapNodeWH);
     },
 
-    nextClick() {
-      // this.__emit('nextClick', e)
+    nextClick(e) {
+      this.__emit('nextClick', e);
       const navWrapNode = this.$props.getRef('navWrap');
       const navWrapNodeWH = this.getOffsetWH(navWrapNode);
       const { offset } = this;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> ant-design-vue 1.4.8 or early `a-tabs` events `nextClick` not trigger

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
fix: tabs trigger `nextClick` event

> 2. Chinese description (optional)
修复 tabs 组件不触发 `nextClick` 事件

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.


`Allow edits from maintainers`