### PR TITLE
fix: update message type

### DIFF
--- a/components/message/index.tsx
+++ b/components/message/index.tsx
@@ -191,4 +191,4 @@ export interface MessageApi {
   destroy(): void;
 }
 
-export default api;
+export default api as MessageApi;


### PR DESCRIPTION
修复message组件类型丢失

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
新版本切换到Typescript后发现多个版本未修复message类型被定义成any  工具无法进行方法联想
