### PR TITLE
fix(submenu): lose rootPrefixCls props

### DIFF
--- a/components/menu/SubMenu.tsx
+++ b/components/menu/SubMenu.tsx
@@ -31,15 +31,16 @@ export default defineComponent({
 
   render() {
     const { $slots, $attrs } = this;
-    const { rootPrefixCls, popupClassName } = { ...this.$props, ...this.injectExtraProps } as any;
+    const props: any = { ...this.$props, ...this.injectExtraProps };
+    const { rootPrefixCls, popupClassName } = props;
     const { theme: antdMenuTheme } = this.menuPropsContext;
-    const props = {
-      ...this.$props,
+    const subMenuProps = {
+      ...props,
       popupClassName: classNames(`${rootPrefixCls}-${antdMenuTheme}`, popupClassName),
       ref: 'subMenu',
       ...$attrs,
       ...Omit($slots, ['default']),
     };
-    return <VcSubMenu {...props}>{getSlot(this)}</VcSubMenu>;
+    return <VcSubMenu {...subMenuProps}>{getSlot(this)}</VcSubMenu>;
   },
 });


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...
- [x] Bug fix

### What's the background?

> 1. VcSubMenu lost rootPrefixCls props.
![image](https://user-images.githubusercontent.com/17797610/99178493-970bd700-274e-11eb-95ec-3afd474a49d0.png)


### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
