### PR TITLE
feat(checkbox): indeterminate support for options in a checkbox group

### DIFF
--- a/components/checkbox/Checkbox.jsx
+++ b/components/checkbox/Checkbox.jsx
@@ -63,6 +63,7 @@ export default {
       };
       checkboxProps.props.checked = checkboxGroup.sValue.indexOf(props.value) !== -1;
       checkboxProps.props.disabled = props.disabled || checkboxGroup.disabled;
+      checkboxProps.props.indeterminate = indeterminate;
     } else {
       checkboxProps.on.change = this.handleChange;
     }

--- a/components/checkbox/Group.jsx
+++ b/components/checkbox/Group.jsx
@@ -81,6 +81,7 @@ export default {
           prefixCls={prefixCls}
           key={option.value.toString()}
           disabled={'disabled' in option ? option.disabled : props.disabled}
+          indeterminate={option.indeterminate}
           value={option.value}
           checked={state.sValue.indexOf(option.value) !== -1}
           onChange={option.onChange || noop}

--- a/components/checkbox/index.en-US.md
+++ b/components/checkbox/index.en-US.md
@@ -24,7 +24,7 @@
 | --- | --- | --- | --- |
 | defaultValue | Default selected value | string\[] | \[] |
 | disabled | Disable all checkboxes | boolean | false |
-| options | Specifies options, you can customize `label` with slot = "label" slot-scope="option" | string\[] \| Array&lt;{ label: string value: string disabled?: boolean, onChange?: function }> | \[] |
+| options | Specifies options, you can customize `label` with slot = "label" slot-scope="option" | string\[] \| Array&lt;{ label: string, value: string, disabled?: boolean, indeterminate?: boolean, onChange?: function }> | \[] |
 | value | Used for setting the currently selected value. | string\[] | \[] |
 
 #### events

--- a/components/checkbox/index.zh-CN.md
+++ b/components/checkbox/index.zh-CN.md
@@ -24,7 +24,7 @@
 | --- | --- | --- | --- |
 | defaultValue | 默认选中的选项 | string\[] | \[] |
 | disabled | 整组失效 | boolean | false |
-| options | 指定可选项，可以通过 slot="label" slot-scope="option" 定制`label` | string\[] \| Array&lt;{ label: string value: string disabled?: boolean, onChange?: function }> | \[] |
+| options | 指定可选项，可以通过 slot="label" slot-scope="option" 定制`label` | string\[] \| Array&lt;{ label: string, value: string, disabled?: boolean, indeterminate?: boolean, onChange?: function }> | \[] |
 | value | 指定选中的选项 | string\[] | \[] |
 
 #### 事件


### PR DESCRIPTION
### This is a ...

- [x] New feature

### What's the background?

https://github.com/vueComponent/ant-design-vue/issues/1788

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

```js
// checkbox-group's option item support indeterminate field
const options = [
   { value: 'Apple' },
   { label: 'Pear', value: 'Pear' },
   { label: 'Orange', value: 'Orange', indeterminate: true },
];
```

### What's the effect? (Optional if not new feature)

Users can pass the indeterminate as prop via checkbox group's option.

### Changelog description (Optional if not new feature)

> 1. English description

Indeterminate support for options in a checkbox group

> 2. Chinese description (optional)

Checkbox Group 支持通过 option 传递 indeterminate.

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
