### PR TITLE
fix: compile error when updating less-loader to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
         "json-templater": "^1.2.0",
         "jsonp": "^0.2.1",
         "less": "^3.9.0",
-        "less-loader": "^5.0.0",
+        "less-loader": "^6.0.0",
         "less-plugin-npm-import": "^2.1.0",
         "lint-staged": "^10.0.0",
         "marked": "0.3.18",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,15 @@ module.exports = {
             loader: 'css-loader',
             options: { sourceMap: true },
           },
-          { loader: 'less-loader', options: { sourceMap: true, javascriptEnabled: true } },
+          {
+            loader: 'less-loader',
+            options: {
+              lessOptions: {
+                sourceMap: true,
+                javascriptEnabled: true,
+              },
+            },
+          },
         ],
       },
       {


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [x] Other (about what?)

### What's the background?
> 1. Describe the source of requirement.
> 2. Resolve what problem.
Compile errors that occur when `less-loader` v6.0.0 is used
> 3. Related issue link.
[#2180](https://github.com/vueComponent/ant-design-vue/pull/2180)

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
[#2150](https://github.com/vueComponent/ant-design-vue/pull/2150)