### PR TITLE
feat: date picker custom format

### DIFF
--- a/components/date-picker/interface.js
+++ b/components/date-picker/interface.js
@@ -7,7 +7,7 @@ export const PickerProps = () => ({
   transitionName: PropTypes.string,
   prefixCls: PropTypes.string,
   inputPrefixCls: PropTypes.string,
-  format: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+  format: PropTypes.oneOfType([PropTypes.string, PropTypes.array, PropTypes.func]),
   disabled: PropTypes.bool,
   allowClear: PropTypes.bool,
   suffixIcon: PropTypes.any,

--- a/components/date-picker/utils.js
+++ b/components/date-picker/utils.js
@@ -1,8 +1,8 @@
-const isFunction = function(obj) {
-  return !!(obj && obj.constructor && obj.call && obj.apply);
-};
-
 export function formatDate(value, format) {
+  const isFunction = function(obj) {
+    return !!(obj && obj.constructor && obj.call && obj.apply);
+  };
+  
   if (!value) {
     return '';
   }

--- a/components/date-picker/utils.js
+++ b/components/date-picker/utils.js
@@ -1,9 +1,16 @@
+const isFunction = function(obj) {
+  return !!(obj && obj.constructor && obj.call && obj.apply);
+};
+
 export function formatDate(value, format) {
   if (!value) {
     return '';
   }
   if (Array.isArray(format)) {
     format = format[0];
+  }
+  if (isFunction(format)) {
+    return format(value);
   }
   return value.format(format);
 }

--- a/components/date-picker/utils.js
+++ b/components/date-picker/utils.js
@@ -10,7 +10,12 @@ export function formatDate(value, format) {
     format = format[0];
   }
   if (isFunction(format)) {
-    return format(value);
+    const result = format(value);
+    if (typeof result === 'string') {
+      return result;
+    } else {
+      throw new Error('The function of format does not return a string');
+    }
   }
   return value.format(format);
 }

--- a/components/vc-calendar/src/Calendar.jsx
+++ b/components/vc-calendar/src/Calendar.jsx
@@ -24,7 +24,7 @@ const getMomentObjectIfValid = date => {
 const Calendar = {
   props: {
     locale: PropTypes.object.def(enUs),
-    format: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+    format: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
     visible: PropTypes.bool.def(true),
     prefixCls: PropTypes.string.def('rc-calendar'),
     // prefixCls: PropTypes.string,

--- a/components/vc-calendar/src/FullCalendar.jsx
+++ b/components/vc-calendar/src/FullCalendar.jsx
@@ -11,7 +11,7 @@ import enUs from './locale/en_US';
 const FullCalendar = {
   props: {
     locale: PropTypes.object.def(enUs),
-    format: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+    format: PropTypes.oneOfType([PropTypes.string, PropTypes.array, PropTypes.func]),
     visible: PropTypes.bool.def(true),
     prefixCls: PropTypes.string.def('rc-calendar'),
     defaultType: PropTypes.string.def('date'),

--- a/components/vc-calendar/src/Picker.jsx
+++ b/components/vc-calendar/src/Picker.jsx
@@ -25,7 +25,7 @@ const Picker = {
     animation: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
     disabled: PropTypes.bool,
     transitionName: PropTypes.string,
-    format: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+    format: PropTypes.oneOfType([PropTypes.string, PropTypes.array, PropTypes.func]),
     // onChange: PropTypes.func,
     // onOpenChange: PropTypes.func,
     children: PropTypes.func,

--- a/components/vc-calendar/src/RangeCalendar.jsx
+++ b/components/vc-calendar/src/RangeCalendar.jsx
@@ -110,7 +110,7 @@ const RangeCalendar = {
     // onValueChange: PropTypes.func,
     // onHoverChange: PropTypes.func,
     // onPanelChange: PropTypes.func,
-    format: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+    format: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
     // onClear: PropTypes.func,
     type: PropTypes.any.def('both'),
     disabledDate: PropTypes.func,

--- a/components/vc-calendar/src/date/DateInput.jsx
+++ b/components/vc-calendar/src/date/DateInput.jsx
@@ -16,7 +16,7 @@ const DateInput = {
     timePicker: PropTypes.object,
     value: PropTypes.object,
     disabledTime: PropTypes.any,
-    format: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+    format: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
     locale: PropTypes.object,
     disabledDate: PropTypes.func,
     // onChange: PropTypes.func,

--- a/components/vc-calendar/src/util/index.js
+++ b/components/vc-calendar/src/util/index.js
@@ -92,12 +92,25 @@ export function isAllowedDate(value, disabledDate, disabledTime) {
 }
 
 export function formatDate(value, format) {
+  const isFunction = function(obj) {
+    return !!(obj && obj.constructor && obj.call && obj.apply);
+  };
+  
   if (!value) {
     return '';
   }
 
   if (Array.isArray(format)) {
     format = format[0];
+  }
+
+  if (isFunction(format)) {
+    const result = format(value);
+    if (typeof result === 'string') {
+      return result;
+    } else {
+      throw new Error('The function of format does not return a string');
+    }
   }
 
   return value.format(format);


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.

I'm trying to implement lunar calendar with datepicker, but obviously moment does not support the formatting of lunar calendar dates. It would be great to accept a function to render custom date strings in the input, instead of relying on moment.format().

> 2. Resolve what problem.

DatePicker only allows momentjs formatting.

> 3. Related issue link.

https://github.com/vueComponent/ant-design-vue/issues/2236

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.

I dug around and found out that format is related to `formatDate` function, so I added support for function to it. 

> 2. List final API realization and usage sample.
```
<template>
  <a-date-picker
    v-model="value"
    :format="customFormat"
  >

  </a-date-picker>
</template>

<script>
  export default {
    data() {
      return {
        value: null,
      }
    },
    methods: {
      customFormat(value) {
        return getLunarDateString(value); // custom implementation to get lunar calendar date
      }
    }
  };
</script>
```
An error will be thrown if the function doesn't return a string to ensure there is a value.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?

`DatePicker`

> 2. What will say in changelog?

Allow a function to be passed into the format property of DatePicker for display string customization.

> 3. Does this PR contains potential break change or other risk?

This should not be a breaking change.

### Changelog description (Optional if not new feature)

> 1. English description

Allow a function to be passed into the format property of DatePicker for display string customization.

> 2. Chinese description (optional)

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)
1. I don't know how to get PropType to work with functions. I made some changes to PropType, but it still shows the vue warning that format expects only string and array.
2. Probably a better way to handle the passed in function not returning a string is to have it fall back to the default format the DatePicker is using, but I'm not sure how to do that.

> If this PR related with other PR or following info. You can type here.
