### PR TITLE
fix: descriptions not render fragmet children

### DIFF
--- a/components/_util/props-util.js
+++ b/components/_util/props-util.js
@@ -330,7 +330,7 @@ export function getComponentName(opts) {
 }
 
 export function isFragment(c) {
-  return c.length === 1 && c[0].type === Fragment;
+  return (c.length === 1 && c[0].type === Fragment) || c.type === Fragment;
 }
 
 export function isEmptyElement(c) {

--- a/components/descriptions/index.jsx
+++ b/components/descriptions/index.jsx
@@ -9,6 +9,7 @@ import {
   getOptionProps,
   getComponent,
   isValidElement,
+  isFragment,
 } from '../_util/props-util';
 import BaseMixin from '../_util/BaseMixin';
 
@@ -215,11 +216,17 @@ const Descriptions = {
     const column = this.getColumn();
     const children = this.$slots.default && this.$slots.default();
     const cloneChildren = toArray(children)
-      .map(child => {
+      .flatMap(child => {
         if (isValidElement(child)) {
           return cloneVNode(child, {
             prefixCls,
           });
+        } else if (isFragment(child) && child.children.length > 0) {
+          return child.children.map(c =>
+            cloneVNode(c, {
+              prefixCls,
+            }),
+          );
         }
         return null;
       })


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...
- [x] Bug fix


### What's the background?

#2793 

> 2. Chinese description (optional)

v-for 在 vue 3 中渲染为 Fragment，在 Descriptions 获取 children 的时候增加 isFragment 判断，并用 flatMap 组合起来

```vue
<template>
  <div>
    <a-descriptions title="User Info" bordered :column="2">
      <a-descriptions-item label="test">
        test
      </a-descriptions-item>
      <a-descriptions-item v-for="(prop, index) in vals" :key="index" :label="prop.name">
        {{ prop.type }}
      </a-descriptions-item>
    </a-descriptions>
    <div v-for="(prop, index) in vals" :key="index">
      {{ prop.type }}
    </div>
  </div>
</template>
<script>
export default {
  data() {
    return {
      vals: [
        { id: 1, name: 'prop1', type: 'text' },
        { id: 2, name: 'prop2', type: 'text' },
      ],
    };
  },
};
</script>

```

before:
![微信截图_20200904155420](https://user-images.githubusercontent.com/4506072/92215647-b32a0700-eec7-11ea-96ec-1ba6fb9398cd.png)

after:
![微信截图_20200904155439](https://user-images.githubusercontent.com/4506072/92215660-b6bd8e00-eec7-11ea-8964-b66d835ae5cc.png)


### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
