### PR TITLE
优化表格开启分页时，自定义onFilter函数多次调用的问题

### DIFF
--- a/components/table/Table.jsx
+++ b/components/table/Table.jsx
@@ -157,6 +157,7 @@ export default {
       sPagination: this.getDefaultPagination(this.$props),
       pivot: undefined,
       sComponents: createComponents(this.components),
+      filterDataCnt: 0
     };
   },
   watch: {
@@ -375,6 +376,7 @@ export default {
 
     getCurrentPageData() {
       let data = this.getLocalData();
+      this.filterDataCnt = data.length;
       let current;
       let pageSize;
       const sPagination = this.sPagination;
@@ -934,7 +936,7 @@ export default {
         size = 'small';
       }
       const position = pagination.position || 'bottom';
-      const total = pagination.total || this.getLocalData().length;
+      const total = pagination.total || this.filterDataCnt;
       const { class: cls, style, onChange, onShowSizeChange, ...restProps } = pagination; // eslint-disable-line
       const paginationProps = mergeProps({
         key: `pagination-${paginationPosition}`,


### PR DESCRIPTION
### 这个变动的性质是
- [x] 日常 bug 修复

### 需求背景
  表格组件开启了分页，绑定在列上的 onFilter函数，在表格的分页组件进行渲染时，会多余调用N * 2次（分页组件实际只需要获得数据数组的大小，重新获取本地数据不必要）。 
  当表格记录数越多，越影响性能。

### Changelog 描述（非新功能可选）

> 1. Fix Table component‘s page subcomponent render performance.（Unnecessary getLocalData() call）
> 2. 优化表格开启分页时，自定义onFilter函数多次调用的问题

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

