### PR TITLE
fixes wrong translation in time-picker component

### DIFF
--- a/components/time-picker/locale/ko_KR.js
+++ b/components/time-picker/locale/ko_KR.js
@@ -1,5 +1,5 @@
 const locale = {
-  placeholder: '날짜 선택',
+  placeholder: '시간 선택',
 };
 
 export default locale;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
> Korean translation of time picker's placeholder text should be '시간 선택'.

### Changelog description (Optional if not new feature)

> 1. English description
fiixes translation .js file's string to be correct.
> 2. Chinese description (optional)

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
