### PR TITLE
feat: 生成web-types.json，支持JetBrains代码提示

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "module": "es/index.js",
   "unpkg": "dist/antd.min.js",
   "typings": "lib/index.d.ts",
+  "web-types": "dist/web-types.json",
   "files": [
     "dist",
     "lib",
@@ -41,6 +42,7 @@
     "prettier": "prettier -c --write '**/*'",
     "pretty-quick": "pretty-quick",
     "dist": "node antd-tools/cli/run.js dist",
+    "code-completion": "node -r esm scripts/code-completion.js",
     "lint": "eslint -c ./.eslintrc --fix --ext .jsx,.js,.vue,.ts,.tsx ./components",
     "lint:site": "eslint -c ./.eslintrc --fix --ext .jsx,.js,.vue ./antdv-demo",
     "lint:docs": "eslint -c ./.eslintrc --fix --ext .jsx,.js,.vue,.md ./antdv-demo/docs/**/demo/**",
@@ -213,6 +215,7 @@
     "dom-align": "^1.10.4",
     "dom-closest": "^0.2.0",
     "dom-scroll-into-view": "^2.0.0",
+    "esm": "^3.2.25",
     "intersperse": "^1.0.0",
     "is-mobile": "^2.2.1",
     "is-negative-zero": "^2.0.0",

--- a/scripts/code-completion.js
+++ b/scripts/code-completion.js
@@ -1,0 +1,132 @@
+const { version, install } = require('../lib/index');
+const { default: PropTypes } = require('../lib/_util/vue-types/index');
+const path = require('path');
+const rimraf = require('rimraf');
+const fs = require('fs');
+
+/**
+ * copy from vuetify
+ * @param filePath
+ */
+function ensureDirectoryExists(filePath) {
+  const folderPath = path.resolve(path.dirname(filePath));
+  if (!fs.existsSync(folderPath)) {
+    fs.mkdirSync(folderPath);
+  }
+}
+
+/**
+ * copy from vuetify
+ * @param filePath
+ */
+function writeJsonFile(obj, file) {
+  ensureDirectoryExists(file);
+  const stream = fs.createWriteStream(file);
+
+  stream.once('open', () => {
+    stream.write(JSON.stringify(obj, null, 2));
+    stream.end();
+  });
+}
+
+/**
+ * 生成VSCode的tags.json和attributes.json文件
+ */
+function generateForVSCode(components) {
+  console.info('not support for vscode now.');
+}
+
+/**
+ * 生成JetBrains系列软件支持的web-types.json文件
+ */
+function generateForWebStorm(components) {
+  const createAttributesForComponent = component => {
+    const componentProps = component.props;
+    let attributes = [];
+    for (let propName in componentProps) {
+      let type = 'string';
+      const propTypeName = componentProps[propName]._vueTypes_name;
+      switch (propTypeName) {
+        case PropTypes.looseBool._vueTypes_name:
+          type = 'boolean';
+          break;
+        case PropTypes.func._vueTypes_name:
+          type = 'function';
+          break;
+        case PropTypes.number._vueTypes_name:
+          type = 'number';
+          break;
+        // case PropTypes.oneOf._vueTypes_name:
+        //   type =
+        default:
+          type = 'string';
+          break;
+      }
+      attributes.push({
+        name: propName,
+        value: {
+          kind: 'expression',
+          type,
+        },
+      });
+    }
+    return attributes;
+  };
+
+  const createEventsForComponent = component => {
+    let events = [];
+    if (component.emits) {
+      events = component.emits.map(eventName => {
+        return {
+          name: eventName,
+          description: '',
+          arguments: [],
+        };
+      });
+    }
+    return events;
+  };
+
+  const createTagForComponent = component => {
+    return {
+      name: component.name,
+      attributes: createAttributesForComponent(component),
+      events: createEventsForComponent(component),
+    };
+  };
+
+  const tags = components.map(createTagForComponent);
+
+  const webTypes = {
+    $schema: 'http://json.schemastore.org/web-types',
+    framework: 'vue',
+    name: 'ant-design-vue',
+    version,
+    contributions: {
+      html: {
+        'types-syntax': 'typescript',
+        'description-markup': 'markdown',
+        tags,
+      },
+    },
+  };
+
+  rimraf.sync(path.resolve('./dist/web-types.json'));
+  writeJsonFile(webTypes, 'dist/web-types.json');
+}
+
+const components = [];
+const fakeVue = {
+  component(componentName, component) {
+    components.push(component);
+  },
+  use(component) {
+    component.install(fakeVue);
+  },
+  config: {
+    globalProperties: {},
+  },
+};
+install(fakeVue);
+generateForWebStorm(components);
+generateForVSCode(components);


### PR DESCRIPTION
### 这个变动的性质是

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 使用IDEA无代码提示，全屏html标签警告。
> 2. 需要支持JetBrains IDE的代码提示，去除IDE中的警告。
> 3. https://github.com/vueComponent/ant-design-vue/issues/3191 https://github.com/vueComponent/ant-design-vue/issues/1286 。

### 实现方案和 API（非新功能可选）

> 1. 执行npm run dist之后，会生成组件，通过暴露出来的install方法可以获取所有组件，利用这里生成web-types.json文件。
> 2. 先执行npm run dist（必须），再执行npm run code-completion，会在dist目录下生成web-types.json文件。
> 3. package.json 新增属性: "web-types": "dist/web-types.json"
       package.json "scripts" 属性新增属性: "code-completion": "node -r esm scripts/code-completion.js"
       package.json 新增依赖: "esm": "^3.2.25"，解决lodash-es问题引起的ant-design在node环境下无法被引用
       scripts/code-completion.js 为实现文件。
> 4. 对了，这个只在dist目录下生成了web-types.json，怎么发布到npm这一部分我不会哦，你们弄一下。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
仅对 JetBrains IDE 用户有影响，会增加代码提示功能。
> 2. 是否有可能隐含的 break change 和其他风险？
无隐藏风险

### Changelog 描述（非新功能可选）

> 1. 英文描述
balabala...
> 2. 中文描述（可选）
JetBrains IDE 增加代码提示功能