### PR TITLE
Make parentContext optional in ModalOptions type

### DIFF
--- a/types/modal.d.ts
+++ b/types/modal.d.ts
@@ -128,7 +128,7 @@ export interface ModalOptions {
    */
   onOk?: () => any;
 
-  parentContext: Object;
+  parentContext?: Object;
 }
 
 export interface ModalConfirm {

--- a/types/modal.d.ts
+++ b/types/modal.d.ts
@@ -128,7 +128,7 @@ export interface ModalOptions {
    */
   onOk?: () => any;
 
-  parentContext?: Object;
+  parentContext?: object;
 }
 
 export interface ModalConfirm {


### PR DESCRIPTION
### This is a ...

- [x] TypeScript definition update

### What's the background?

In https://github.com/vueComponent/ant-design-vue/commit/b8a0195379ea0862ae2464a68e92396c17e68604 the `parentContext` field was added to `ModalOptions`.

Since upgrading to 1.4.11 (which is the first release containing this change), I receive build errors in my TypeScript project on code like the following:

```ts
this.$error({ content: 'Error message goes here.' });
```

It produces a build error because the `parentContext` property is now required:

```
Error:(62, 21) TS2345: Argument of type '{ content: string; }' is not assignable to parameter of type 'ModalOptions'.
  Property 'parentContext' is missing in type '{ content: string; }' but required in type 'ModalOptions'.
```

I don't think it was intentional that this property be required (if it was, that's a breaking change and should have been a major semver bump). So the type definition should make it optional.