### PR TITLE
i18n: vc-calendar support shortYear for year

### DIFF
--- a/components/vc-calendar/src/decade/DecadePanel.jsx
+++ b/components/vc-calendar/src/decade/DecadePanel.jsx
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import PropTypes from '../../../_util/vue-types';
 import BaseMixin from '../../../_util/BaseMixin';
 const ROW = 4;
@@ -40,6 +41,12 @@ export default {
       this.sValue = val;
     },
   },
+  methods: {
+    shortYear(year) {
+      const { locale } = this;
+      return locale.shortYear ? moment(year).format(locale.shortYear) : year;
+    },
+  },
   render() {
     const value = this.sValue;
     const { locale, renderFooter } = this.$props;
@@ -77,7 +84,9 @@ export default {
           [`${prefixCls}-last-century-cell`]: isLast,
           [`${prefixCls}-next-century-cell`]: isNext,
         };
-        const content = `${dStartDecade}-${dEndDecade}`;
+        const content = `${this.shortYear(String(dStartDecade))}-${this.shortYear(
+          String(dEndDecade),
+        )}`;
         let clickHandler = noop;
         if (isLast) {
           clickHandler = this.previousCentury;
@@ -110,7 +119,7 @@ export default {
           />
 
           <div class={`${prefixCls}-century`}>
-            {startYear}-{endYear}
+            {this.shortYear(String(startYear))}-{this.shortYear(String(endYear))}
           </div>
           <a
             class={`${prefixCls}-next-century-btn`}

--- a/components/vc-calendar/src/month/MonthPanel.jsx
+++ b/components/vc-calendar/src/month/MonthPanel.jsx
@@ -67,7 +67,7 @@ const MonthPanel = {
       disabledDate,
       renderFooter,
     } = this;
-    const year = sValue.year();
+    const year = locale.shortYear ? sValue.format(locale.shortYear) : sValue.year();
     const prefixCls = `${rootPrefixCls}-month-panel`;
 
     const footer = renderFooter && renderFooter('month');

--- a/components/vc-calendar/src/year/YearPanel.jsx
+++ b/components/vc-calendar/src/year/YearPanel.jsx
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import PropTypes from '../../../_util/vue-types';
 import BaseMixin from '../../../_util/BaseMixin';
 import { getListeners } from '../../../_util/props-util';
@@ -53,7 +54,7 @@ export default {
         years[rowIndex] = [];
         for (let colIndex = 0; colIndex < COL; colIndex++) {
           const year = previousYear + index;
-          const content = String(year);
+          const content = this.shortYear(String(year));
           years[rowIndex][colIndex] = {
             content,
             year,
@@ -63,6 +64,10 @@ export default {
         }
       }
       return years;
+    },
+    shortYear(year) {
+      const { locale } = this;
+      return locale.shortYear ? moment(year).format(locale.shortYear) : year;
     },
   },
 
@@ -127,7 +132,7 @@ export default {
               title={locale.decadeSelect}
             >
               <span class={`${prefixCls}-decade-select-content`}>
-                {startYear}-{endYear}
+                {this.shortYear(String(startYear))}-{this.shortYear(String(endYear))}
               </span>
               <span class={`${prefixCls}-decade-select-arrow`}>x</span>
             </a>


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

### 这个变动的性质是

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 描述相关需求的来源。
    允许定义日期选择控件定义短年的配置.
    如: 需要日期控件需要显示 令和元年, 平成24年或民國109年等多语言设置
> 2. 要解决的问题。
    加入`shortYear`作为key，用户可选配置
> 3. 相关的 issue 讨论链接。

### 实现方案和 API（非新功能可选）

> 1. 基本的解决思路和其他可选方案。
> 2. 列出最终的 API 实现和用法。
> 3. 涉及 UI/交互变动需要有截图或 GIF。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
    DecadePanel 短年显示配置有可能过长, 有可能超出容器, 实现方式可能不是很合适.
> 2. 是否有可能隐含的 break change 和其他风险？

### Changelog 描述（非新功能可选）

> 1. 英文描述
> 2. 中文描述（可选）

### 请求合并前的自查清单

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。