### PR TITLE
fix(vc-select): when mode is tags, the tag can't be add by Enter

### DIFF
--- a/components/vc-select/Select.jsx
+++ b/components/vc-select/Select.jsx
@@ -376,7 +376,7 @@ const Select = {
     },
 
     onInputKeydown(event) {
-      const { disabled, combobox, defaultActiveFirstOption } = this.$props;
+      const { disabled, combobox, defaultActiveFirstOption, tags, open } = this.$props;
       if (disabled) {
         return;
       }
@@ -410,6 +410,15 @@ const Select = {
           this.comboboxTimer = setTimeout(() => {
             this.setOpenState(false);
           });
+        }
+        if (typeof open === 'boolean' && !open && tags) {
+          this.setOpenState(false);
+          const { _inputValue } = state;
+          this.setInputValue('');
+          const tmpValue = this.getValueByInput(_inputValue);
+          if (tmpValue !== undefined) {
+            this.fireChange(tmpValue);
+          }
         }
       } else if (keyCode === KeyCode.ESC) {
         if (state._open) {


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
1. 问题描述
 当 **select** 组件设置 `mode=tags` 且 `open=false` 时，无法使用回车键进行标签的添加

2. 复现代码
``` vue
<template>
  <a-select
    v-model:value="value"
    mode="tags"
    style="width: 100%"
    placeholder="Tags Mode"
    :open="false"
    @change="handleChange"
  >
    <a-select-option v-for="i in 25" :key="(i + 9).toString(36) + i">
      {{ (i + 9).toString(36) + i }}
    </a-select-option>
  </a-select>
</template>
<script>
export default {
  data() {
    return {
      value: [],
    };
  },
  methods: {
    handleChange(value) {
      console.log(`selected ${value}`);
    },
  },
};
</script>

```

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

