### PR TITLE
fix: treeSelect scroll when value has children

### DIFF
--- a/components/vc-tree-select/src/Select.jsx
+++ b/components/vc-tree-select/src/Select.jsx
@@ -238,7 +238,8 @@ const Select = {
           const treeNode = domTreeNodes[key];
 
           if (treeNode) {
-            const domNode = treeNode.$el;
+            // Fix scroll when value has children https://github.com/vueComponent/ant-design-vue/issues/2615
+            const domNode = treeNode.$children.length ? treeNode.$el.children[1] : treeNode.$el;
             raf(() => {
               const popupNode = this.popup.$el;
               const triggerContainer = findPopupContainer(popupNode, `${prefixCls}-dropdown`);


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
close https://github.com/vueComponent/ant-design-vue/issues/2615

- 其实原因是，当 value 为父节点时，domNode 为 父节点 和子节点的 整个元素，这样在计算的时候，出现问题。将 domNode 改为父节点的根元素即可。

![2020-07-28 14 38 42](https://user-images.githubusercontent.com/29775873/88628562-bbc93980-d0e0-11ea-9e92-a60c8affb918.gif)


### Changelog description (Optional if not new feature)

||Changelog|
|---|---|
|CN|修复 TreeSelect `value`为父节点并激活 `showSearch` 时，下拉框滚动位置条异常的问题。|
|EN| Fix the problem that the scroll position bar of the drop-down box is abnormal when TreeSelect `value` is the parent node and `showSearch` is activated.|

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

