### PR TITLE
fix(trigger): use passive touch events to prevent browser warnings

### DIFF
--- a/components/vc-trigger/Trigger.jsx
+++ b/components/vc-trigger/Trigger.jsx
@@ -165,6 +165,7 @@ export default {
             currentDocument,
             'touchstart',
             this.onDocumentClick,
+            { passive: true },
           );
         }
         // close popup when trigger type contains 'onContextmenu' and document is scrolling.
@@ -174,6 +175,7 @@ export default {
             currentDocument,
             'scroll',
             this.onContextmenuClose,
+            { passive: true },
           );
         }
         // close popup when trigger type contains 'onContextmenu' and window is blur.
@@ -378,7 +380,7 @@ export default {
         mouseProps.onMouseleave = self.onPopupMouseleave;
       }
       mouseProps.onMousedown = this.onPopupMouseDown;
-      mouseProps.onTouchstart = this.onPopupMouseDown;
+      mouseProps.onTouchstartPassive = this.onPopupMouseDown;
       const { handleGetPopupClassFromAlign, getRootDomNode, getContainer, $attrs } = self;
       const {
         prefixCls,
@@ -603,11 +605,11 @@ export default {
     if (this.isClickToHide() || this.isClickToShow()) {
       newChildProps.onClick = this.onClick;
       newChildProps.onMousedown = this.onMousedown;
-      newChildProps.onTouchstart = this.onTouchstart;
+      newChildProps.onTouchstartPassive = this.onTouchstart;
     } else {
       newChildProps.onClick = this.createTwoChains('onClick');
       newChildProps.onMousedown = this.createTwoChains('onMousedown');
-      newChildProps.onTouchstart = this.createTwoChains('onTouchstart');
+      newChildProps.onTouchstartPassive = this.createTwoChains('onTouchstart');
     }
     if (this.isMouseEnterToShow()) {
       newChildProps.onMouseenter = this.onMouseenter;


### PR DESCRIPTION
修复这个：

![image](https://user-images.githubusercontent.com/6134068/92449898-47a8a800-f1ed-11ea-8d76-c8986bea62fb.png)

这里不需要preventDefault，设置 `passive: true` 的确可以提升浏览器响应速率

---

First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)