### PR TITLE
fix: carousel's pauseOnDotsHover not work

### DIFF
--- a/components/vc-slick/src/inner-slider.js
+++ b/components/vc-slick/src/inner-slider.js
@@ -604,7 +604,6 @@ export default {
       ...trackProps,
       focusOnSelect: this.focusOnSelect ? this.selectHandler : null,
       ref: this.trackRefHandler,
-      onMouseenter: pauseOnHover ? this.onTrackOver : noop,
       onMouseleave: pauseOnHover ? this.onTrackLeave : noop,
       onMouseover: pauseOnHover ? this.onTrackOver : noop,
     };
@@ -635,7 +634,6 @@ export default {
       dotProps = {
         ...dotProps,
         clickHandler: this.changeSlide,
-        onMouseenter: pauseOnDotsHover ? this.onDotsOver : noop,
         onMouseover: pauseOnDotsHover ? this.onDotsOver : noop,
         onMouseleave: pauseOnDotsHover ? this.onDotsLeave : noop,
       };

--- a/components/vc-slick/src/inner-slider.js
+++ b/components/vc-slick/src/inner-slider.js
@@ -635,7 +635,7 @@ export default {
       dotProps = {
         ...dotProps,
         clickHandler: this.changeSlide,
-        onMouseenter: pauseOnDotsHover ? this.onDotsLeave : noop,
+        onMouseenter: pauseOnDotsHover ? this.onDotsOver : noop,
         onMouseover: pauseOnDotsHover ? this.onDotsOver : noop,
         onMouseleave: pauseOnDotsHover ? this.onDotsLeave : noop,
       };


### PR DESCRIPTION

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Use Carousel, set autoplay, autoplaySpeed, pauseOnDotsHover.
> 2. Hover on dots, it doesn't work.

### API Realization (Optional if not new feature)

> 1.  show file changes.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. fix Carousel's prop of pauseOnDotsHover not work.
> 2. 修复Carousel组件pauseOnDotsHover失效问题。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

