### PR TITLE
fix: [TreeSelect]when init component with dispaly:none ,component can't search #1629

### DIFF
--- a/components/vc-tree-select/src/SearchInput.jsx
+++ b/components/vc-tree-select/src/SearchInput.jsx
@@ -71,7 +71,8 @@ const SearchInput = {
      */
     alignInputWidth() {
       this.inputRef.current.style.width = `${this.mirrorInputRef.current.clientWidth ||
-        this.mirrorInputRef.current.offsetWidth}px`;
+        this.mirrorInputRef.current.offsetWidth ||
+        4}px`;
     },
 
     /**

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
         "less-loader": "^5.0.0",
         "less-plugin-npm-import": "^2.1.0",
         "lint-staged": "^7.2.2",
-        "markdown-it": "^8.4.0",
+        "markdown-it": "^10.0.0",
         "markdown-it-anchor": "^5.0.0",
         "marked": "^0.8.0",
         "merge2": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
         "webpack-cli": "^3.2.1",
         "webpack-dev-server": "^3.1.14",
         "webpack-merge": "^4.1.1",
-        "webpackbar": "^3.1.5",
+        "webpackbar": "^4.0.0",
         "xhr-mock": "^2.5.1"
     },
     "dependencies": {


### PR DESCRIPTION

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
when init component with dispaly:none ,component can't search
> 2. solves the issue[#1629](https://github.com/vueComponent/ant-design-vue/issues/1629)


### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed


