### PR TITLE
fix: input textarea hadle when has affix

### DIFF
--- a/components/input/style/index.less
+++ b/components/input/style/index.less
@@ -24,11 +24,6 @@
 .@{ant-prefix}-input-affix-wrapper {
   .reset-component;
   .input-affix-wrapper(~'@{ant-prefix}-input');
-
-  // https://github.com/ant-design/ant-design/issues/6144
-  .@{ant-prefix}-input {
-    min-height: 100%; // use min-height, assume that no smaller height to override
-  }
 }
 
 .@{ant-prefix}-input-password-icon {


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

fix https://github.com/vueComponent/ant-design-vue/issues/2486

### What's the effect? (Optional if not new feature)
- 向下拖动正常
- 无法向上拖动

| # | Preview |
|---|---|
|Before ❌  | ![2020-07-07 16 03 25](https://user-images.githubusercontent.com/29775873/86743466-79758500-c06b-11ea-953e-641e5b3bde8f.gif)|
| After ✅ |  ![2020-07-07 16 04 32](https://user-images.githubusercontent.com/29775873/86743755-b3df2200-c06b-11ea-8776-cb4b57d7b9b2.gif) |

### Changelog description (Optional if not new feature)

| - | changelog|
|---| ---|
| EN| Fix the problem that Input textarea cannot drag upward when allow-clear is activated. |
|CN | 修复 Input textarea 激活 allow-clear 时无法向上拖动的问题。 |

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
