### PR TITLE
fix: fix the "finish" event of statistic countdown

### DIFF
--- a/components/statistic/Countdown.jsx
+++ b/components/statistic/Countdown.jsx
@@ -47,13 +47,8 @@ export default {
     startTimer() {
       if (this.countdownId) return;
       this.countdownId = window.setInterval(() => {
-        const { value } = this.$props;
-        const timestamp = getTime(value);
-
-        if (timestamp < Date.now()) {
-          this.stopTimer();
-        }
         this.$refs.statistic.$forceUpdate();
+        this.syncTimer();
       }, REFRESH_INTERVAL);
     },
 

--- a/components/statistic/Countdown.jsx
+++ b/components/statistic/Countdown.jsx
@@ -47,20 +47,21 @@ export default {
     startTimer() {
       if (this.countdownId) return;
       this.countdownId = window.setInterval(() => {
+        const { value } = this.$props;
+        const timestamp = getTime(value);
+
+        if (timestamp < Date.now()) {
+          this.stopTimer();
+        }
         this.$refs.statistic.$forceUpdate();
       }, REFRESH_INTERVAL);
     },
 
     stopTimer() {
-      const { value } = this.$props;
       if (this.countdownId) {
         clearInterval(this.countdownId);
         this.countdownId = undefined;
-
-        const timestamp = getTime(value);
-        if (timestamp < Date.now()) {
-          this.$emit('finish');
-        }
+        this.$emit('finish');
       }
     },
 

--- a/components/statistic/Countdown.jsx
+++ b/components/statistic/Countdown.jsx
@@ -53,10 +53,15 @@ export default {
     },
 
     stopTimer() {
+      const { value } = this.$props;
       if (this.countdownId) {
         clearInterval(this.countdownId);
         this.countdownId = undefined;
-        this.$emit('finish');
+
+        const timestamp = getTime(value);
+        if (timestamp < Date.now()) {
+          this.$emit('finish');
+        }
       }
     },
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

The `@finish` event in statistic countdown component doesn't work at all.

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
