### PR TITLE
feat: add prop "disabled" for tooltip, and all components based on it

### DIFF
--- a/components/tooltip/Tooltip.jsx
+++ b/components/tooltip/Tooltip.jsx
@@ -191,6 +191,9 @@ export default {
     const child = this.getDisabledCompatibleChildren(
       isValidElement(children) ? children : <span>{children}</span>,
     );
+    if ($props.disabled) {
+      return child;
+    }
     const childCls = {
       [openClassName || `${prefixCls}-open`]: true,
     };

--- a/components/tooltip/abstractTooltipProps.js
+++ b/components/tooltip/abstractTooltipProps.js
@@ -3,6 +3,7 @@ const triggerType = PropTypes.oneOf(['hover', 'focus', 'click', 'contextmenu']);
 export default () => ({
   trigger: PropTypes.oneOfType([triggerType, PropTypes.arrayOf(triggerType)]).def('hover'),
   visible: PropTypes.bool,
+  disabled: PropTypes.bool,
   defaultVisible: PropTypes.bool,
   placement: PropTypes.oneOf([
     'top',

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -11,6 +11,45 @@
         <p>{{ text }}</p>
       </a-collapse-panel>
     </a-collapse>
+
+    <a-divider orientation="left">Examples</a-divider>
+
+    <a-tooltip title="Tooltip Disabled" disabled placement="top">
+      <a-button disabled>Tooltip Disabled</a-button>
+    </a-tooltip>
+    <a-tooltip title="Tooltip Enabled" placement="top">
+      <a-button>Tooltip Enabled</a-button>
+    </a-tooltip>
+
+    <a-divider></a-divider>
+
+    <a-popconfirm placement="top" disabled ok-text="Yes" cancel-text="No">
+      <template slot="title">
+        <p>Popconfirm Disabled</p>
+      </template>
+      <a-button disabled>Popconfirm Disabled</a-button>
+    </a-popconfirm>
+    <a-popconfirm placement="top" ok-text="Yes" cancel-text="No">
+      <template slot="title">
+        <p>Popconfirm Enabled</p>
+      </template>
+      <a-button>Popconfirm Enabled</a-button>
+    </a-popconfirm>
+
+    <a-divider></a-divider>
+
+    <a-popover title="Popover Disabled" disabled>
+      <template slot="content">
+        <p>Popover Disabled</p>
+      </template>
+      <a-button disabled>Popover Disabled</a-button>
+    </a-popover>
+    <a-popover title="Popover Enabled">
+      <template slot="content">
+        <p>Popover Enabled</p>
+      </template>
+      <a-button>Popover Enabled</a-button>
+    </a-popover>
   </div>
 </template>
 <script>


### PR DESCRIPTION
### 这个变动的性质是

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. tooltip 需要支持 disabled

### 实现方案和 API（非新功能可选）

> 1. 添加 props "disabled"

### 对用户的影响和可能的风险（非新功能可选）

> 1. 新增特性，应该不会影响原有组件使用。

### Changelog 描述（非新功能可选）

> 1. add prop "disabled" for tooltip, and all components based on it（popover, popconfirm）
> 2. tooltip 组件添加 prop "disabled"，以及所有基于 tooltip 的组件（popover, popconfirm）

### 请求合并前的自查清单

- [ ] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。