### PR TITLE
feat: write method of JSX compatible v-model

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -64,7 +64,12 @@ export default defineComponent({
   },
   data() {
     const props = this.$props;
-    const value = typeof props.value === 'undefined' ? props.defaultValue : props.value;
+    const value =
+      typeof props.value === 'undefined'
+        ? typeof props.modelValue === 'undefined'
+          ? props.defaultValue
+          : props.modelValue
+        : props.value;
     return {
       stateValue: typeof value === 'undefined' ? '' : value,
       isFocused: false,
@@ -134,7 +139,8 @@ export default defineComponent({
       });
     },
     triggerChange(e: Event) {
-      this.$emit('update:value', (e.target as any).value);
+      this.$emit('update:value', (e.target as HTMLInputElement).value);
+      this.$emit('update:modelValue', (e.target as HTMLInputElement).value);
       this.$emit('change', e);
       this.$emit('input', e);
     },

--- a/components/input/inputProps.ts
+++ b/components/input/inputProps.ts
@@ -6,6 +6,7 @@ export default {
   inputPrefixCls: PropTypes.string,
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  modelValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   placeholder: {
     type: [String, Number] as PropType<string | number>,
   },
@@ -31,4 +32,5 @@ export default {
   onChange: PropTypes.func,
   onInput: PropTypes.func,
   'onUpdate:value': PropTypes.func,
+  'onUpdate:modelValue': PropTypes.func,
 };


### PR DESCRIPTION
### 组件：Input

### 这个变动的性质是

- 新特性提交
- TypeScript 定义更新

### 需求背景

这个问题实际上是在写vue3用jsx页面的时候发现的

![image](https://user-images.githubusercontent.com/53512912/97958101-8884fd80-1de7-11eb-93c3-7b3ee8945c03.png)
![image](https://user-images.githubusercontent.com/53512912/97958141-976bb000-1de7-11eb-91a6-b95fc399bf22.png)

https://github.com/vuejs/jsx-next#installation
在jsx-next中确实是支持了在jsx中写v-model，但组件却不行

希望是在用jsx写法也只用一个v-model就可以进行数据的双向绑定，方便用户使用

### 实现方案和 API（非新功能可选）

https://vue-docs-next-zh-cn.netlify.app/guide/migration/v-model.html#_3-x-%E8%AF%AD%E6%B3%95
vue3的文档中比较清楚的写出了v-model的变更
新增了modelValue和update:modelValue

### 对用户的影响和可能的风险（非新功能可选）

不影响模板语法的写法，只是兼容了jsx的写法

### 请求合并前的自查清单

![image](https://user-images.githubusercontent.com/53512912/97958314-eca7c180-1de7-11eb-9488-2db34ef50a6f.png)

### 后续计划（非新功能可选）

认为相关的，如果只有一个v-model而不像v-mode:title类似的vue3写法的，可以考虑都加上modelValue的参数，jsx-next中还没有深入去看，不知道未来会不会能在jsx中写v-model:title，如果实现了的话，后期希望组件能进一步优化吧。
