### PR TITLE
fix: [TreeSelect] type check failed when value is number

### DIFF
--- a/components/tree-select/interface.jsx
+++ b/components/tree-select/interface.jsx
@@ -19,7 +19,7 @@ export const TreeSelectProps = () => ({
   loadData: PropTypes.func,
   maxTagCount: PropTypes.number,
   maxTagPlaceholder: PropTypes.any,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.array]),
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.array, PropTypes.number]),
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.array]),
   multiple: PropTypes.bool,
   notFoundContent: PropTypes.any,

--- a/components/tree-select/interface.jsx
+++ b/components/tree-select/interface.jsx
@@ -20,7 +20,7 @@ export const TreeSelectProps = () => ({
   maxTagCount: PropTypes.number,
   maxTagPlaceholder: PropTypes.any,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.array, PropTypes.number]),
-  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.array]),
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.array, PropTypes.number]),
   multiple: PropTypes.bool,
   notFoundContent: PropTypes.any,
   // onSelect: (value: any) => void,


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.

When value is number `TreeSelect` component will report type check failed warning . It should same as select.

> 2. Resolve what problem.
> 3. Related issue link.

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
