### PR TITLE
Add capability to FormModel component, to validate part of the fields while still getting a Promise in return

### DIFF
--- a/components/form-model/Form.jsx
+++ b/components/form-model/Form.jsx
@@ -114,10 +114,18 @@ const Form = {
         field.clearValidate();
       });
     },
-    validate(callback) {
+    validate(callback, fieldProps) {
       if (!this.model) {
         warning(false, 'FormModel', 'model is required for resetFields to work.');
         return;
+      }
+      fieldProps = [].concat(fieldProps);
+      let fields;
+      // 没传入fieldProps或者传入的为空数组时，验证所有字段
+      if (fieldProps.length === 0) {
+        fields = this.fields;
+      } else {
+        fields = this.fields.filter(field => fieldProps.indexOf(field.prop) !== -1);
       }
       let promise;
       // if no callback, return promise
@@ -131,17 +139,17 @@ const Form = {
       let valid = true;
       let count = 0;
       // 如果需要验证的fields为空，调用验证时立刻返回callback
-      if (this.fields.length === 0 && callback) {
+      if (fields.length === 0 && callback) {
         callback(true);
       }
       let invalidFields = {};
-      this.fields.forEach(field => {
+      fields.forEach(field => {
         field.validate('', (message, field) => {
           if (message) {
             valid = false;
           }
           invalidFields = Object.assign({}, invalidFields, field);
-          if (typeof callback === 'function' && ++count === this.fields.length) {
+          if (typeof callback === 'function' && ++count === fields.length) {
             callback(valid, invalidFields);
           }
         });

--- a/types/form-model/form.d.ts
+++ b/types/form-model/form.d.ts
@@ -148,12 +148,12 @@ export declare class FormModel extends AntdComponent {
   validateOnRuleChange: boolean;
 
   /**
-   * validate the whole form. Takes a callback as a param. After validation,
-   * the callback will be executed with two params: a boolean indicating if the validation has passed,
-   * and an object containing all fields that fail the validation. Returns a promise if callback is omitted
+   * validate the whole form or part of the fields. Takes a callback as the 1st param and field props to validate as the 2nd param.
+   * After validation, the callback will be executed with two params: a boolean indicating if the validation has passed,
+   * and an object containing all fields that fail the validation. Returns a promise if callback is not provided.
    * @type Function
    */
-  validate: (callback?: (boolean: Boolean, object: Object) => void) => void | Promise<any>;
+  validate: (callback?: (boolean: Boolean, object: Object) => void, fieldProps?: string[] | string) => void | Promise<any>;
 
   /**
    * validate one or several form items


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
- I need to validate part of the fields and expect a `Promise` as return value.
- `FormModel.validate()` supports returning a promise, but doesn't support validating part of the fields. From my understanding, this method is to get a final result against all fields' validity.
- `FormModel.validateField()` supports validating part of the fields, but doesn't support returning a promise. From my understanding, this method is to apply a callback to each of the fields passed in.

### API Realization
My original goal is to get a final result against **part of the fields' validity**, thus refactoring `FormModel.validate()` is my choice.

I added a second parameter to this method, making it `validate(callback, fieldProps)`. In order to avoid a destructive refactoring, I put `fieldProps` at the 2nd position - inserting it at the 1st position will break this method's backward compatibility, which is unacceptable IMO.

### What's the effect?
Now I can validate just part of the form fields while still getting a `Promise` in return,

```js
const valid = await this.$refs.dataForm.validate(undefined, ['fieldProp1', 'fieldProp2']);
```

### Changelog description
1. English description
> Add a second parameter `fieldProps` to `FormModel.validate()` to support validating part of the form fields and get a `Promise` in return.

2. Chinese description (optional)
> 给 `FormModel.validate()` 增加第二个参数 `fieldProps` 以支持验证部分字段的同时也能获得一个 `Promise` 作为返回值。

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [x] Demo is not needed
- [x] TypeScript definition is updated/provided
- [x] Changelog is provided

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
