### PR TITLE
fix: validate callback return error type

### DIFF
--- a/types/form-model/form.d.ts
+++ b/types/form-model/form.d.ts
@@ -153,7 +153,7 @@ export declare class FormModel extends AntdComponent {
    * and an object containing all fields that fail the validation. Returns a promise if callback is omitted
    * @type Function
    */
-  validate: (callback?: (boolean: Boolean, object: Object) => void) => void | Promise<any>;
+  validate: (callback?: (boolean: boolean, object: Object) => void) => void | Promise<any>;
 
   /**
    * validate one or several form items


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

### 这个变动的性质是

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [x] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 描述相关需求的来源。

validate callback 返回类型错误

> 2. 要解决的问题。

validate callback 的第一个返回参数类型是 Boolean 对象，用这个值做 if 判断的时候，typescript 检查时会被认为永远是 true

> 3. 相关的 issue 讨论链接。

无

### 实现方案和 API（非新功能可选）

> 1. 基本的解决思路和其他可选方案。
> 2. 列出最终的 API 实现和用法。
> 3. 涉及 UI/交互变动需要有截图或 GIF。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
> 2. 是否有可能隐含的 break change 和其他风险？

### Changelog 描述（非新功能可选）

> 1. 英文描述
> 2. 中文描述（可选）

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。

