### PR TITLE
fix: deep nested verification of data sources

### DIFF
--- a/components/form-model/FormItem.jsx
+++ b/components/form-model/FormItem.jsx
@@ -161,8 +161,13 @@ export default {
       const selfRules = this.rules;
       const requiredRule =
         this.required !== undefined ? { required: !!this.required, trigger: 'change' } : [];
-      const prop = getPropByPath(formRules, this.prop || '');
-      formRules = formRules ? prop.o[this.prop || ''] || prop.v : [];
+      // FIX: deep nested verification of data sources
+      const propArray = !!this.prop ? this.prop.split('.') : this.prop;
+      const propArrayLength = propArray.length;
+      const propTemp =
+        propArray && propArrayLength > 1 ? propArray[propArrayLength - 1] : this.prop;
+      const prop = getPropByPath(formRules, propTemp || '');
+      formRules = formRules ? prop.o[propTemp || ''] || prop.v : [];
       return [].concat(selfRules || formRules || []).concat(requiredRule);
     },
     getFilteredRule(trigger) {

--- a/components/form-model/FormItem.jsx
+++ b/components/form-model/FormItem.jsx
@@ -163,9 +163,8 @@ export default {
         this.required !== undefined ? { required: !!this.required, trigger: 'change' } : [];
       // FIX: deep nested verification of data sources
       const propArray = !!this.prop ? this.prop.split('.') : this.prop;
-      const propArrayLength = propArray.length;
       const propTemp =
-        propArray && propArrayLength > 1 ? propArray[propArrayLength - 1] : this.prop;
+        propArray && propArray.length > 1 ? propArray[propArray.length - 1] : this.prop;
       const prop = getPropByPath(formRules, propTemp || '');
       formRules = formRules ? prop.o[propTemp || ''] || prop.v : [];
       return [].concat(selfRules || formRules || []).concat(requiredRule);


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.

```vue
<template>
<a-form-model ref="ruleForm2" :model="ruleForm2" :rules="rules2">

        <a-form-model-item has-feedback prop="name1">
          <a-input v-model="ruleForm2.name1" :maxLength="10" placeholder="name1" />
        </a-form-model-item>
        <a-form-model-item has-feedback prop="name2">
          <a-input v-model="ruleForm2.name2" :maxLength="10" placeholder="name2" />
        </a-form-model-item>
      </a-form-model>

<a-form-model ref="ruleForm" :model="ruleForm" :rules="rules">
          <a-table :columns="rolledSteelCreateLCDemandColumns" :data-source="ruleForm.datasource" :pagination="false">
            <template slot-scope="text, record,index" slot="categoryName">
              <a-form-model-item has-feedback :prop="`datasource.${index}.categoryName`">
                <a-input v-model="record.categoryName"  placeholder="名称" />
              </a-form-model-item>
            </template>
            <template slot-scope="text, record,index" slot="categorySpecification">
              <a-form-model-item :prop="`datasource.${index}.categorySpecification`">
                <a-input v-model="record.categorySpecification"  placeholder="规格"></a-input>
              </a-form-model-item>
            </template>
            <span slot-scope="text, record" slot="wangtBuyCount" class="double-input">
              <a-input type="number" v-model="record.wangtBuyCount.count" class="count" placeholder="数量" @change="countChange(record)"></a-input>
              <a-cascader v-model="record.unit" popupClassName="clcd-cascader" placeholder="单位" class="unit" />
            </span>
            <a-input v-model="record.productManufacturer" :maxLength="15" slot-scope="text, record" slot="productManufacturer" placeholder="厂商"></a-input>
            <a-input v-model="record.categoryCharacter" :maxLength="15" slot-scope="text, record" slot="categoryCharacter" placeholder="特性"></a-input>
            <a-input v-model="record.categoryRemark" :maxLength="30" slot-scope="text, record" slot="categoryRemark" placeholder="备注"></a-input>
            <a href="javascript:;" slot="operate" slot-scope="text, record" @click="delRow(record.key)">删除</a>
          </a-table>
        </a-form-model>
</template>

<script>
export default {
  data() {
    const validate = (rule, value, callback) => {
      if (value === '' || value == undefined) {
        callback(new Error('请输入内容'))
      } else {
        if (this.ruleForm.checkPass !== '') {
          this.$refs.ruleForm.validateField('checkPass')
        }
        callback()
      }
    }
    return {
       ruleForm: {
        datasource: [
          {
            key: 0,
            categoryName: '',
            categorySpecification: '',
            wangtBuyCount: {
              count: '',
              unit: '',
            },
            productManufacturer: '',
            categoryCharacter: '',
            categoryRemark: '',
          },
          {
            key: 1,
            categoryName: '',
            categorySpecification: '',
            wangtBuyCount: {
              count: '',
              unit: '',
            },
            productManufacturer: '',
            categoryCharacter: '',
            categoryRemark: '',
          },
        ],
        rules: {
        categoryName: [{ required: true, message: '请输入品类名称', trigger: 'blur' }],
        categorySpecification: [{ validator: validate,message:'name1', trigger: 'blur' }],
      },
ruleForm2:{
        name1:'',
        name2:''
      },
rules2:{
        name1: [{ validator: validate,message:'name1', trigger: 'blur' }],
        name2: [{ validator: validate,message:'name1', trigger: 'blur' }],
      },
     }
}
</script>
```
以上为示例片段，运行需要进行修改，修改后有测试了正常写法，未发现有影响。

> 2. Resolve what problem.

问题：按照常规的写法，table 中的 input 校验异常，例如：已经输入文字，但是还是显示为空。
期望：按照常规的写法，在节点中不添加其它辅助属性，只要在prop中指定数据深度，就可以自动匹配rules中的规则，并正确校验。
特殊情况下属性写法 ·:prop="`datasource.${index}.categoryName`"·
结果：可以正常校验

> 3. Related issue link.

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
