### PR TITLE
Table中有空数据时默认文本显示，column可自定义默认文本，并且优先级高于table

### DIFF
--- a/components/table/Table.jsx
+++ b/components/table/Table.jsx
@@ -59,6 +59,7 @@ export default {
     dataSource: [],
     prefixCls: 'ant-table',
     useFixedHeader: false,
+    columnDefaultText:'无',
     // rowSelection: null,
     size: 'default',
     loading: false,

--- a/components/table/Table.jsx
+++ b/components/table/Table.jsx
@@ -26,16 +26,16 @@ import {
 import BaseMixin from '../_util/BaseMixin';
 import { TableProps } from './interface';
 
-function noop() {}
+function noop () { }
 
-function stopPropagation(e) {
+function stopPropagation (e) {
   e.stopPropagation();
   if (e.nativeEvent && e.nativeEvent.stopImmediatePropagation) {
     e.nativeEvent.stopImmediatePropagation();
   }
 }
 
-function getRowSelection(props) {
+function getRowSelection (props) {
   return props.rowSelection || {};
 }
 
@@ -49,7 +49,6 @@ const defaultPagination = {
  * can works appropriately。
  */
 const emptyObject = {};
-
 export default {
   name: 'Table',
   Column,
@@ -59,7 +58,7 @@ export default {
     dataSource: [],
     prefixCls: 'ant-table',
     useFixedHeader: false,
-    columnDefaultText:'无',
+    columnDefaultText: '无',
     // rowSelection: null,
     size: 'default',
     loading: false,
@@ -77,7 +76,7 @@ export default {
   // columns: ColumnProps<T>[];
   // components: TableComponents;
 
-  data() {
+  data () {
     // this.columns = props.columns || normalizeColumns(props.children)
 
     this.createComponents(this.components);
@@ -97,7 +96,7 @@ export default {
   },
   watch: {
     pagination: {
-      handler(val) {
+      handler (val) {
         this.setState(previousState => {
           const newPagination = {
             ...defaultPagination,
@@ -112,7 +111,7 @@ export default {
       deep: true,
     },
     rowSelection: {
-      handler(val) {
+      handler (val) {
         if (val && 'selectedRowKeys' in val) {
           this.store.setState({
             selectedRowKeys: val.selectedRowKeys || [],
@@ -125,13 +124,13 @@ export default {
       },
       deep: true,
     },
-    dataSource() {
+    dataSource () {
       this.store.setState({
         selectionDirty: false,
       });
       this.CheckboxPropsCache = {};
     },
-    columns(val) {
+    columns (val) {
       if (this.getSortOrderColumns(val).length > 0) {
         const sortState = this.getSortStateFromColumns(val);
         if (
@@ -154,12 +153,12 @@ export default {
         }
       }
     },
-    components(val, preVal) {
+    components (val, preVal) {
       this.createComponents(val, preVal);
     },
   },
   methods: {
-    getCheckboxPropsByItem(item, index) {
+    getCheckboxPropsByItem (item, index) {
       const rowSelection = getRowSelection(this.$props);
       if (!rowSelection.getCheckboxProps) {
         return { props: {} };
@@ -173,7 +172,7 @@ export default {
       return this.CheckboxPropsCache[key];
     },
 
-    getDefaultSelection() {
+    getDefaultSelection () {
       const rowSelection = getRowSelection(this.$props);
       if (!rowSelection.getCheckboxProps) {
         return [];
@@ -185,19 +184,19 @@ export default {
         .map((record, rowIndex) => this.getRecordKey(record, rowIndex));
     },
 
-    getDefaultPagination(props) {
+    getDefaultPagination (props) {
       const pagination = props.pagination || {};
       return this.hasPagination(props)
         ? {
-            ...defaultPagination,
-            ...pagination,
-            current: pagination.defaultCurrent || pagination.current || 1,
-            pageSize: pagination.defaultPageSize || pagination.pageSize || 10,
-          }
+          ...defaultPagination,
+          ...pagination,
+          current: pagination.defaultCurrent || pagination.current || 1,
+          pageSize: pagination.defaultPageSize || pagination.pageSize || 10,
+        }
         : {};
     },
 
-    onRow(record, index) {
+    onRow (record, index) {
       const { prefixCls, customRow } = this;
       const custom = customRow ? customRow(record, index) : {};
       return mergeProps(custom, {
@@ -209,7 +208,7 @@ export default {
       });
     },
 
-    setSelectedRowKeys(selectedRowKeys, selectionInfo) {
+    setSelectedRowKeys (selectedRowKeys, selectionInfo) {
       const { selectWay, record, checked, changeRowKeys, nativeEvent } = selectionInfo;
       const rowSelection = getRowSelection(this.$props);
       if (rowSelection && !('selectedRowKeys' in rowSelection)) {
@@ -242,11 +241,11 @@ export default {
       }
     },
 
-    hasPagination() {
+    hasPagination () {
       return this.pagination !== false;
     },
 
-    isFiltersChanged(filters) {
+    isFiltersChanged (filters) {
       let filtersChanged = false;
       if (Object.keys(filters).length !== Object.keys(this.sFilters).length) {
         filtersChanged = true;
@@ -260,18 +259,18 @@ export default {
       return filtersChanged;
     },
 
-    getSortOrderColumns(columns) {
+    getSortOrderColumns (columns) {
       return flatFilter(columns || this.columns || [], column => 'sortOrder' in column);
     },
 
-    getFilteredValueColumns(columns) {
+    getFilteredValueColumns (columns) {
       return flatFilter(
         columns || this.columns || [],
         column => typeof column.filteredValue !== 'undefined',
       );
     },
 
-    getFiltersFromColumns(columns) {
+    getFiltersFromColumns (columns) {
       const filters = {};
       this.getFilteredValueColumns(columns).forEach(col => {
         const colKey = this.getColumnKey(col);
@@ -280,7 +279,7 @@ export default {
       return filters;
     },
 
-    getDefaultSortOrder(columns) {
+    getDefaultSortOrder (columns) {
       const definedSortState = this.getSortStateFromColumns(columns);
 
       const defaultSortedColumn = flatFilter(
@@ -298,7 +297,7 @@ export default {
       return definedSortState;
     },
 
-    getSortStateFromColumns(columns) {
+    getSortStateFromColumns (columns) {
       // return first column which sortOrder is not falsy
       const sortedColumn = this.getSortOrderColumns(columns).filter(col => col.sortOrder)[0];
 
@@ -315,7 +314,7 @@ export default {
       };
     },
 
-    getSorterFn(state) {
+    getSorterFn (state) {
       const { sSortOrder: sortOrder, sSortColumn: sortColumn } = state || this.$data;
       if (!sortOrder || !sortColumn || typeof sortColumn.sorter !== 'function') {
         return;
@@ -329,7 +328,7 @@ export default {
         return 0;
       };
     },
-    isSameColumn(a, b) {
+    isSameColumn (a, b) {
       if (a && b && a.key && a.key === b.key) {
         return true;
       }
@@ -343,7 +342,7 @@ export default {
       );
     },
 
-    toggleSortOrder(column) {
+    toggleSortOrder (column) {
       if (!column.sorter) {
         return;
       }
@@ -378,7 +377,7 @@ export default {
       );
     },
 
-    handleFilter(column, nextFilters) {
+    handleFilter (column, nextFilters) {
       const props = this.$props;
       const pagination = { ...this.sPagination };
       const filters = {
@@ -444,7 +443,7 @@ export default {
       });
     },
 
-    handleSelect(record, rowIndex, e) {
+    handleSelect (record, rowIndex, e) {
       const checked = e.target.checked;
       const nativeEvent = e.nativeEvent;
       const defaultSelection = this.store.getState().selectionDirty
@@ -513,7 +512,7 @@ export default {
       }
     },
 
-    handleRadioSelect(record, rowIndex, e) {
+    handleRadioSelect (record, rowIndex, e) {
       const checked = e.target.checked;
       const nativeEvent = e.nativeEvent;
       const key = this.getRecordKey(record, rowIndex);
@@ -530,7 +529,7 @@ export default {
       });
     },
 
-    handleSelectRow(selectionKey, index, onSelectFunc) {
+    handleSelectRow (selectionKey, index, onSelectFunc) {
       const data = this.getFlatCurrentPageData(this.$props.childrenColumnName);
       const defaultSelection = this.store.getState().selectionDirty
         ? []
@@ -599,7 +598,7 @@ export default {
       });
     },
 
-    handlePageChange(current, ...otherArguments) {
+    handlePageChange (current, ...otherArguments) {
       const props = this.$props;
       const pagination = { ...this.sPagination };
       if (current) {
@@ -638,7 +637,7 @@ export default {
       );
     },
 
-    renderSelectionBox(type) {
+    renderSelectionBox (type) {
       return (_, record, index) => {
         const rowKey = this.getRecordKey(record, index); // 从 1 开始
         const props = this.getCheckboxPropsByItem(record, index);
@@ -670,7 +669,7 @@ export default {
       };
     },
 
-    getRecordKey(record, index) {
+    getRecordKey (record, index) {
       const { rowKey } = this;
       const recordKey = typeof rowKey === 'function' ? rowKey(record, index) : record[rowKey];
       warning(
@@ -680,11 +679,11 @@ export default {
       return recordKey === undefined ? index : recordKey;
     },
 
-    getPopupContainer() {
+    getPopupContainer () {
       return this.$el;
     },
 
-    renderRowSelection(locale) {
+    renderRowSelection (locale) {
       const { prefixCls, rowSelection, childrenColumnName } = this;
       const columns = this.columns.concat();
       if (rowSelection) {
@@ -739,11 +738,11 @@ export default {
       return columns;
     },
 
-    getColumnKey(column, index) {
+    getColumnKey (column, index) {
       return column.key || column.dataIndex || index;
     },
 
-    getMaxCurrent(total) {
+    getMaxCurrent (total) {
       const { current, pageSize } = this.sPagination;
       if ((current - 1) * pageSize >= total) {
         return Math.floor((total - 1) / pageSize) + 1;
@@ -751,7 +750,7 @@ export default {
       return current;
     },
 
-    isSortColumn(column) {
+    isSortColumn (column) {
       const { sSortColumn: sortColumn } = this;
       if (!column || !sortColumn) {
         return false;
@@ -759,7 +758,7 @@ export default {
       return this.getColumnKey(sortColumn) === this.getColumnKey(column);
     },
 
-    renderColumnsDropdown(columns, locale) {
+    renderColumnsDropdown (columns, locale) {
       const { prefixCls, dropdownPrefixCls } = this;
       const { sSortOrder: sortOrder, sFilters: filters } = this;
       return treeMap(columns, (column, i) => {
@@ -846,7 +845,7 @@ export default {
         };
       });
     },
-    renderColumnTitle(title) {
+    renderColumnTitle (title) {
       const { sFilters: filters, sSortOrder: sortOrder } = this.$data;
       // https://github.com/ant-design/ant-design/issues/11246#issuecomment-405009167
       if (title instanceof Function) {
@@ -858,7 +857,7 @@ export default {
       return title;
     },
 
-    getColumnTitle(title, parentNode) {
+    getColumnTitle (title, parentNode) {
       if (!title) {
         return;
       }
@@ -886,7 +885,7 @@ export default {
       }
     },
 
-    handleShowSizeChange(current, pageSize) {
+    handleShowSizeChange (current, pageSize) {
       const pagination = this.sPagination;
       pagination.onShowSizeChange(current, pageSize);
       const nextPagination = {
@@ -904,7 +903,7 @@ export default {
       );
     },
 
-    renderPagination(paginationPosition) {
+    renderPagination (paginationPosition) {
       // 强制不需要分页
       if (!this.hasPagination()) {
         return null;
@@ -940,7 +939,7 @@ export default {
     },
 
     // Get pagination, filters, sorter
-    prepareParamsArguments(state) {
+    prepareParamsArguments (state) {
       const pagination = { ...state.sPagination };
       // remove useless handle function in Table.onChange
       delete pagination.onChange;
@@ -960,7 +959,7 @@ export default {
       return [pagination, filters, sorter, extra];
     },
 
-    findColumn(myKey) {
+    findColumn (myKey) {
       let column;
       treeMap(this.columns, c => {
         if (this.getColumnKey(c) === myKey) {
@@ -970,7 +969,7 @@ export default {
       return column;
     },
 
-    getCurrentPageData() {
+    getCurrentPageData () {
       let data = this.getLocalData();
       let current;
       let pageSize;
@@ -996,27 +995,27 @@ export default {
       return data;
     },
 
-    getFlatData() {
+    getFlatData () {
       return flatArray(this.getLocalData(null, false));
     },
 
-    getFlatCurrentPageData(childrenColumnName) {
+    getFlatCurrentPageData (childrenColumnName) {
       return flatArray(this.getCurrentPageData(), childrenColumnName);
     },
 
-    recursiveSort(data, sorterFn) {
+    recursiveSort (data, sorterFn) {
       const { childrenColumnName = 'children' } = this;
       return data.sort(sorterFn).map(item =>
         item[childrenColumnName]
           ? {
-              ...item,
-              [childrenColumnName]: this.recursiveSort(item[childrenColumnName], sorterFn),
-            }
+            ...item,
+            [childrenColumnName]: this.recursiveSort(item[childrenColumnName], sorterFn),
+          }
           : item,
       );
     },
 
-    getLocalData(state, filter = true) {
+    getLocalData (state, filter = true) {
       const currentState = state || this.$data;
       const { sFilters: filters } = currentState;
       const { dataSource } = this.$props;
@@ -1041,15 +1040,15 @@ export default {
           const onFilter = col.onFilter;
           data = onFilter
             ? data.filter(record => {
-                return values.some(v => onFilter(v, record));
-              })
+              return values.some(v => onFilter(v, record));
+            })
             : data;
         });
       }
       return data;
     },
 
-    createComponents(components = {}, prevComponents) {
+    createComponents (components = {}, prevComponents) {
       const bodyRow = components && components.body && components.body.row;
       const preBodyRow = prevComponents && prevComponents.body && prevComponents.body.row;
       if (!this.row || bodyRow !== preBodyRow) {
@@ -1064,7 +1063,7 @@ export default {
       };
     },
 
-    renderTable(contextLocale, loading) {
+    renderTable (contextLocale, loading) {
       const locale = { ...contextLocale, ...this.locale };
       const { prefixCls, showHeader, ...restProps } = getOptionProps(this);
       const data = this.getCurrentPageData();
@@ -1082,6 +1081,11 @@ export default {
       columns = columns.map((column, i) => {
         const newColumn = { ...column };
         newColumn.key = this.getColumnKey(newColumn, i);
+        if (!newColumn.columnDefaultText) {
+          if (restProps.columnDefaultText) {
+            newColumn.columnDefaultText = restProps.columnDefaultText;
+          }
+        }
         return newColumn;
       });
       let expandIconColumnIndex = columns[0] && columns[0].key === 'selection-column' ? 1 : 0;
@@ -1109,7 +1113,7 @@ export default {
     },
   },
 
-  render() {
+  render () {
     const { prefixCls } = this;
     const data = this.getCurrentPageData();
 

--- a/components/table/Table.jsx
+++ b/components/table/Table.jsx
@@ -26,16 +26,16 @@ import {
 import BaseMixin from '../_util/BaseMixin';
 import { TableProps } from './interface';
 
-function noop () { }
+function noop() {}
 
-function stopPropagation (e) {
+function stopPropagation(e) {
   e.stopPropagation();
   if (e.nativeEvent && e.nativeEvent.stopImmediatePropagation) {
     e.nativeEvent.stopImmediatePropagation();
   }
 }
 
-function getRowSelection (props) {
+function getRowSelection(props) {
   return props.rowSelection || {};
 }
 
@@ -76,7 +76,7 @@ export default {
   // columns: ColumnProps<T>[];
   // components: TableComponents;
 
-  data () {
+  data() {
     // this.columns = props.columns || normalizeColumns(props.children)
 
     this.createComponents(this.components);
@@ -96,7 +96,7 @@ export default {
   },
   watch: {
     pagination: {
-      handler (val) {
+      handler(val) {
         this.setState(previousState => {
           const newPagination = {
             ...defaultPagination,
@@ -111,7 +111,7 @@ export default {
       deep: true,
     },
     rowSelection: {
-      handler (val) {
+      handler(val) {
         if (val && 'selectedRowKeys' in val) {
           this.store.setState({
             selectedRowKeys: val.selectedRowKeys || [],
@@ -124,13 +124,13 @@ export default {
       },
       deep: true,
     },
-    dataSource () {
+    dataSource() {
       this.store.setState({
         selectionDirty: false,
       });
       this.CheckboxPropsCache = {};
     },
-    columns (val) {
+    columns(val) {
       if (this.getSortOrderColumns(val).length > 0) {
         const sortState = this.getSortStateFromColumns(val);
         if (
@@ -153,12 +153,12 @@ export default {
         }
       }
     },
-    components (val, preVal) {
+    components(val, preVal) {
       this.createComponents(val, preVal);
     },
   },
   methods: {
-    getCheckboxPropsByItem (item, index) {
+    getCheckboxPropsByItem(item, index) {
       const rowSelection = getRowSelection(this.$props);
       if (!rowSelection.getCheckboxProps) {
         return { props: {} };
@@ -172,7 +172,7 @@ export default {
       return this.CheckboxPropsCache[key];
     },
 
-    getDefaultSelection () {
+    getDefaultSelection() {
       const rowSelection = getRowSelection(this.$props);
       if (!rowSelection.getCheckboxProps) {
         return [];
@@ -184,19 +184,19 @@ export default {
         .map((record, rowIndex) => this.getRecordKey(record, rowIndex));
     },
 
-    getDefaultPagination (props) {
+    getDefaultPagination(props) {
       const pagination = props.pagination || {};
       return this.hasPagination(props)
         ? {
-          ...defaultPagination,
-          ...pagination,
-          current: pagination.defaultCurrent || pagination.current || 1,
-          pageSize: pagination.defaultPageSize || pagination.pageSize || 10,
-        }
+            ...defaultPagination,
+            ...pagination,
+            current: pagination.defaultCurrent || pagination.current || 1,
+            pageSize: pagination.defaultPageSize || pagination.pageSize || 10,
+          }
         : {};
     },
 
-    onRow (record, index) {
+    onRow(record, index) {
       const { prefixCls, customRow } = this;
       const custom = customRow ? customRow(record, index) : {};
       return mergeProps(custom, {
@@ -208,7 +208,7 @@ export default {
       });
     },
 
-    setSelectedRowKeys (selectedRowKeys, selectionInfo) {
+    setSelectedRowKeys(selectedRowKeys, selectionInfo) {
       const { selectWay, record, checked, changeRowKeys, nativeEvent } = selectionInfo;
       const rowSelection = getRowSelection(this.$props);
       if (rowSelection && !('selectedRowKeys' in rowSelection)) {
@@ -241,11 +241,11 @@ export default {
       }
     },
 
-    hasPagination () {
+    hasPagination() {
       return this.pagination !== false;
     },
 
-    isFiltersChanged (filters) {
+    isFiltersChanged(filters) {
       let filtersChanged = false;
       if (Object.keys(filters).length !== Object.keys(this.sFilters).length) {
         filtersChanged = true;
@@ -259,18 +259,18 @@ export default {
       return filtersChanged;
     },
 
-    getSortOrderColumns (columns) {
+    getSortOrderColumns(columns) {
       return flatFilter(columns || this.columns || [], column => 'sortOrder' in column);
     },
 
-    getFilteredValueColumns (columns) {
+    getFilteredValueColumns(columns) {
       return flatFilter(
         columns || this.columns || [],
         column => typeof column.filteredValue !== 'undefined',
       );
     },
 
-    getFiltersFromColumns (columns) {
+    getFiltersFromColumns(columns) {
       const filters = {};
       this.getFilteredValueColumns(columns).forEach(col => {
         const colKey = this.getColumnKey(col);
@@ -279,7 +279,7 @@ export default {
       return filters;
     },
 
-    getDefaultSortOrder (columns) {
+    getDefaultSortOrder(columns) {
       const definedSortState = this.getSortStateFromColumns(columns);
 
       const defaultSortedColumn = flatFilter(
@@ -297,7 +297,7 @@ export default {
       return definedSortState;
     },
 
-    getSortStateFromColumns (columns) {
+    getSortStateFromColumns(columns) {
       // return first column which sortOrder is not falsy
       const sortedColumn = this.getSortOrderColumns(columns).filter(col => col.sortOrder)[0];
 
@@ -314,7 +314,7 @@ export default {
       };
     },
 
-    getSorterFn (state) {
+    getSorterFn(state) {
       const { sSortOrder: sortOrder, sSortColumn: sortColumn } = state || this.$data;
       if (!sortOrder || !sortColumn || typeof sortColumn.sorter !== 'function') {
         return;
@@ -328,7 +328,7 @@ export default {
         return 0;
       };
     },
-    isSameColumn (a, b) {
+    isSameColumn(a, b) {
       if (a && b && a.key && a.key === b.key) {
         return true;
       }
@@ -342,7 +342,7 @@ export default {
       );
     },
 
-    toggleSortOrder (column) {
+    toggleSortOrder(column) {
       if (!column.sorter) {
         return;
       }
@@ -377,7 +377,7 @@ export default {
       );
     },
 
-    handleFilter (column, nextFilters) {
+    handleFilter(column, nextFilters) {
       const props = this.$props;
       const pagination = { ...this.sPagination };
       const filters = {
@@ -443,7 +443,7 @@ export default {
       });
     },
 
-    handleSelect (record, rowIndex, e) {
+    handleSelect(record, rowIndex, e) {
       const checked = e.target.checked;
       const nativeEvent = e.nativeEvent;
       const defaultSelection = this.store.getState().selectionDirty
@@ -512,7 +512,7 @@ export default {
       }
     },
 
-    handleRadioSelect (record, rowIndex, e) {
+    handleRadioSelect(record, rowIndex, e) {
       const checked = e.target.checked;
       const nativeEvent = e.nativeEvent;
       const key = this.getRecordKey(record, rowIndex);
@@ -529,7 +529,7 @@ export default {
       });
     },
 
-    handleSelectRow (selectionKey, index, onSelectFunc) {
+    handleSelectRow(selectionKey, index, onSelectFunc) {
       const data = this.getFlatCurrentPageData(this.$props.childrenColumnName);
       const defaultSelection = this.store.getState().selectionDirty
         ? []
@@ -598,7 +598,7 @@ export default {
       });
     },
 
-    handlePageChange (current, ...otherArguments) {
+    handlePageChange(current, ...otherArguments) {
       const props = this.$props;
       const pagination = { ...this.sPagination };
       if (current) {
@@ -637,7 +637,7 @@ export default {
       );
     },
 
-    renderSelectionBox (type) {
+    renderSelectionBox(type) {
       return (_, record, index) => {
         const rowKey = this.getRecordKey(record, index); // 从 1 开始
         const props = this.getCheckboxPropsByItem(record, index);
@@ -669,7 +669,7 @@ export default {
       };
     },
 
-    getRecordKey (record, index) {
+    getRecordKey(record, index) {
       const { rowKey } = this;
       const recordKey = typeof rowKey === 'function' ? rowKey(record, index) : record[rowKey];
       warning(
@@ -679,11 +679,11 @@ export default {
       return recordKey === undefined ? index : recordKey;
     },
 
-    getPopupContainer () {
+    getPopupContainer() {
       return this.$el;
     },
 
-    renderRowSelection (locale) {
+    renderRowSelection(locale) {
       const { prefixCls, rowSelection, childrenColumnName } = this;
       const columns = this.columns.concat();
       if (rowSelection) {
@@ -738,11 +738,11 @@ export default {
       return columns;
     },
 
-    getColumnKey (column, index) {
+    getColumnKey(column, index) {
       return column.key || column.dataIndex || index;
     },
 
-    getMaxCurrent (total) {
+    getMaxCurrent(total) {
       const { current, pageSize } = this.sPagination;
       if ((current - 1) * pageSize >= total) {
         return Math.floor((total - 1) / pageSize) + 1;
@@ -750,7 +750,7 @@ export default {
       return current;
     },
 
-    isSortColumn (column) {
+    isSortColumn(column) {
       const { sSortColumn: sortColumn } = this;
       if (!column || !sortColumn) {
         return false;
@@ -758,7 +758,7 @@ export default {
       return this.getColumnKey(sortColumn) === this.getColumnKey(column);
     },
 
-    renderColumnsDropdown (columns, locale) {
+    renderColumnsDropdown(columns, locale) {
       const { prefixCls, dropdownPrefixCls } = this;
       const { sSortOrder: sortOrder, sFilters: filters } = this;
       return treeMap(columns, (column, i) => {
@@ -845,7 +845,7 @@ export default {
         };
       });
     },
-    renderColumnTitle (title) {
+    renderColumnTitle(title) {
       const { sFilters: filters, sSortOrder: sortOrder } = this.$data;
       // https://github.com/ant-design/ant-design/issues/11246#issuecomment-405009167
       if (title instanceof Function) {
@@ -857,7 +857,7 @@ export default {
       return title;
     },
 
-    getColumnTitle (title, parentNode) {
+    getColumnTitle(title, parentNode) {
       if (!title) {
         return;
       }
@@ -885,7 +885,7 @@ export default {
       }
     },
 
-    handleShowSizeChange (current, pageSize) {
+    handleShowSizeChange(current, pageSize) {
       const pagination = this.sPagination;
       pagination.onShowSizeChange(current, pageSize);
       const nextPagination = {
@@ -903,7 +903,7 @@ export default {
       );
     },
 
-    renderPagination (paginationPosition) {
+    renderPagination(paginationPosition) {
       // 强制不需要分页
       if (!this.hasPagination()) {
         return null;
@@ -939,7 +939,7 @@ export default {
     },
 
     // Get pagination, filters, sorter
-    prepareParamsArguments (state) {
+    prepareParamsArguments(state) {
       const pagination = { ...state.sPagination };
       // remove useless handle function in Table.onChange
       delete pagination.onChange;
@@ -959,7 +959,7 @@ export default {
       return [pagination, filters, sorter, extra];
     },
 
-    findColumn (myKey) {
+    findColumn(myKey) {
       let column;
       treeMap(this.columns, c => {
         if (this.getColumnKey(c) === myKey) {
@@ -969,7 +969,7 @@ export default {
       return column;
     },
 
-    getCurrentPageData () {
+    getCurrentPageData() {
       let data = this.getLocalData();
       let current;
       let pageSize;
@@ -995,27 +995,27 @@ export default {
       return data;
     },
 
-    getFlatData () {
+    getFlatData() {
       return flatArray(this.getLocalData(null, false));
     },
 
-    getFlatCurrentPageData (childrenColumnName) {
+    getFlatCurrentPageData(childrenColumnName) {
       return flatArray(this.getCurrentPageData(), childrenColumnName);
     },
 
-    recursiveSort (data, sorterFn) {
+    recursiveSort(data, sorterFn) {
       const { childrenColumnName = 'children' } = this;
       return data.sort(sorterFn).map(item =>
         item[childrenColumnName]
           ? {
-            ...item,
-            [childrenColumnName]: this.recursiveSort(item[childrenColumnName], sorterFn),
-          }
+              ...item,
+              [childrenColumnName]: this.recursiveSort(item[childrenColumnName], sorterFn),
+            }
           : item,
       );
     },
 
-    getLocalData (state, filter = true) {
+    getLocalData(state, filter = true) {
       const currentState = state || this.$data;
       const { sFilters: filters } = currentState;
       const { dataSource } = this.$props;
@@ -1040,15 +1040,15 @@ export default {
           const onFilter = col.onFilter;
           data = onFilter
             ? data.filter(record => {
-              return values.some(v => onFilter(v, record));
-            })
+                return values.some(v => onFilter(v, record));
+              })
             : data;
         });
       }
       return data;
     },
 
-    createComponents (components = {}, prevComponents) {
+    createComponents(components = {}, prevComponents) {
       const bodyRow = components && components.body && components.body.row;
       const preBodyRow = prevComponents && prevComponents.body && prevComponents.body.row;
       if (!this.row || bodyRow !== preBodyRow) {
@@ -1063,7 +1063,7 @@ export default {
       };
     },
 
-    renderTable (contextLocale, loading) {
+    renderTable(contextLocale, loading) {
       const locale = { ...contextLocale, ...this.locale };
       const { prefixCls, showHeader, ...restProps } = getOptionProps(this);
       const data = this.getCurrentPageData();
@@ -1113,7 +1113,7 @@ export default {
     },
   },
 
-  render () {
+  render() {
     const { prefixCls } = this;
     const data = this.getCurrentPageData();
 

--- a/components/table/Table.jsx
+++ b/components/table/Table.jsx
@@ -58,7 +58,7 @@ export default {
     dataSource: [],
     prefixCls: 'ant-table',
     useFixedHeader: false,
-    columnDefaultText: '无',
+    tableDefaultText: '无',
     // rowSelection: null,
     size: 'default',
     loading: false,
@@ -1082,8 +1082,8 @@ export default {
         const newColumn = { ...column };
         newColumn.key = this.getColumnKey(newColumn, i);
         if (!newColumn.columnDefaultText) {
-          if (restProps.columnDefaultText) {
-            newColumn.columnDefaultText = restProps.columnDefaultText;
+          if (restProps.tableDefaultText) {
+            newColumn.columnDefaultText = restProps.tableDefaultText;
           }
         }
         return newColumn;

--- a/components/table/demo/basic.md
+++ b/components/table/demo/basic.md
@@ -1,3 +1,11 @@
+<!--
+ * @Descripttion: 
+ * @version: 
+ * @Author: zero
+ * @Date: 2020-04-16 15:07:58
+ * @LastEditors: zero
+ * @LastEditTime: 2020-04-16 16:59:15
+ -->
 <cn>
 #### 基本用法
 简单的表格，最后一列是各种操作。
@@ -66,7 +74,7 @@ const data = [{
   tags: ['loser'],
 }, {
   key: '3',
-  name: 'Joe Black',
+  name: '',
   age: 32,
   address: 'Sidney No. 1 Lake Park',
   tags: ['cool', 'teacher'],

--- a/components/table/demo/basic.md
+++ b/components/table/demo/basic.md
@@ -1,12 +1,3 @@
-<!--
- * @Descripttion: 
- * @version: 
- * @Author: zero
- * @Date: 2020-04-16 15:07:58
- * @LastEditors: zero
- * @LastEditTime: 2020-04-16 16:59:15
- -->
-<cn>
 #### 基本用法
 简单的表格，最后一列是各种操作。
 </cn>

--- a/components/table/demo/index.vue
+++ b/components/table/demo/index.vue
@@ -1,6 +1,7 @@
 <script>
 import Ajax from './ajax.md';
 import Basic from './basic.md';
+import TableDefaultText from './tableDefaultText';
 import Bordered from './bordered.md';
 import ColspanRowspan from './colspan-rowspan.md';
 import CustomFilterPanel from './custom-filter-panel.md';
@@ -64,6 +65,7 @@ export default {
         <md cn={md.cn} us={md.us}/>
         <Ajax />
         <Basic />
+        <TableDefaultText />
         <Bordered />
         <ColspanRowspan />
         <CustomFilterPanel />

--- a/components/table/demo/tableDefaultText.md
+++ b/components/table/demo/tableDefaultText.md
@@ -1,16 +1,18 @@
 <cn>
-#### 基本用法
-简单的表格，最后一列是各种操作。
+#### 列表项存在空数据时默认显示
+通过Table上的tableDefaultText属性可以当表格里有数据为空时默认显示tableDefaultText的值
+通过columns的columnDefaultText属性可以自定义该列中数据为空时默认显示自定义columns中columnDefaultText的值，且优先级高于table
 </cn>
 
 <us>
-#### basic Usage
-Simple table with actions.
+#### List items appear by default when there is empty data
+The tableDefaultText property on the Table can be used to display the value of tableDefaultText by default when the data in the table is empty.
+The columnDefaultText property of the columns can be used to customize the default value of the columnDefaultText in the custom columns when the data in the column is empty
 </us>
 
 ```html
 <template>
-  <a-table :columns="columns" :dataSource="data">
+  <a-table :columns="columns" :dataSource="data" tableDefaultText='无'>
     <a slot="name" slot-scope="text" href="javascript:;">{{text}}</a>
     <span slot="customTitle"><a-icon type="smile-o" /> Name</span>
     <span slot="tags" slot-scope="tags">
@@ -41,6 +43,7 @@ const columns = [{
   title: 'Address',
   dataIndex: 'address',
   key: 'address',
+  columnDefaultText:'未填写地址'
 }, {
   title: 'Tags',
   key: 'tags',
@@ -67,8 +70,8 @@ const data = [{
 }, {
   key: '3',
   name: 'Joe Black',
-  age: 32,
-  address: 'Sidney No. 1 Lake Park',
+  age: '',
+  address: '',
   tags: ['cool', 'teacher'],
 }];
 

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -37,6 +37,7 @@ const columns = [{
 | --- | --- | --- | --- |
 | bordered | 是否展示外边框和列边框 | boolean | false |
 | childrenColumnName | 指定树形结构的列名 | string\[] | children |
+| tableDefaultText | 设置Table全局数据为空时的显示文本 | string | '无' |
 | columns | 表格列的配置描述，具体项见下表 | array | - |
 | components | 覆盖默认的 table 元素 | object | - |
 | dataSource | 数据数组 | any\[] |  |
@@ -108,6 +109,7 @@ const columns = [{
 | align | 设置列内容的对齐方式 | 'left' \| 'right' \| 'center' | 'left' |
 | colSpan | 表头列合并,设置为 0 时，不渲染 | number |  |
 | dataIndex | 列数据在数据项中对应的 key，支持 `a.b.c` 的嵌套写法 | string | - |
+| columnDefaultText | 设置Column该列数据为空时的显示文本,优先级高于Table | string | 与Table的tableDefaultText一致 |
 | filterDropdown | 可以自定义筛选菜单，此函数只负责渲染图层，需要自行编写各种交互 | VNode \| slot-scope | - |
 | filterDropdownVisible | 用于控制自定义筛选菜单是否可见 | boolean | - |
 | filtered | 标识数据是否经过过滤，筛选图标会高亮 | boolean | false |

--- a/components/table/interface.js
+++ b/components/table/interface.js
@@ -87,6 +87,7 @@ export const TableRowSelection = {
 
 export const TableProps = {
   prefixCls: PropTypes.string,
+  columnDefaultText:PropTypes.string,
   dropdownPrefixCls: PropTypes.string,
   rowSelection: PropTypes.oneOfType([PropTypes.shape(TableRowSelection).loose, null]),
   pagination: PropTypes.oneOfType([

--- a/components/table/interface.js
+++ b/components/table/interface.js
@@ -88,7 +88,7 @@ export const TableRowSelection = {
 
 export const TableProps = {
   prefixCls: PropTypes.string,
-  columnDefaultText:PropTypes.string,
+  tableDefaultText:PropTypes.string,
   dropdownPrefixCls: PropTypes.string,
   rowSelection: PropTypes.oneOfType([PropTypes.shape(TableRowSelection).loose, null]),
   pagination: PropTypes.oneOfType([

--- a/components/table/interface.js
+++ b/components/table/interface.js
@@ -19,6 +19,7 @@ export const ColumnProps = {
   dataIndex: PropTypes.string,
   customRender: PropTypes.func,
   customCell: PropTypes.func,
+  columnDefaultText: PropTypes.string,
   customHeaderCell: PropTypes.func,
   align: PropTypes.oneOf(['left', 'right', 'center']),
   filters: PropTypes.arrayOf(ColumnFilterItem),

--- a/components/vc-table/src/Column.jsx
+++ b/components/vc-table/src/Column.jsx
@@ -6,6 +6,7 @@ export default {
     colSpan: PropTypes.number,
     title: PropTypes.any,
     dataIndex: PropTypes.string,
+    columnDefaultText: PropTypes.string,
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     fixed: PropTypes.oneOf([true, 'left', 'right']),
     customRender: PropTypes.func,

--- a/components/vc-table/src/Table.jsx
+++ b/components/vc-table/src/Table.jsx
@@ -69,7 +69,6 @@ export default {
     {
       data: [],
       useFixedHeader: false,
-      columnDefaultText: '无',
       rowKey: 'key',
       rowClassName: () => '',
       prefixCls: 'rc-table',

--- a/components/vc-table/src/Table.jsx
+++ b/components/vc-table/src/Table.jsx
@@ -20,7 +20,7 @@ export default {
     {
       data: PropTypes.array,
       useFixedHeader: PropTypes.bool,
-      columnDefaultText: PropTypes.string,
+      tableDefaultText: PropTypes.string,
       columns: PropTypes.array,
       prefixCls: PropTypes.string,
       bodyStyle: PropTypes.object,

--- a/components/vc-table/src/Table.jsx
+++ b/components/vc-table/src/Table.jsx
@@ -20,6 +20,7 @@ export default {
     {
       data: PropTypes.array,
       useFixedHeader: PropTypes.bool,
+      columnDefaultText: PropTypes.string,
       columns: PropTypes.array,
       prefixCls: PropTypes.string,
       bodyStyle: PropTypes.object,
@@ -68,6 +69,7 @@ export default {
     {
       data: [],
       useFixedHeader: false,
+      columnDefaultText: '无',
       rowKey: 'key',
       rowClassName: () => '',
       prefixCls: 'rc-table',

--- a/components/vc-table/src/TableCell.jsx
+++ b/components/vc-table/src/TableCell.jsx
@@ -43,17 +43,20 @@ export default {
       column,
       component: BodyCell,
     } = this;
-    const { dataIndex, customRender, className = '' } = column;
+    const { dataIndex, customRender, className = '', columnDefaultText } = column;
     const cls = className || column.class;
     // We should return undefined if no dataIndex is specified, but in order to
     // be compatible with object-path's behavior, we return the record object instead.
     let text;
     if (typeof dataIndex === 'number') {
-      text = get(record, dataIndex);
+      text = get(record, dataIndex) || columnDefaultText;
     } else if (!dataIndex || dataIndex.length === 0) {
-      text = record;
+      text = record || columnDefaultText;
+      if (columnDefaultText) {
+        text = columnDefaultText;
+      }
     } else {
-      text = get(record, dataIndex);
+      text = get(record, dataIndex) || columnDefaultText;
     }
     let tdProps = {
       props: {},

--- a/components/vc-table/src/TableCell.jsx
+++ b/components/vc-table/src/TableCell.jsx
@@ -52,9 +52,6 @@ export default {
       text = get(record, dataIndex) || columnDefaultText;
     } else if (!dataIndex || dataIndex.length === 0) {
       text = record || columnDefaultText;
-      if (columnDefaultText) {
-        text = columnDefaultText;
-      }
     } else {
       text = get(record, dataIndex) || columnDefaultText;
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,11 @@
+/*
+ * @Descripttion: 
+ * @version: 
+ * @Author: zero
+ * @Date: 2020-04-16 15:07:58
+ * @LastEditors: zero
+ * @LastEditTime: 2020-04-16 15:13:51
+ */
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const merge = require('webpack-merge');
@@ -31,7 +39,6 @@ module.exports = merge(baseWebpackConfig, {
   },
   devServer: {
     port: 3000,
-    host: '0.0.0.0',
     historyApiFallback: {
       rewrites: [{ from: /./, to: '/index.html' }],
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,3 @@
-/*
- * @Descripttion: 
- * @version: 
- * @Author: zero
- * @Date: 2020-04-16 15:07:58
- * @LastEditors: zero
- * @LastEditTime: 2020-04-16 15:13:51
- */
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const merge = require('webpack-merge');


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

### 这个变动的性质是

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 当Tblle中有空数据时，需要显示默认文本。
> 2. 需要将新的tableDefaultText属性添加到Table组件中，以默认显示空数据。 为了在列数据为空时使列自定义默认文本，需要将columnDefaultText属性添加到该列，并且columnDefaultText的优先级高于tableDefaultText。

### 实现方案和 API（非新功能可选）

> 1. 默认情况下，将新的tableDefaultText属性添加到表组件以显示空数据。 要在列数据为空时自定义列的默认文本，需要将columnDefaultText属性添加到该列，并且columnDefaultText的优先级高于tableDefaultText。 没有为列设置columnDefaultText。 在该列的最终呈现文本中，如果数据为空，则使用columnDefaultText.
> 2. 将新的tableDefaultText属性添加到表组件以显示空数据。 要在列数据为空时自定义列的默认文本，需要将columnDefaultText属性添加到该列，并且columnDefaultText的优先级高于tableDefaultText。 没有为列设置columnDefaultText。 在该列的最终呈现文本中，如果数据为空，则使用columnDefaultText。


### 对用户的影响和可能的风险（非新功能可选）

> 1. 当table表存在空数据时，空数据会显示默认的tableDefaultText，如果自定义了columnDefaultText，则该列中的空数据会显示columnDefaultTex的值

### Changelog 描述（非新功能可选）

> 1. Table.jsx adds the tableDefaultText property, and adds the value of tableDefaultText to columnDefaultText if the columnDefaultText value is not set in column in the renderTable method. Added corresponding properties to TableProps and ColumnProps in interface.js, and added columnDefaultText for this column by default when the text is empty in TableCell.jsx
> 2. Table.jsx添加tableDefaultText属性，如果未在renderTable方法的column中设置columnDefaultText值，则将tableDefaultText的值添加到columnDefaultText。 在TableCell.jsx中，当文本为空时，在interface.js中为TableProps和ColumnProps添加了相应的属性，并且默认情况下为此列添加了columnDefaultText。

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。
