### PR TITLE
feat(style): add @modal-header-border-color-split variable

### DIFF
--- a/components/modal/style/modal.less
+++ b/components/modal/style/modal.less
@@ -83,7 +83,7 @@
     padding: 16px 24px;
     color: @text-color;
     background: @modal-header-bg;
-    border-bottom: @border-width-base @border-style-base @border-color-split;
+    border-bottom: @border-width-base @border-style-base @modal-header-border-color-split;
     border-radius: @border-radius-base @border-radius-base 0 0;
   }
 

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -394,6 +394,7 @@
 // --
 @modal-body-padding: 24px;
 @modal-header-bg: @component-background;
+@modal-header-border-color-split: @border-color-split;
 @modal-heading-color: @heading-color;
 @modal-footer-bg: transparent;
 @modal-footer-border-color-split: @border-color-split;


### PR DESCRIPTION
### This is a **Component style update for Modal**

### What's the background?

We're using antdv as our project's component library. I was looking to change to header split border's color when I realized the less variable was missing.

`@modal-footer-border-color-split` exists in this project and even `@modal-header-border-color-split` exists in antd of React library so I thought it makes sense that it also exists here. 

I haven't found any issues regarding this, and instead of opening one, I'm opening a PR that adds the variable to default.less and uses it in modal.less

### What's the effect?

This change allows the customization of modal component's header's split border's color to be customized separately from other split border colors.

Has no effect unless the variable is set to a different value in a custom theme. No breaking changes.

Resolves #2196 

### Changelog description

Added @modal-header-border-color-split theme variable.