### PR TITLE
修复tsx语法糖下FormModel组件内部获取不到this.model

### DIFF
--- a/components/form-model/Form.jsx
+++ b/components/form-model/Form.jsx
@@ -47,6 +47,10 @@ export const ValidationRule = {
 
 const Form = {
   name: 'AFormModel',
+  model: {
+    prop: 'model',
+    event: 'change'
+  },
   props: initDefaultProps(FormProps, {
     layout: 'horizontal',
     hideRequiredMark: false,

--- a/components/form-model/Form.jsx
+++ b/components/form-model/Form.jsx
@@ -49,7 +49,7 @@ const Form = {
   name: 'AFormModel',
   model: {
     prop: 'model',
-    event: 'change'
+    event: 'change',
   },
   props: initDefaultProps(FormProps, {
     layout: 'horizontal',


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

tsx语法糖下双向绑定form-model组件内部获取不到this.model,导致validate/resetFields报错
#2122 

### 实现方案和 API（非新功能可选）

定义自定义组件model属性

### 对用户的影响和可能的风险（非新功能可选）

无影响

### Changelog 描述（非新功能可选）

> 1. 英文描述
use model option fix tsx syntax.
> 2. 中文描述（可选）
使用model选项实现双向绑定，修正tsx语法糖下解析错误

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。