### PR TITLE
fix: nativeEvent is not a complete Event object

### DIFF
--- a/components/vc-checkbox/src/Checkbox.jsx
+++ b/components/vc-checkbox/src/Checkbox.jsx
@@ -77,6 +77,7 @@ export default {
         this.sChecked = e.target.checked;
       }
       this.$forceUpdate(); // change前，维持现有状态
+      e.shiftKey = this.eventShiftKey
       this.__emit('change', {
         target: {
           ...props,
@@ -88,7 +89,7 @@ export default {
         preventDefault() {
           e.preventDefault();
         },
-        nativeEvent: { ...e, shiftKey: this.eventShiftKey },
+        nativeEvent: e,
       });
       this.eventShiftKey = false;
     },

--- a/components/vc-checkbox/src/Checkbox.jsx
+++ b/components/vc-checkbox/src/Checkbox.jsx
@@ -77,7 +77,7 @@ export default {
         this.sChecked = e.target.checked;
       }
       this.$forceUpdate(); // change前，维持现有状态
-      e.shiftKey = this.eventShiftKey
+      e.shiftKey = this.eventShiftKey;
       this.__emit('change', {
         target: {
           ...props,


### PR DESCRIPTION
The Spread syntax is only get own property of an object，but many properties of Event are on it's prototype chains, so the result is that the passed nativeEvent only has two property: isTrutsed  and shiftKey

First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
> 2. Resolve what problem.
> 3. Related issue link.

#1810

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.