### PR TITLE
fix: page-header组件设置backIcon为false，隐藏backIcon失败问题

### DIFF
--- a/components/page-header/index.jsx
+++ b/components/page-header/index.jsx
@@ -56,7 +56,7 @@ const renderTitle = (h, prefixCls, instance) => {
   const subTitle = getComponentFromProp(instance, 'subTitle');
   const tags = getComponentFromProp(instance, 'tags');
   const extra = getComponentFromProp(instance, 'extra');
-  const backIcon = getComponentFromProp(instance, 'backIcon') || <Icon type="arrow-left" />;
+  const backIcon = getComponentFromProp(instance, 'backIcon') !== undefined ? getComponentFromProp(instance, 'backIcon') : <Icon type="arrow-left" />;
   const onBack = instance.$listeners.back;
   const headingPrefixCls = `${prefixCls}-heading`;
   if (title || subTitle || tags || extra) {


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### Changelog description (Optional if not new feature)

> 1. English description
> 2. 由于项目需要动态判断是否有返回图标，但使用backIcon属性为false，并没有像api上说的能隐藏图标，查看代码后发现是“||” 判断的问题，导致设置为false后显示了默认值

