### PR TITLE
fix: unexpected wave color value

### DIFF
--- a/components/_util/wave.jsx
+++ b/components/_util/wave.jsx
@@ -125,10 +125,13 @@ export default defineComponent({
         }
         this.resetEffect(node);
         // Get wave color from target
-        const waveColor =
-          getComputedStyle(node).getPropertyValue('border-top-color') || // Firefox Compatible
-          getComputedStyle(node).getPropertyValue('border-color') ||
-          getComputedStyle(node).getPropertyValue('background-color');
+        let waveColor = getComputedStyle(node).getPropertyValue('background-color');
+        if (getComputedStyle(node).getPropertyValue('border-width') !== '0px') {
+          waveColor =
+            getComputedStyle(node).getPropertyValue('border-top-color') || // Firefox Compatible
+            getComputedStyle(node).getPropertyValue('border-color') ||
+            waveColor;
+        }
         this.clickWaveTimeoutId = window.setTimeout(() => this.onClick(node, waveColor), 0);
         raf.cancel(this.animationStartId);
         this.animationStart = true;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

1. 当`border`为`unset`但是`background`为**规则判断**之内的颜色的时候，`wave`的颜色非我预期的按钮背景色。
2. 希望可以正确获取颜色。

### API Realization (Optional if not new feature)

1. 由于`border`设置为`unset`的时候，`border-color`的值实际上是`rgb(255, 255, 255)`，因此会造成这段代码：
``` js
const waveColor =
          getComputedStyle(node).getPropertyValue('border-top-color') || // Firefox Compatible
          getComputedStyle(node).getPropertyValue('border-color')
```
取到了值，以至于不会去取`background-color`的值。
所以解决思路是默认获取`background`的值，判断一下`border-width`的宽度，如果非0的话，获取`border-color`的值。

### Self Check before Merge

- [x] Doc is not needed
- [x] Demo is not needed
- [x] TypeScript definition  not needed
- [x] Changelog not needed

### Additional Plan? (Optional if not new feature)

理论上`getPropertyValue('border-color')`这个的取值好像必然是非空的，因此彻底解决这个交互问题可能没有那么简单。
