### PR TITLE
Table性能优化，减少getLocalData调用

### DIFF
--- a/components/table/Table.jsx
+++ b/components/table/Table.jsx
@@ -157,6 +157,7 @@ export default {
       sPagination: this.getDefaultPagination(this.$props),
       pivot: undefined,
       sComponents: createComponents(this.components),
+      filterDataCnt: 0
     };
   },
   watch: {
@@ -375,6 +376,7 @@ export default {
 
     getCurrentPageData() {
       let data = this.getLocalData();
+      this.filterDataCnt = data.length;
       let current;
       let pageSize;
       const sPagination = this.sPagination;
@@ -934,7 +936,7 @@ export default {
         size = 'small';
       }
       const position = pagination.position || 'bottom';
-      const total = pagination.total || this.getLocalData().length;
+      const total = pagination.total || this.filterDataCnt;
       const { class: cls, style, onChange, onShowSizeChange, ...restProps } = pagination; // eslint-disable-line
       const paginationProps = mergeProps({
         key: `pagination-${paginationPosition}`,

--- a/components/table/Table.jsx
+++ b/components/table/Table.jsx
@@ -867,7 +867,7 @@ export default {
       }
 
       const extra = {
-        currentDataSource: this.getLocalData(state),
+        currentDataSource: []//this.getLocalData(state),// 这里应该是冗余的
       };
 
       return [pagination, filters, sorter, extra];
@@ -1171,7 +1171,7 @@ export default {
       transformCellText,
     }) {
       const { showHeader, locale, getPopupContainer, ...restProps } = getOptionProps(this);
-      const data = this.getCurrentPageData();
+      const data = this.filterCurrentPageData;
       const expandIconAsCell = this.expandedRowRender && this.expandIconAsCell !== false;
 
       // use props.getPopupContainer first
@@ -1242,6 +1242,7 @@ export default {
       transformCellText: customizeTransformCellText,
     } = this;
     const data = this.getCurrentPageData();
+    this.filterCurrentPageData = data;   // 当前页过滤后数据，变量不能放到 data 里面，否则会导致无限循环，这里直接赋值即可
     const {
       getPopupContainer: getContextPopupContainer,
       transformCellText: tct,


### PR DESCRIPTION
Table 组件性能优化

### This is a optimized for table component
- [x] Bug fix
- [ ] Site / document update

### What's the background?

> 1. 点击分页，排序，过滤时都会导致 getLocalData 多次调用，getLocalData里调用了上层onFilter
> 2. 更改后降低 onFilter 调用次数，提升控件性能;

### Changelog description (Optional if not new feature)

> 1. The Table component optimized to reduce calls to the getLocalData function for filtering, paging controls, and sorting
> 2. Table组件进一步优化，减少过滤，分页控件，排序对getLocalData函数的调用

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
