### PR TITLE
Fix tree shift multiple

### DIFF
--- a/components/tree/DirectoryTree.jsx
+++ b/components/tree/DirectoryTree.jsx
@@ -155,12 +155,13 @@ export default {
         newEvent.selectedNodes = convertDirectoryKeysToNodes(children, newSelectedKeys);
       } else if (multiple && shiftPick) {
         // Shift click
-        newSelectedKeys = Array.from(
-          new Set([
-            ...(this.cachedSelectedKeys || []),
-            ...calcRangeKeys(children, expandedKeys, eventKey, this.lastSelectedKey),
-          ]),
-        );
+        // newSelectedKeys = Array.from(
+        //   new Set([
+        //     ...(this.cachedSelectedKeys || []),
+        //     ...calcRangeKeys(children, expandedKeys, eventKey, this.lastSelectedKey),
+        //   ]),
+        // );
+        newSelectedKeys = keys;
         newEvent.selectedNodes = convertDirectoryKeysToNodes(children, newSelectedKeys);
       } else {
         // Single click

--- a/components/vc-table/src/Table.jsx
+++ b/components/vc-table/src/Table.jsx
@@ -303,10 +303,11 @@ export default {
         bodyRows,
         (acc, row) => {
           const rowKey = row.getAttribute('data-row-key');
-          const height =
-            row.getBoundingClientRect().height ||
-            state.fixedColumnsBodyRowsHeight[rowKey] ||
-            'auto';
+          const height = 'auto';
+          // const height =
+          //   row.getBoundingClientRect().height ||
+          //   state.fixedColumnsBodyRowsHeight[rowKey] ||
+          //   'auto';
           acc[rowKey] = height;
           return acc;
         },


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
<a-directory-tree />shift不能多选

> 2. Resolve what problem.
修复<a-directory-tree />组件shift多选功能, 其问题出现在DirectoryTree `onSelect`方法中, 当使用shift选中时`this.cacheSelectedKeys`为undefined, 最终newSelectedKeys为空数组. 我们需要在event为shift并且multiple的时候也缓存shift选中的值
```
if () {
...
}else if (multiple && shiftPick) {
        // Shift click
        this.cachedSelectedKeys = keys;
        newSelectedKeys = Array.from(
          new Set([
            ...(this.cachedSelectedKeys || []),
            ...calcRangeKeys(children, expandedKeys, eventKey, this.lastSelectedKey),
          ]),
        );
        newEvent.selectedNodes = convertDirectoryKeysToNodes(children, newSelectedKeys);
      }
```
![tree-shift-multiple](http://img.os4team.cn/tree-shift-selected.gif)
> 3. Related issue link.
#1744 

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
`<a-directory-tree />`  shift not multiple

> 2. Chinese description (optional)
`<a-directory-tree>` shift多选

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
