### PR TITLE
fix: remove redundant tabindex on autocomplete

### DIFF
--- a/components/auto-complete/index.jsx
+++ b/components/auto-complete/index.jsx
@@ -136,6 +136,7 @@ const AutoComplete = {
         getInputElement: this.getInputElement,
         notFoundContent: getComponentFromProp(this, 'notFoundContent'),
         placeholder: '',
+        tabIndex: -1,
       },
       class: cls,
       ref: 'select',


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
Currently the autocomplete component has a redundant tab index on the wrapper element, causing 2 tabs to get into the actual input child element.
> 2. Resolve what problem.
The redundant tab index should be removed, so the autocomplete input's tab index works consistently like other input.
> 3. Related issue link.
#1438

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
Yes. The way focus works on the autocomplete component will be corrected, requiring only one Tab keypress to get to like any other input.
> 2. What will say in changelog?
Fix redundant tabindex on the wrapper element of autocomplete
> 3. Does this PR contains potential break change or other risk?
No

### Changelog description (Optional if not new feature)

> 1. English description
Fix redundant tabindex on the wrapper element of autocomplete
> 2. Chinese description (optional)

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
