### PR TITLE
fix: the error of icon property of component

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -27,22 +27,25 @@ export default defineComponent({
         large: 'lg',
         small: 'sm',
       },
-      sLoading: !!this.loading,
+      sLoading: false,
       hasTwoCNChar: false,
     };
   },
   watch: {
-    loading(val, preVal) {
-      if (preVal && typeof preVal !== 'boolean') {
-        clearTimeout(this.delayTimeout);
-      }
-      if (val && typeof val !== 'boolean' && val.delay) {
-        this.delayTimeout = setTimeout(() => {
+    loading: {
+      handler(val, preVal) {
+        if (preVal && typeof preVal !== 'boolean') {
+          clearTimeout(this.delayTimeout);
+        }
+        if (val && typeof val !== 'boolean' && val.delay) {
+          this.delayTimeout = setTimeout(() => {
+            this.sLoading = !!val;
+          }, val.delay);
+        } else {
           this.sLoading = !!val;
-        }, val.delay);
-      } else {
-        this.sLoading = !!val;
-      }
+        }
+      },
+      immediate: true,
     },
   },
   mounted() {


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. 使用Button、Alert等组件,赋值props.icon,最终渲染出来的不是prop.icon对应的vnode，而是对应的value字符串.

### Changelog description (Optional if not new feature)

> 1. 问题发生在components/_util/props-util/index.js文件中的getComponent函数。在判断完temp不为function 或 execute为 false就直接返回了temp，这里缺少入参prop为“icon”时是需要通过temp获取对应的icon对象(vnode)再返回的逻辑
```js
const getComponent = (instance, prop = 'default', options = instance, execute = true) => {
  let com = undefined;
  if (instance.$) {
    const temp = instance[prop];
    if (temp !== undefined) {
     // 缺少temp转icon对象(vnode)的逻辑
      return typeof temp === 'function' && execute ? temp(options) : temp;
    } else {
      com = instance.$slots[prop];
      com = execute && com ? com(options) : com;
    }
  } 
  // ……
};
```
