### PR TITLE
fix: 处理 cascader 最后一级 children 为空时显示的异常

### DIFF
--- a/components/vc-cascader/Menus.jsx
+++ b/components/vc-cascader/Menus.jsx
@@ -170,15 +170,13 @@ export default {
     const { prefixCls, dropdownMenuColumnStyle } = this;
     return (
       <div>
-        {this.getShowOptions().map((options, menuIndex) => {
-          if (options.length > 0) {
-            return (
-              <ul class={`${prefixCls}-menu`} key={menuIndex} style={dropdownMenuColumnStyle}>
-                {options.map(option => this.getOption(option, menuIndex))}
-              </ul>
-            );
-          }
-        })}
+        {this.getShowOptions().filter(options => {
+          return options.length > 0;
+        }).map((options, menuIndex) => (
+          <ul class={`${prefixCls}-menu`} key={menuIndex} style={dropdownMenuColumnStyle}>
+            {options.map(option => this.getOption(option, menuIndex))}
+          </ul>
+        ))}
       </div>
     );
   },

--- a/components/vc-cascader/Menus.jsx
+++ b/components/vc-cascader/Menus.jsx
@@ -170,11 +170,15 @@ export default {
     const { prefixCls, dropdownMenuColumnStyle } = this;
     return (
       <div>
-        {this.getShowOptions().map((options, menuIndex) => (
-          <ul class={`${prefixCls}-menu`} key={menuIndex} style={dropdownMenuColumnStyle}>
-            {options.map(option => this.getOption(option, menuIndex))}
-          </ul>
-        ))}
+        {this.getShowOptions().map((options, menuIndex) => {
+          if (options.length > 0) {
+            return (
+              <ul class={`${prefixCls}-menu`} key={menuIndex} style={dropdownMenuColumnStyle}>
+                {options.map(option => this.getOption(option, menuIndex))}
+              </ul>
+            );
+          }
+        })}
       </div>
     );
   },

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <a-cascader :options="options"></a-cascader>
+    <a-cascader :options="options"/>
   </div>
 </template>
 <script>

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -1,23 +1,29 @@
 <template>
   <div>
-    <a-collapse :accordion="true" default-active-key="2" :bordered="false">
-      <a-collapse-panel key="1" header="This is panel header 1">
-        <p>{{ text }}</p>
-      </a-collapse-panel>
-      <a-collapse-panel key="2" header="This is panel header 2" :disabled="false">
-        <p>{{ text }}</p>
-      </a-collapse-panel>
-      <a-collapse-panel key="3" header="This is panel header 3">
-        <p>{{ text }}</p>
-      </a-collapse-panel>
-    </a-collapse>
+    <a-cascader :options="options"></a-cascader>
   </div>
 </template>
 <script>
 export default {
   data() {
     return {
-      text: `A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.`,
+      options: [
+        {
+          value: '0',
+          label: '0',
+          children: [
+            {
+              value: '0-0',
+              label: '0-0',
+              children: [
+                {
+                  value: '0-0-0',
+                  label: '0-0-0',
+                  children: [],
+                }],
+            }],
+        },
+      ],
     };
   },
 };


### PR DESCRIPTION
### 这个变动的性质是

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [x] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 当 cascader 最后一级 children 为空是会额外显示一个多余的空列表。

### 实现方案和 API（非新功能可选）

> 1. 改动前： [https://d.pr/free/v/z6VrIs](https://d.pr/free/v/z6VrIs)
> 2. 改动后： [https://d.pr/free/v/GCc62z](https://d.pr/free/v/GCc62z)

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

