### PR TITLE
修复#2040 Safari下Tab组件的切换内容丢失

### DIFF
--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -9,7 +9,7 @@
   height: 0;
   padding: 0 !important;
   overflow: hidden;
-  opacity: 0;
+  // opacity: 0;
   pointer-events: none;
   input {
     visibility: hidden;


### PR DESCRIPTION
### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景
修复Safari下Tab组件的切换内容丢失的问题
#2040 

### 实现方案和 API（非新功能可选）
原方案中inactive的tab透明度设置成0，但是tab切换后，透明度变成1以后，Safari没有执行渲染，虽然inactive已经去掉，capacity设置为1，但是tab实际的透明度还是0。把inactive的tab的透明度为0去掉就能避免这个问题


### 对用户的影响和可能的风险（非新功能可选）
我不了解这里inactive的tab透明度设置成0的作用是什么。至少目前来看这个bug在safari上解决了。
如果会引发其他的问题，请再考虑其他方式实现这个透明度变化的问题。

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
