### PR TITLE
fix: 修复mask为false情况下点击遮罩仍然触发cancel事件的bug,并且mask为false时支持点击后面的节点

### DIFF
--- a/components/modal/style/modal.less
+++ b/components/modal/style/modal.less
@@ -13,6 +13,10 @@
   padding-bottom: 24px;
   pointer-events: none;
 
+  &-no-mask {
+    pointer-events: none;
+  }
+
   &-wrap {
     position: fixed;
     top: 0;

--- a/components/vc-dialog/Dialog.jsx
+++ b/components/vc-dialog/Dialog.jsx
@@ -180,6 +180,9 @@ export default {
       if (Date.now() - this.openTime < 300) {
         return;
       }
+      if (this.mask === false) {
+        return;
+      }
       if (e.target === e.currentTarget && !this.dialogMouseDown) {
         this.close(e);
       }
@@ -411,7 +414,7 @@ export default {
     },
   },
   render() {
-    const { prefixCls, maskClosable, visible, wrapClassName, title, wrapProps } = this;
+    const { prefixCls, maskClosable, visible, wrapClassName, title, wrapProps, mask } = this;
     const style = this.getWrapStyle();
     // clear hide display
     // and only set display after async anim, not here for hide
@@ -424,7 +427,11 @@ export default {
         <div
           tabIndex={-1}
           onKeydown={this.onKeydown}
-          class={`${prefixCls}-wrap ${wrapClassName || ''}`}
+          class={{
+            [`${prefixCls}-wrap`]: true,
+            [`${prefixCls}-no-mask`]: !mask,
+            [wrapClassName]: !!wrapClassName,
+          }}
           ref="wrap"
           onClick={maskClosable ? this.onMaskClick : noop}
           onMouseup={maskClosable ? this.onMaskMouseUp : noop}

--- a/components/vc-dialog/LazyRenderBox.jsx
+++ b/components/vc-dialog/LazyRenderBox.jsx
@@ -10,7 +10,6 @@ const ILazyRenderBoxPropTypes = {
 export default {
   props: ILazyRenderBoxPropTypes,
   render() {
-    console.log(111111, getListeners(this));
     return <div {...{ on: getListeners(this) }}>{this.$slots.default}</div>;
   },
 };

--- a/components/vc-dialog/LazyRenderBox.jsx
+++ b/components/vc-dialog/LazyRenderBox.jsx
@@ -10,6 +10,7 @@ const ILazyRenderBoxPropTypes = {
 export default {
   props: ILazyRenderBoxPropTypes,
   render() {
+    console.log(111111, getListeners(this));
     return <div {...{ on: getListeners(this) }}>{this.$slots.default}</div>;
   },
 };

--- a/components/vc-dialog/assets/index/Dialog.less
+++ b/components/vc-dialog/assets/index/Dialog.less
@@ -3,6 +3,10 @@
   width: auto;
   margin: 10px;
 
+  &-no-mask {
+    pointer-events: none;
+  }
+
   &-wrap {
     position: fixed;
     overflow: auto;

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -1,24 +1,45 @@
 <template>
   <div>
-    <a-collapse :accordion="true" default-active-key="2" :bordered="false">
-      <a-collapse-panel key="1" header="This is panel header 1">
-        <p>{{ text }}</p>
-      </a-collapse-panel>
-      <a-collapse-panel key="2" header="This is panel header 2" :disabled="false">
-        <p>{{ text }}</p>
-      </a-collapse-panel>
-      <a-collapse-panel key="3" header="This is panel header 3">
-        <p>{{ text }}</p>
-      </a-collapse-panel>
-    </a-collapse>
+    <a-button type="primary" @click="showModal">
+      Open Modal with async logic
+    </a-button>
+    <a-modal
+      title="Title"
+      :visible="visible"
+      :confirm-loading="confirmLoading"
+      :mask="false"
+      @ok="handleOk"
+      @cancel="handleCancel"
+    >
+      <p>{{ ModalText }}</p>
+    </a-modal>
   </div>
 </template>
 <script>
 export default {
   data() {
     return {
-      text: `A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.`,
+      ModalText: 'Content of the modal',
+      visible: false,
+      confirmLoading: false,
     };
+  },
+  methods: {
+    showModal() {
+      this.visible = true;
+    },
+    handleOk(e) {
+      this.ModalText = 'The modal will be closed after two seconds';
+      this.confirmLoading = true;
+      setTimeout(() => {
+        this.visible = false;
+        this.confirmLoading = false;
+      }, 2000);
+    },
+    handleCancel(e) {
+      console.log('Clicked cancel button');
+      this.visible = false;
+    },
   },
 };
 </script>


### PR DESCRIPTION
### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 描述相关需求的来源。
* Modal 组件的 mask 设置为 false 时，点击空白处依旧会触发 cancel 事件。#2667
* Modal 组件的 mask 设置为 false 时，它后面的节点无法点击。 #1667
> 2. 要解决的问题。
Modal 组件的 mask 设置为 false 时，点击空白处不触发cancel事件，并且支持点击后面的节点
> 3. 相关的 issue 讨论链接。


### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供