### PR TITLE
fix(select): error onclick showAction 'focus'

### DIFF
--- a/components/vc-select/Select.jsx
+++ b/components/vc-select/Select.jsx
@@ -507,6 +507,21 @@ const Select = {
     onArrowClick(e) {
       e.stopPropagation();
       e.preventDefault();
+
+      if (this._preventNextArrowClick) {
+        this._preventNextArrowClick = false;
+        return;
+      }
+
+      this.clearBlurTime();
+      if (!this.disabled) {
+        this.setOpenState(!this.$data._open, { needFocus: !this.$data._open });
+      }
+    },
+
+    onArrowFocus(e) {
+      this._preventNextArrowClick = true;
+
       this.clearBlurTime();
       if (!this.disabled) {
         this.setOpenState(!this.$data._open, { needFocus: !this.$data._open });
@@ -1498,11 +1513,13 @@ const Select = {
       );
       return (
         <span
+          tabIndex="-1"
           key="arrow"
           class={`${prefixCls}-arrow`}
           style={UNSELECTABLE_STYLE}
           {...{ attrs: UNSELECTABLE_ATTRIBUTE }}
           onClick={this.onArrowClick}
+          onFocus={this.onArrowFocus}
           ref="arrow"
         >
           {inputIcon || defaultIcon}

--- a/components/vc-select/Select.jsx
+++ b/components/vc-select/Select.jsx
@@ -1545,22 +1545,6 @@ const Select = {
       return null;
     },
 
-    selectionRefClick() {
-      //e.stopPropagation();
-      if (!this.disabled) {
-        const input = this.getInputDOMNode();
-        if (this._focused && this.$data._open) {
-          // this._focused = false;
-          this.setOpenState(false, false);
-          input && input.blur();
-        } else {
-          this.clearBlurTime();
-          //this._focused = true;
-          this.setOpenState(true, true);
-          input && input.focus();
-        }
-      }
-    },
     selectionRefFocus(e) {
       if (this._focused || this.disabled || isMultipleOrTagsOrCombobox(this.$props)) {
         e.preventDefault();
@@ -1695,7 +1679,6 @@ const Select = {
           tabIndex={props.disabled ? -1 : props.tabIndex}
           onBlur={this.selectionRefBlur}
           onFocus={this.selectionRefFocus}
-          onClick={this.selectionRefClick}
           onKeydown={isMultipleOrTagsOrCombobox(props) ? noop : this.onKeyDown}
         >
           <div {...selectionProps}>

--- a/components/vc-select/Select.jsx
+++ b/components/vc-select/Select.jsx
@@ -162,6 +162,7 @@ const Select = {
       ...state,
       _mirrorInputValue: state._inputValue, // https://github.com/vueComponent/ant-design-vue/issues/1458
       ...this.getDerivedStateFromProps(props, state),
+      _preventNextArrowClick: false,
     };
   },
 
@@ -519,7 +520,7 @@ const Select = {
       }
     },
 
-    onArrowFocus(e) {
+    onArrowFocus() {
       this._preventNextArrowClick = true;
 
       this.clearBlurTime();

--- a/components/vc-select/Select.jsx
+++ b/components/vc-select/Select.jsx
@@ -162,7 +162,6 @@ const Select = {
       ...state,
       _mirrorInputValue: state._inputValue, // https://github.com/vueComponent/ant-design-vue/issues/1458
       ...this.getDerivedStateFromProps(props, state),
-      _preventNextArrowClick: false,
     };
   },
 
@@ -502,30 +501,6 @@ const Select = {
       }
       if (this.autoClearSearchValue) {
         this.setInputValue('');
-      }
-    },
-
-    onArrowClick(e) {
-      e.stopPropagation();
-      e.preventDefault();
-
-      if (this._preventNextArrowClick) {
-        this._preventNextArrowClick = false;
-        return;
-      }
-
-      this.clearBlurTime();
-      if (!this.disabled) {
-        this.setOpenState(!this.$data._open, { needFocus: !this.$data._open });
-      }
-    },
-
-    onArrowFocus() {
-      this._preventNextArrowClick = true;
-
-      this.clearBlurTime();
-      if (!this.disabled) {
-        this.setOpenState(!this.$data._open, { needFocus: !this.$data._open });
       }
     },
 
@@ -1514,13 +1489,10 @@ const Select = {
       );
       return (
         <span
-          tabIndex="-1"
           key="arrow"
           class={`${prefixCls}-arrow`}
           style={UNSELECTABLE_STYLE}
           {...{ attrs: UNSELECTABLE_ATTRIBUTE }}
-          onClick={this.onArrowClick}
-          onFocus={this.onArrowFocus}
           ref="arrow"
         >
           {inputIcon || defaultIcon}

--- a/components/vc-trigger/Trigger.jsx
+++ b/components/vc-trigger/Trigger.jsx
@@ -230,7 +230,7 @@ export default {
       this.clearDelayTimer();
       if (this.isFocusToShow()) {
         this.focusTime = Date.now();
-        this.delaySetPopupVisible(true, this.$props.focusDelay);
+        if (!this.$data.sPopupVisible) this.delaySetPopupVisible(true, this.$props.focusDelay);
       }
     },
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.

When tabbing to (as opposed to clicking on) a select in default/single mode, it does not display the dropdown or let you enter input in the case of show-search.

The bug is documented for the react project here: https://github.com/ant-design/ant-design/issues/14503

In the react project this can be fixed by adding the prop: `:show-action="['focus','click']"` to the select.  This also works in the vue project but it causes a side effect in that, with the prop in place, clicking on the select now instantly closes it.

> 2. Resolve what problem.

The side effect bug can be fixed by deleting `selectionRefClick()` in Select.jsx.  It is not clear what this method is for as the select appears to work just fine without it, and it is the cause of the side effect.

The show-action prop is currently an undocumented feature (both in the react and vue projects), but probably should be documented or the behaviour simply made the default in a future update.

> 3. Related issue link.

Fixes #2325

(In react project: https://github.com/ant-design/ant-design/issues/14503 - already fixed)

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

