### PR TITLE
style: fix select focused in input group

### DIFF
--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -327,6 +327,10 @@
       }
     }
 
+    & > .@{ant-prefix}-select-focused {
+      z-index: 1;
+    }
+
     & > *:first-child,
     & > .@{ant-prefix}-select:first-child > .@{ant-prefix}-select-selection,
     & > .@{ant-prefix}-calendar-picker:first-child .@{ant-prefix}-input,


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

same as : https://github.com/ant-design/ant-design/issues/23984

### Changelog description (Optional if not new feature)

- EN：Fix Select focus border style in Input.Group
- CN：修复 Input.Group 中 Select 选项 focus 边框样式

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
