### PR TITLE
Table中有空数据时设置默认文本显示，column可自定义默认文本，并且优先级高于table

### DIFF
--- a/components/table/Table.jsx
+++ b/components/table/Table.jsx
@@ -115,6 +115,7 @@ export default {
   props: initDefaultProps(TableProps, {
     dataSource: [],
     useFixedHeader: false,
+    tableDefaultText: '无',
     // rowSelection: null,
     size: 'default',
     loading: false,
@@ -1199,6 +1200,11 @@ export default {
       }).map((column, i) => {
         const newColumn = { ...column };
         newColumn.key = getColumnKey(newColumn, i);
+        if (!newColumn.columnDefaultText) {
+          if (restProps.tableDefaultText) {
+            newColumn.columnDefaultText = restProps.tableDefaultText;
+          }
+        }
         return newColumn;
       });
 

--- a/components/table/interface.js
+++ b/components/table/interface.js
@@ -19,6 +19,7 @@ export const ColumnProps = {
   dataIndex: PropTypes.string,
   customRender: PropTypes.func,
   customCell: PropTypes.func,
+  columnDefaultText: PropTypes.string,
   customHeaderCell: PropTypes.func,
   align: PropTypes.oneOf(['left', 'right', 'center']),
   ellipsis: PropTypes.bool,
@@ -92,6 +93,7 @@ export const TableRowSelection = {
 
 export const TableProps = {
   prefixCls: PropTypes.string,
+  tableDefaultText: PropTypes.string,
   dropdownPrefixCls: PropTypes.string,
   rowSelection: PropTypes.oneOfType([PropTypes.shape(TableRowSelection).loose, null]),
   pagination: PropTypes.oneOfType([

--- a/components/vc-table/src/Column.jsx
+++ b/components/vc-table/src/Column.jsx
@@ -7,6 +7,7 @@ export default {
     colSpan: PropTypes.number,
     title: PropTypes.any,
     dataIndex: PropTypes.string,
+    columnDefaultText: PropTypes.string,
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     ellipsis: PropTypes.bool,
     fixed: PropTypes.oneOf([true, 'left', 'right']),

--- a/components/vc-table/src/Table.jsx
+++ b/components/vc-table/src/Table.jsx
@@ -22,6 +22,7 @@ export default {
     {
       data: PropTypes.array,
       useFixedHeader: PropTypes.bool,
+      tableDefaultText: PropTypes.string,
       columns: PropTypes.array,
       prefixCls: PropTypes.string,
       bodyStyle: PropTypes.object,

--- a/components/vc-table/src/TableCell.jsx
+++ b/components/vc-table/src/TableCell.jsx
@@ -44,16 +44,16 @@ export default {
       column,
       component: BodyCell,
     } = this;
-    const { dataIndex, customRender, className = '' } = column;
+    const { dataIndex, customRender, className = '', columnDefaultText } = column;
     // We should return undefined if no dataIndex is specified, but in order to
     // be compatible with object-path's behavior, we return the record object instead.
     let text;
     if (typeof dataIndex === 'number') {
-      text = get(record, dataIndex);
+      text = get(record, dataIndex) || columnDefaultText;
     } else if (!dataIndex || dataIndex.length === 0) {
-      text = record;
+      text = record || columnDefaultText;
     } else {
-      text = get(record, dataIndex);
+      text = get(record, dataIndex) || columnDefaultText;
     }
     let tdProps = {
       props: {},


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

### 这个变动的性质是

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 当Tblle中有空数据时，需要显示默认文本。
> 2. 需要将新的tableDefaultText属性添加到Table组件中，以默认显示空数据。 为了在列数据为空时使列自定义默认文本，需要将columnDefaultText属性添加到该列，并且columnDefaultText的优先级高于tableDefaultText。

### 实现方案和 API（非新功能可选）

> 1. 默认情况下，将新的tableDefaultText属性添加到表组件以显示空数据。 要在列数据为空时自定义列的默认文本，需要将columnDefaultText属性添加到该列，并且columnDefaultText的优先级高于tableDefaultText。 没有为列设置columnDefaultText。 在该列的最终呈现文本中，如果数据为空，则使用columnDefaultText.
> 2. 将新的tableDefaultText属性添加到表组件以显示空数据。 要在列数据为空时自定义列的默认文本，需要将columnDefaultText属性添加到该列，并且columnDefaultText的优先级高于tableDefaultText。 没有为列设置columnDefaultText。 在该列的最终呈现文本中，如果数据为空，则使用columnDefaultText。


### 对用户的影响和可能的风险（非新功能可选）

> 1. 当table表存在空数据时，空数据会显示默认的tableDefaultText，如果自定义了columnDefaultText，则该列中的空数据会显示columnDefaultTex的值

### Changelog 描述（非新功能可选）

> 1. Table.jsx adds the tableDefaultText property, and adds the value of tableDefaultText to columnDefaultText if the columnDefaultText value is not set in column in the renderTable method. Added corresponding properties to TableProps and ColumnProps in interface.js, and added columnDefaultText for this column by default when the text is empty in TableCell.jsx
> 2. Table.jsx添加tableDefaultText属性，如果未在renderTable方法的column中设置columnDefaultText值，则将tableDefaultText的值添加到columnDefaultText。 在TableCell.jsx中，当文本为空时，在interface.js中为TableProps和ColumnProps添加了相应的属性，并且默认情况下为此列添加了columnDefaultText。
> 修改了components\vc-table\src\Table.jsx，components\table\Table.jsx，components\table\interface.js，components\vc-table\src\Column.jsx 4个文件
> 增加了antdv-demo\tableDefaultText.md文档说明

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。

