### PR TITLE
fix: [component:vc-pagination]emit change.current before change

### DIFF
--- a/components/vc-pagination/Pagination.jsx
+++ b/components/vc-pagination/Pagination.jsx
@@ -259,8 +259,8 @@ export default {
           });
         }
         // this.$emit('input', page)
-        this.$emit('change', page, this.statePageSize);
         this.$emit('change.current', page, this.statePageSize);
+        this.$emit('change', page, this.statePageSize);
         return page;
       }
       return this.stateCurrent;


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

### 这个变动的性质是

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [x] 其他改动（是关于什么的改动？）emit事件优化

### 需求背景

> 1. 描述相关需求的来源。
希望在a-pagination的@change方法里直接使用双向绑定的current
> 2. 要解决的问题。
@change方法里得到的current的值是延后于双向绑定的时机的
> 3. 相关的 issue 讨论链接。

### 实现方案和 API（非新功能可选）

> 1. 基本的解决思路和其他可选方案。
对调change和change.current事件的先后顺序
> 2. 列出最终的 API 实现和用法。
> 3. 涉及 UI/交互变动需要有截图或 GIF。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
一般不会有影响，除非之前的用户特意关注于这个先后顺序
> 2. 是否有可能隐含的 break change 和其他风险？

### Changelog 描述（非新功能可选）

> 1. 英文描述
> 2. 中文描述（可选）

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。
