### PR TITLE
fix: menu cannot be collapsed by the layout

### DIFF
--- a/components/menu/index.jsx
+++ b/components/menu/index.jsx
@@ -1,4 +1,4 @@
-import { inject, provide } from 'vue';
+import { inject, provide, toRef } from 'vue';
 import omit from 'omit.js';
 import VcMenu, { Divider, ItemGroup } from '../vc-menu';
 import SubMenu from './SubMenu';
@@ -61,9 +61,12 @@ const Menu = {
     provide('menuPropsContext', this.$props);
   },
   setup() {
+    const layoutSiderContext = inject('layoutSiderContext', {});
+    const layoutSiderCollapsed = toRef(layoutSiderContext, 'sCollapsed');
     return {
       configProvider: inject('configProvider', ConfigConsumerProps),
-      layoutSiderContext: inject('layoutSiderContext', {}),
+      layoutSiderContext,
+      layoutSiderCollapsed,
     };
   },
   // model: {
@@ -88,7 +91,7 @@ const Menu = {
     inlineCollapsed(val) {
       this.collapsedChange(val);
     },
-    'layoutSiderContext.sCollapsed'(val) {
+    layoutSiderCollapsed(val) {
       this.collapsedChange(val);
     },
   },


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

1. 重现地址：[antdv文档-Layout组件-侧边布局](https://2x.antdv.com/components/layout-cn/#%E4%BE%A7%E8%BE%B9%E5%B8%83%E5%B1%80)
2. 重现方式：菜单组件在展开二级菜单时，折叠Layout sider，子菜单无法跟随折叠.
3. 出现该问题是因为vue3中的 watch options 不再支持 key expressions 的方式使用 [vuejs/vue-next#2003]。因此导致 `Menu` 组件中无法 `watch` 到 `layoutSiderContext.sCollapsed`.

![Kapture 2020-09-09 at 23 59 28](https://user-images.githubusercontent.com/21698973/92623311-a0b13280-f2f8-11ea-8dfd-9bac13997b2b.gif)

![image](https://user-images.githubusercontent.com/21698973/92622953-3dbf9b80-f2f8-11ea-8d95-4f800423682c.png)

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
