### PR TITLE
fix: the button's loading property without delay

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -27,22 +27,25 @@ export default defineComponent({
         large: 'lg',
         small: 'sm',
       },
-      sLoading: !!this.loading,
+      sLoading: false,
       hasTwoCNChar: false,
     };
   },
   watch: {
-    loading(val, preVal) {
-      if (preVal && typeof preVal !== 'boolean') {
-        clearTimeout(this.delayTimeout);
-      }
-      if (val && typeof val !== 'boolean' && val.delay) {
-        this.delayTimeout = setTimeout(() => {
+    loading: {
+      handler(val, preVal) {
+        if (preVal && typeof preVal !== 'boolean') {
+          clearTimeout(this.delayTimeout);
+        }
+        if (val && typeof val !== 'boolean' && val.delay) {
+          this.delayTimeout = setTimeout(() => {
+            this.sLoading = !!val;
+          }, val.delay);
+        } else {
           this.sLoading = !!val;
-        }, val.delay);
-      } else {
-        this.sLoading = !!val;
-      }
+        }
+      },
+      immediate: true,
     },
   },
   mounted() {


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. 设置button组件loading属性值为{delay: 3000}无效

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. It is invalid to set the value of button component loading property to {delay: 3000}. Check the ant design Vue's button.jsx File code. It is found that the value of sLoading attribute returned in data is props.loading If loading is set to object type in the parent component, the sLoading value of the child component is set to true, and the delay function fails
> 2. 设置button组件loading属性值为{delay: 3000}无效，查看ant-design-vue的button.jsx文件代码，发现data中返回的sLoading属性值是将props.loading转为boolean类型，导致在父组件设置loading为object类型则子组件的sLoading赋值为true，delay功能失效
