### PR TITLE
Make moment.js tree-shakable by moving ConfigConsumerProps to own file (v1)

### DIFF
--- a/components/_util/wave.jsx
+++ b/components/_util/wave.jsx
@@ -1,6 +1,6 @@
 import TransitionEvents from './css-animation/Event';
 import raf from './raf';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 let styleForPesudo;
 
 // Where el is the DOM element you'd like to test for visibility

--- a/components/affix/index.jsx
+++ b/components/affix/index.jsx
@@ -4,7 +4,7 @@ import omit from 'omit.js';
 import ResizeObserver from '../vc-resize-observer';
 import BaseMixin from '../_util/BaseMixin';
 import throttleByAnimationFrame from '../_util/throttleByAnimationFrame';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 import warning from '../_util/warning';
 import {

--- a/components/alert/index.jsx
+++ b/components/alert/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from '../_util/vue-types';
 import getTransitionProps from '../_util/getTransitionProps';
 import { getComponentFromProp, isValidElement } from '../_util/props-util';
 import { cloneElement } from '../_util/vnode';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 
 function noop() {}

--- a/components/anchor/Anchor.jsx
+++ b/components/anchor/Anchor.jsx
@@ -6,7 +6,7 @@ import scrollTo from '../_util/scrollTo';
 import getScroll from '../_util/getScroll';
 import { initDefaultProps } from '../_util/props-util';
 import BaseMixin from '../_util/BaseMixin';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 function getDefaultContainer() {
   return window;

--- a/components/anchor/AnchorLink.jsx
+++ b/components/anchor/AnchorLink.jsx
@@ -1,7 +1,7 @@
 import PropTypes from '../_util/vue-types';
 import { initDefaultProps, getComponentFromProp } from '../_util/props-util';
 import classNames from 'classnames';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 export const AnchorLinkProps = {
   prefixCls: PropTypes.string,

--- a/components/auto-complete/index.jsx
+++ b/components/auto-complete/index.jsx
@@ -3,7 +3,7 @@ import Select, { AbstractSelectProps, SelectValue } from '../select';
 import Input from '../input';
 import InputElement from './InputElement';
 import PropTypes from '../_util/vue-types';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import {
   getComponentFromProp,
   getOptionProps,

--- a/components/avatar/Avatar.jsx
+++ b/components/avatar/Avatar.jsx
@@ -1,4 +1,4 @@
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Icon from '../icon';
 import { getListeners, getComponentFromProp } from '../_util/props-util';
 import PropTypes from '../_util/vue-types';

--- a/components/back-top/index.jsx
+++ b/components/back-top/index.jsx
@@ -3,7 +3,7 @@ import addEventListener from '../vc-util/Dom/addEventListener';
 import getScroll from '../_util/getScroll';
 import BaseMixin from '../_util/BaseMixin';
 import getTransitionProps from '../_util/getTransitionProps';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 import { getListeners } from '../_util/props-util';
 import scrollTo from '../_util/scrollTo';

--- a/components/badge/Badge.jsx
+++ b/components/badge/Badge.jsx
@@ -11,7 +11,7 @@ import {
 import { cloneElement } from '../_util/vnode';
 import getTransitionProps from '../_util/getTransitionProps';
 import isNumeric from '../_util/isNumeric';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 const BadgeProps = {
   /** Number to show in badge */

--- a/components/badge/ScrollNumber.jsx
+++ b/components/badge/ScrollNumber.jsx
@@ -4,7 +4,7 @@ import BaseMixin from '../_util/BaseMixin';
 import { getStyle } from '../_util/props-util';
 import omit from 'omit.js';
 import { cloneElement } from '../_util/vnode';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 function getNumberArray(num) {
   return num

--- a/components/breadcrumb/Breadcrumb.jsx
+++ b/components/breadcrumb/Breadcrumb.jsx
@@ -2,7 +2,7 @@ import PropTypes from '../_util/vue-types';
 import { cloneElement } from '../_util/vnode';
 import { filterEmpty, getComponentFromProp, getSlotOptions } from '../_util/props-util';
 import warning from '../_util/warning';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import BreadcrumbItem from './BreadcrumbItem';
 import Menu from '../menu';
 

--- a/components/breadcrumb/BreadcrumbItem.jsx
+++ b/components/breadcrumb/BreadcrumbItem.jsx
@@ -1,6 +1,6 @@
 import PropTypes from '../_util/vue-types';
 import { hasProp, getComponentFromProp } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import DropDown from '../dropdown/dropdown';
 import Icon from '../icon';
 

--- a/components/breadcrumb/BreadcrumbSeparator.jsx
+++ b/components/breadcrumb/BreadcrumbSeparator.jsx
@@ -1,4 +1,4 @@
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import PropTypes from '../_util/vue-types';
 
 export default {

--- a/components/button/button-group.jsx
+++ b/components/button/button-group.jsx
@@ -1,6 +1,6 @@
 import { filterEmpty } from '../_util/props-util';
 import PropTypes from '../_util/vue-types';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 const ButtonGroupProps = {
   prefixCls: PropTypes.string,

--- a/components/button/button.jsx
+++ b/components/button/button.jsx
@@ -2,7 +2,7 @@ import Wave from '../_util/wave';
 import Icon from '../icon';
 import buttonTypes from './buttonTypes';
 import { filterEmpty, getListeners, getComponentFromProp } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 const rxTwoCNChar = /^[\u4e00-\u9fa5]{2}$/;
 const isTwoCNChar = rxTwoCNChar.test.bind(rxTwoCNChar);

--- a/components/calendar/Header.jsx
+++ b/components/calendar/Header.jsx
@@ -2,7 +2,7 @@ import Select from '../select';
 import { Group, Button } from '../radio';
 import PropTypes from '../_util/vue-types';
 import { initDefaultProps } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 const { Option } = Select;
 

--- a/components/calendar/index.jsx
+++ b/components/calendar/index.jsx
@@ -6,7 +6,7 @@ import FullCalendar from '../vc-calendar/src/FullCalendar';
 import Header from './Header';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import interopDefault from '../_util/interopDefault';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import enUS from './locale/en_US';
 import Base from '../base';
 import { checkValidate, stringToMoment, momentToString, TimeType } from '../_util/moment-util';

--- a/components/card/Card.jsx
+++ b/components/card/Card.jsx
@@ -10,7 +10,7 @@ import {
   getListeners,
 } from '../_util/props-util';
 import BaseMixin from '../_util/BaseMixin';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 const { TabPane } = Tabs;
 export default {

--- a/components/card/Grid.jsx
+++ b/components/card/Grid.jsx
@@ -1,5 +1,5 @@
 import PropTypes from '../_util/vue-types';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import { getListeners } from '../_util/props-util';
 
 export default {

--- a/components/card/Meta.jsx
+++ b/components/card/Meta.jsx
@@ -1,6 +1,6 @@
 import PropTypes from '../_util/vue-types';
 import { getComponentFromProp, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 export default {
   name: 'ACardMeta',

--- a/components/carousel/index.jsx
+++ b/components/carousel/index.jsx
@@ -6,7 +6,7 @@ import hasProp, {
   filterEmpty,
   getListeners,
 } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 import warning from '../_util/warning';
 import classNames from 'classnames';

--- a/components/cascader/index.jsx
+++ b/components/cascader/index.jsx
@@ -20,7 +20,7 @@ import {
 import BaseMixin from '../_util/BaseMixin';
 import { cloneElement } from '../_util/vnode';
 import warning from '../_util/warning';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 
 const CascaderOptionType = PropTypes.shape({

--- a/components/checkbox/Checkbox.jsx
+++ b/components/checkbox/Checkbox.jsx
@@ -2,7 +2,7 @@ import PropTypes from '../_util/vue-types';
 import classNames from 'classnames';
 import VcCheckbox from '../vc-checkbox';
 import hasProp, { getOptionProps, getAttrs, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import warning from '../_util/warning';
 function noop() {}
 

--- a/components/checkbox/Group.jsx
+++ b/components/checkbox/Group.jsx
@@ -1,7 +1,7 @@
 import PropTypes from '../_util/vue-types';
 import Checkbox from './Checkbox';
 import hasProp from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 function noop() {}
 export default {

--- a/components/collapse/Collapse.jsx
+++ b/components/collapse/Collapse.jsx
@@ -9,7 +9,7 @@ import {
 import { cloneElement } from '../_util/vnode';
 import VcCollapse, { collapseProps } from '../vc-collapse';
 import Icon from '../icon';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 export default {
   name: 'ACollapse',

--- a/components/collapse/CollapsePanel.jsx
+++ b/components/collapse/CollapsePanel.jsx
@@ -1,6 +1,6 @@
 import { getOptionProps, getComponentFromProp, getListeners } from '../_util/props-util';
 import VcCollapse, { panelProps } from '../vc-collapse';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 export default {
   name: 'ACollapsePanel',

--- a/components/color-picker/ColorPicker.jsx
+++ b/components/color-picker/ColorPicker.jsx
@@ -1,5 +1,5 @@
 import PropTypes from '../_util/vue-types';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import BaseMixin from '../_util/BaseMixin';
 import Pickr from '@simonwep/pickr/dist/pickr.es5.min';
 import Icon from '../icon';

--- a/components/comment/index.jsx
+++ b/components/comment/index.jsx
@@ -1,6 +1,6 @@
 import PropsTypes from '../_util/vue-types';
 import { getComponentFromProp, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 export const CommentProps = {
   actions: PropsTypes.array,

--- a/components/config-provider/configConsumerProps.jsx
+++ b/components/config-provider/configConsumerProps.jsx
@@ -1,0 +1,9 @@
+import defaultRenderEmpty from './renderEmpty';
+
+export const ConfigConsumerProps = {
+  getPrefixCls: (suffixCls, customizePrefixCls) => {
+    if (customizePrefixCls) return customizePrefixCls;
+    return `ant-${suffixCls}`;
+  },
+  renderEmpty: defaultRenderEmpty,
+};

--- a/components/config-provider/index.jsx
+++ b/components/config-provider/index.jsx
@@ -82,14 +82,6 @@ const ConfigProvider = {
   },
 };
 
-export const ConfigConsumerProps = {
-  getPrefixCls: (suffixCls, customizePrefixCls) => {
-    if (customizePrefixCls) return customizePrefixCls;
-    return `ant-${suffixCls}`;
-  },
-  renderEmpty: defaultRenderEmpty,
-};
-
 /* istanbul ignore next */
 ConfigProvider.install = function(Vue) {
   Vue.use(Base);

--- a/components/config-provider/renderEmpty.jsx
+++ b/components/config-provider/renderEmpty.jsx
@@ -1,6 +1,6 @@
 import PropTypes from '../_util/vue-types';
 import Empty from '../empty';
-import { ConfigConsumerProps } from './';
+import { ConfigConsumerProps } from './configConsumerProps';
 
 const RenderEmpty = {
   functional: true,

--- a/components/date-picker/RangePicker.jsx
+++ b/components/date-picker/RangePicker.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import shallowequal from 'shallowequal';
 import Icon from '../icon';
 import Tag from '../tag';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import interopDefault from '../_util/interopDefault';
 import { RangePickerProps } from './interface';
 import {

--- a/components/date-picker/WeekPicker.jsx
+++ b/components/date-picker/WeekPicker.jsx
@@ -2,7 +2,7 @@ import * as moment from 'moment';
 import Calendar from '../vc-calendar';
 import VcDatePicker from '../vc-calendar/src/Picker';
 import Icon from '../icon';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import {
   hasProp,
   getOptionProps,

--- a/components/date-picker/createPicker.js
+++ b/components/date-picker/createPicker.js
@@ -4,7 +4,7 @@ import MonthCalendar from '../vc-calendar/src/MonthCalendar';
 import VcDatePicker from '../vc-calendar/src/Picker';
 import classNames from 'classnames';
 import Icon from '../icon';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import interopDefault from '../_util/interopDefault';
 import BaseMixin from '../_util/BaseMixin';
 import {

--- a/components/date-picker/wrapPicker.js
+++ b/components/date-picker/wrapPicker.js
@@ -4,7 +4,7 @@ import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import { generateShowHourMinuteSecond } from '../time-picker';
 import enUS from './locale/en_US';
 import { getOptionProps, initDefaultProps, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import { checkValidate, stringToMoment, momentToString } from '../_util/moment-util';
 
 const DEFAULT_FORMAT = {

--- a/components/descriptions/index.jsx
+++ b/components/descriptions/index.jsx
@@ -1,6 +1,6 @@
 import warning from '../_util/warning';
 import ResponsiveObserve, { responsiveArray } from '../_util/responsiveObserve';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Col from './Col';
 import PropTypes from '../_util/vue-types';
 import {

--- a/components/divider/index.jsx
+++ b/components/divider/index.jsx
@@ -1,5 +1,5 @@
 import PropTypes from '../_util/vue-types';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 
 const Divider = {

--- a/components/drawer/index.jsx
+++ b/components/drawer/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from '../_util/vue-types';
 import BaseMixin from '../_util/BaseMixin';
 import Icon from '../icon';
 import { getComponentFromProp, getOptionProps, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 
 const Drawer = {

--- a/components/dropdown/dropdown-button.jsx
+++ b/components/dropdown/dropdown-button.jsx
@@ -5,7 +5,7 @@ import Dropdown from './dropdown';
 import PropTypes from '../_util/vue-types';
 import { hasProp, getComponentFromProp } from '../_util/props-util';
 import getDropdownProps from './getDropdownProps';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Icon from '../icon';
 
 const ButtonTypesProps = buttonTypes();

--- a/components/dropdown/dropdown.jsx
+++ b/components/dropdown/dropdown.jsx
@@ -9,7 +9,7 @@ import {
   getListeners,
 } from '../_util/props-util';
 import getDropdownProps from './getDropdownProps';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Icon from '../icon';
 
 const DropdownProps = getDropdownProps();

--- a/components/empty/index.jsx
+++ b/components/empty/index.jsx
@@ -1,5 +1,5 @@
 import PropTypes from '../_util/vue-types';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import { getComponentFromProp, getListeners } from '../_util/props-util';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import DefaultEmptyImg from './empty';

--- a/components/form-model/Form.jsx
+++ b/components/form-model/Form.jsx
@@ -5,7 +5,7 @@ import isRegExp from 'lodash/isRegExp';
 import warning from '../_util/warning';
 import FormItem from './FormItem';
 import { initDefaultProps, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 export const FormProps = {
   layout: PropTypes.oneOf(['horizontal', 'inline', 'vertical']),

--- a/components/form-model/FormItem.jsx
+++ b/components/form-model/FormItem.jsx
@@ -11,7 +11,7 @@ import {
   isValidElement,
 } from '../_util/props-util';
 import BaseMixin from '../_util/BaseMixin';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import FormItem from '../form/FormItem';
 import { cloneElement } from '../_util/vnode';
 

--- a/components/form/Form.jsx
+++ b/components/form/Form.jsx
@@ -9,7 +9,7 @@ import createFormField from '../vc-form/src/createFormField';
 import FormItem from './FormItem';
 import { FIELD_META_PROP, FIELD_DATA_PROP } from './constants';
 import { initDefaultProps, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 
 export const FormCreateOption = {

--- a/components/form/FormItem.jsx
+++ b/components/form/FormItem.jsx
@@ -17,7 +17,7 @@ import getTransitionProps from '../_util/getTransitionProps';
 import BaseMixin from '../_util/BaseMixin';
 import { cloneElement, cloneVNodes } from '../_util/vnode';
 import Icon from '../icon';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 function noop() {}
 

--- a/components/grid/Col.jsx
+++ b/components/grid/Col.jsx
@@ -1,5 +1,5 @@
 import PropTypes from '../_util/vue-types';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import { getListeners } from '../_util/props-util';
 
 const stringOrNumber = PropTypes.oneOfType([PropTypes.string, PropTypes.number]);

--- a/components/grid/Row.jsx
+++ b/components/grid/Row.jsx
@@ -1,6 +1,6 @@
 import PropTypes from '../_util/vue-types';
 import BaseMixin from '../_util/BaseMixin';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import ResponsiveObserve from '../_util/responsiveObserve';
 
 const RowProps = {

--- a/components/input-number/index.jsx
+++ b/components/input-number/index.jsx
@@ -3,7 +3,7 @@ import { initDefaultProps, getOptionProps, getListeners } from '../_util/props-u
 import classNames from 'classnames';
 import Icon from '../icon';
 import VcInputNumber from '../vc-input-number/src';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 
 export const InputNumberProps = {

--- a/components/input/Group.jsx
+++ b/components/input/Group.jsx
@@ -1,6 +1,6 @@
 import PropTypes from '../_util/vue-types';
 import { filterEmpty, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 export default {
   name: 'AInputGroup',

--- a/components/input/Input.jsx
+++ b/components/input/Input.jsx
@@ -3,7 +3,7 @@ import TextArea from './TextArea';
 import omit from 'omit.js';
 import inputProps from './inputProps';
 import { hasProp, getComponentFromProp, getListeners, getOptionProps } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import ClearableLabeledInput from './ClearableLabeledInput';
 
 function noop() {}

--- a/components/input/Search.jsx
+++ b/components/input/Search.jsx
@@ -7,7 +7,7 @@ import Button from '../button';
 import { cloneElement } from '../_util/vnode';
 import PropTypes from '../_util/vue-types';
 import { getOptionProps, getComponentFromProp, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 export default {
   name: 'AInputSearch',

--- a/components/input/TextArea.jsx
+++ b/components/input/TextArea.jsx
@@ -2,7 +2,7 @@ import ClearableLabeledInput from './ClearableLabeledInput';
 import ResizableTextArea from './ResizableTextArea';
 import inputProps from './inputProps';
 import hasProp, { getListeners, getOptionProps } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import { fixControlledValue, resolveOnChange } from './Input';
 import PropTypes from '../_util/vue-types';
 

--- a/components/layout/Sider.jsx
+++ b/components/layout/Sider.jsx
@@ -9,7 +9,7 @@ import {
 } from '../_util/props-util';
 import BaseMixin from '../_util/BaseMixin';
 import isNumeric from '../_util/isNumeric';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Icon from '../icon';
 
 // matchMedia polyfill for

--- a/components/layout/layout.jsx
+++ b/components/layout/layout.jsx
@@ -1,7 +1,7 @@
 import PropTypes from '../_util/vue-types';
 import classNames from 'classnames';
 import { getOptionProps, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 export const BasicProps = {
   prefixCls: PropTypes.string,

--- a/components/list/Item.jsx
+++ b/components/list/Item.jsx
@@ -7,7 +7,7 @@ import {
   isEmptyElement,
 } from '../_util/props-util';
 import { Col } from '../grid';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import { ListGridType } from './index';
 import { cloneElement } from '../_util/vnode';
 

--- a/components/list/index.jsx
+++ b/components/list/index.jsx
@@ -1,7 +1,7 @@
 import PropTypes from '../_util/vue-types';
 import classNames from 'classnames';
 import omit from 'omit.js';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 import Spin from '../spin';
 import Pagination, { PaginationConfig } from '../pagination';

--- a/components/mentions/index.jsx
+++ b/components/mentions/index.jsx
@@ -6,7 +6,7 @@ import { mentionsProps } from '../vc-mentions/src/mentionsProps';
 import Base from '../base';
 import Spin from '../spin';
 import BaseMixin from '../_util/BaseMixin';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import {
   getOptionProps,
   getComponentFromProp,

--- a/components/menu/index.jsx
+++ b/components/menu/index.jsx
@@ -8,7 +8,7 @@ import Item from './MenuItem';
 import { hasProp, getListeners, getOptionProps } from '../_util/props-util';
 import BaseMixin from '../_util/BaseMixin';
 import commonPropsType from '../vc-menu/commonPropsType';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 // import raf from '../_util/raf';
 

--- a/components/modal/Modal.jsx
+++ b/components/modal/Modal.jsx
@@ -16,7 +16,7 @@ import {
   mergeProps,
   getListeners,
 } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 let mousePosition = null;
 // ref: https://github.com/ant-design/ant-design/issues/15795

--- a/components/page-header/index.jsx
+++ b/components/page-header/index.jsx
@@ -1,6 +1,6 @@
 import PropTypes from '../_util/vue-types';
 import { getComponentFromProp, getOptionProps } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Icon from '../icon';
 import Breadcrumb from '../breadcrumb';
 import Avatar from '../avatar';

--- a/components/pagination/Pagination.jsx
+++ b/components/pagination/Pagination.jsx
@@ -6,7 +6,7 @@ import { getOptionProps, getListeners } from '../_util/props-util';
 import VcPagination from '../vc-pagination';
 import enUS from '../vc-pagination/locale/en_US';
 import Icon from '../icon';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 export const PaginationProps = () => ({
   total: PropTypes.number,

--- a/components/popconfirm/index.jsx
+++ b/components/popconfirm/index.jsx
@@ -9,7 +9,7 @@ import Icon from '../icon';
 import Button from '../button';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import defaultLocale from '../locale-provider/default';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 
 const tooltipProps = abstractTooltipProps();

--- a/components/popover/index.jsx
+++ b/components/popover/index.jsx
@@ -2,7 +2,7 @@ import Tooltip from '../tooltip';
 import abstractTooltipProps from '../tooltip/abstractTooltipProps';
 import PropTypes from '../_util/vue-types';
 import { getOptionProps, getComponentFromProp, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 
 const props = abstractTooltipProps();

--- a/components/progress/progress.jsx
+++ b/components/progress/progress.jsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import PropTypes from '../_util/vue-types';
 import { getOptionProps, initDefaultProps, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Icon from '../icon';
 import Line from './line';
 import Circle from './circle';

--- a/components/radio/Group.jsx
+++ b/components/radio/Group.jsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import PropTypes from '../_util/vue-types';
 import Radio from './Radio';
 import { getOptionProps, filterEmpty, hasProp, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 function noop() {}
 
 export default {

--- a/components/radio/Radio.jsx
+++ b/components/radio/Radio.jsx
@@ -2,7 +2,7 @@ import PropTypes from '../_util/vue-types';
 import VcCheckbox from '../vc-checkbox';
 import classNames from 'classnames';
 import { getOptionProps, getAttrs, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 function noop() {}
 

--- a/components/radio/RadioButton.jsx
+++ b/components/radio/RadioButton.jsx
@@ -1,6 +1,6 @@
 import Radio from './Radio';
 import { getOptionProps, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 export default {
   name: 'ARadioButton',

--- a/components/rate/index.jsx
+++ b/components/rate/index.jsx
@@ -1,7 +1,7 @@
 import omit from 'omit.js';
 import PropTypes from '../_util/vue-types';
 import { getOptionProps, getComponentFromProp, getListeners } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import VcRate from '../vc-rate';
 import Icon from '../icon';
 import Tooltip from '../tooltip';

--- a/components/result/index.jsx
+++ b/components/result/index.jsx
@@ -1,6 +1,6 @@
 import PropTypes from '../_util/vue-types';
 import { getComponentFromProp } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Icon from '../icon';
 import Base from '../base';
 import noFound from './noFound';

--- a/components/select/index.jsx
+++ b/components/select/index.jsx
@@ -2,7 +2,7 @@ import warning from '../_util/warning';
 import omit from 'omit.js';
 import PropTypes from '../_util/vue-types';
 import { Select as VcSelect, Option, OptGroup } from '../vc-select';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import {
   getComponentFromProp,
   getOptionProps,

--- a/components/skeleton/index.jsx
+++ b/components/skeleton/index.jsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import PropTypes from '../_util/vue-types';
 import { initDefaultProps, hasProp } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Avatar, { SkeletonAvatarProps } from './Avatar';
 import Title, { SkeletonTitleProps } from './Title';
 import Paragraph, { SkeletonParagraphProps } from './Paragraph';

--- a/components/slider/index.jsx
+++ b/components/slider/index.jsx
@@ -6,7 +6,7 @@ import VcRange from '../vc-slider/src/Range';
 import VcHandle from '../vc-slider/src/Handle';
 import Tooltip from '../tooltip';
 import Base from '../base';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import abstractTooltipProps from '../tooltip/abstractTooltipProps';
 
 // export interface SliderMarks {

--- a/components/space/index.jsx
+++ b/components/space/index.jsx
@@ -1,6 +1,6 @@
 import PropTypes from '../_util/vue-types';
 import { filterEmpty, initDefaultProps } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 export const SpaceSizeType = PropTypes.oneOfType([
   PropTypes.number,

--- a/components/spin/Spin.jsx
+++ b/components/spin/Spin.jsx
@@ -9,7 +9,7 @@ import {
   getListeners,
 } from '../_util/props-util';
 import { cloneElement } from '../_util/vnode';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 export const SpinSize = PropTypes.oneOf(['small', 'default', 'large']);
 

--- a/components/statistic/Statistic.jsx
+++ b/components/statistic/Statistic.jsx
@@ -1,6 +1,6 @@
 import PropTypes from '../_util/vue-types';
 import { getComponentFromProp, initDefaultProps } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import StatisticNumber from './Number';
 
 export const StatisticProps = {

--- a/components/steps/index.jsx
+++ b/components/steps/index.jsx
@@ -2,7 +2,7 @@ import PropTypes from '../_util/vue-types';
 import { initDefaultProps, getOptionProps, getListeners } from '../_util/props-util';
 import VcSteps from '../vc-steps';
 import Icon from '../icon';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 
 const getStepsProps = (defaultProps = {}) => {

--- a/components/switch/index.jsx
+++ b/components/switch/index.jsx
@@ -3,7 +3,7 @@ import hasProp, { getOptionProps, getComponentFromProp, getListeners } from '../
 import VcSwitch from '../vc-switch';
 import Wave from '../_util/wave';
 import Icon from '../icon';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 import warning from '../_util/warning';
 

--- a/components/table/Table.jsx
+++ b/components/table/Table.jsx
@@ -11,7 +11,7 @@ import createBodyRow from './createBodyRow';
 import { flatArray, treeMap, flatFilter } from './util';
 import { initDefaultProps, mergeProps, getOptionProps, getListeners } from '../_util/props-util';
 import BaseMixin from '../_util/BaseMixin';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import { TableProps } from './interface';
 import Pagination from '../pagination';
 import Icon from '../icon';

--- a/components/tabs/tabs.jsx
+++ b/components/tabs/tabs.jsx
@@ -11,7 +11,7 @@ import {
 } from '../_util/props-util';
 import { cloneElement } from '../_util/vnode';
 import isValid from '../_util/isValid';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import TabBar from './TabBar';
 
 export default {

--- a/components/tag/CheckableTag.jsx
+++ b/components/tag/CheckableTag.jsx
@@ -1,5 +1,5 @@
 import PropTypes from '../_util/vue-types';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 export default {
   name: 'ACheckableTag',

--- a/components/tag/Tag.jsx
+++ b/components/tag/Tag.jsx
@@ -5,7 +5,7 @@ import omit from 'omit.js';
 import Wave from '../_util/wave';
 import { hasProp, getListeners, getOptionProps } from '../_util/props-util';
 import BaseMixin from '../_util/BaseMixin';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import warning from '../_util/warning';
 
 const PresetColorTypes = [

--- a/components/time-picker/index.jsx
+++ b/components/time-picker/index.jsx
@@ -15,7 +15,7 @@ import {
   getListeners,
 } from '../_util/props-util';
 import { cloneElement } from '../_util/vnode';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 import {
   checkValidate,

--- a/components/timeline/Timeline.jsx
+++ b/components/timeline/Timeline.jsx
@@ -11,7 +11,7 @@ import {
 import { cloneElement } from '../_util/vnode';
 import TimelineItem from './TimelineItem';
 import Icon from '../icon';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 export const TimelineProps = {
   prefixCls: PropTypes.string,

--- a/components/timeline/TimelineItem.jsx
+++ b/components/timeline/TimelineItem.jsx
@@ -6,7 +6,7 @@ import {
   getComponentFromProp,
   getListeners,
 } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 export const TimeLineItemProps = {
   prefixCls: PropTypes.string,

--- a/components/tooltip/Tooltip.jsx
+++ b/components/tooltip/Tooltip.jsx
@@ -10,7 +10,7 @@ import {
   isValidElement,
   getListeners,
 } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import abstractTooltipProps from './abstractTooltipProps';
 
 const splitObject = (obj, keys) => {

--- a/components/transfer/index.jsx
+++ b/components/transfer/index.jsx
@@ -12,7 +12,7 @@ import List from './list';
 import Operation from './operation';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import defaultLocale from '../locale-provider/default';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import warning from '../_util/warning';
 import Base from '../base';
 

--- a/components/tree-select/index.jsx
+++ b/components/tree-select/index.jsx
@@ -9,7 +9,7 @@ import {
   filterEmpty,
   getListeners,
 } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Base from '../base';
 
 export { TreeData, TreeSelectProps } from './interface';

--- a/components/tree/DirectoryTree.jsx
+++ b/components/tree/DirectoryTree.jsx
@@ -18,7 +18,7 @@ import {
   getListeners,
   getComponentFromProp,
 } from '../_util/props-util';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 
 // export type ExpandAction = false | 'click' | 'dblclick'; export interface
 // DirectoryTreeProps extends TreeProps {   expandAction?: ExpandAction; }

--- a/components/tree/Tree.jsx
+++ b/components/tree/Tree.jsx
@@ -10,7 +10,7 @@ import {
   getListeners,
 } from '../_util/props-util';
 import { cloneElement } from '../_util/vnode';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Icon from '../icon';
 
 function TreeProps() {

--- a/components/upload/Upload.jsx
+++ b/components/upload/Upload.jsx
@@ -7,7 +7,7 @@ import BaseMixin from '../_util/BaseMixin';
 import { getOptionProps, initDefaultProps, hasProp, getListeners } from '../_util/props-util';
 import LocaleReceiver from '../locale-provider/LocaleReceiver';
 import defaultLocale from '../locale-provider/default';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import Dragger from './Dragger';
 import UploadList from './UploadList';
 import { UploadProps } from './interface';

--- a/components/upload/UploadList.jsx
+++ b/components/upload/UploadList.jsx
@@ -1,7 +1,7 @@
 import BaseMixin from '../_util/BaseMixin';
 import { getOptionProps, initDefaultProps, getListeners } from '../_util/props-util';
 import getTransitionProps from '../_util/getTransitionProps';
-import { ConfigConsumerProps } from '../config-provider';
+import { ConfigConsumerProps } from '../config-provider/configConsumerProps';
 import { previewImage, isImageUrl } from './utils';
 import Icon from '../icon';
 import Tooltip from '../tooltip';


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [x] Other (about what?):   **import module size**

### What's the background?

> 1. Describe the source of requirement.

If an app only wants to import some components, the import package size should be small. e.g.
```js
// using babel-plugin-import in babelrc:
["import", { "libraryName": "ant-design-vue", "libraryDirectory": "es", "style": "css" }]

// only importing some components in src/main.js:
import { Badge, Popconfirm, Table } from 'ant-design-vue';
console.log(Badge);

// run
npx vue-cli-service build --report --mode production src/main.js
```

But this creates a **400KB bundle** :fearful: with most of it being moment.js
![bundle size report](https://user-images.githubusercontent.com/3758846/104271367-0fff8480-549b-11eb-9ff1-bc15ec7c5140.png)

> 2. Resolve what problem.

Badge imports moment.js this way:
- https://github.com/vueComponent/ant-design-vue/blob/0f467695e2d86866b3f672956f7e15e1e5f999e9/components/badge/Badge.jsx#L43-L45
- https://github.com/vueComponent/ant-design-vue/blob/0f467695e2d86866b3f672956f7e15e1e5f999e9/components/badge/Badge.jsx#L14
- https://github.com/vueComponent/ant-design-vue/blob/0f467695e2d86866b3f672956f7e15e1e5f999e9/components/config-provider/index.jsx#L85-L91
- https://github.com/vueComponent/ant-design-vue/blob/0f467695e2d86866b3f672956f7e15e1e5f999e9/components/config-provider/index.jsx#L6
- https://github.com/vueComponent/ant-design-vue/blob/0f467695e2d86866b3f672956f7e15e1e5f999e9/components/locale-provider/index.jsx#L2

So by moving `ConfigConsumerProps` out of `components/config-provider/index.jsx`, moment.js will not be imported and now bundle takes only 80KB.

(moment.js will still be imported if e.g. `import { ConfigProvider, Calendar } from 'ant-design-vue';`). 

### What's the effect?

> 1. Does this PR affect user? Which part will be affected?

If user imports only a few components, their tree-shaked bundle will not include moment.js, reducing their bundle size
```diff
   File                         Size                             Gzipped

-  dist/js/app.93a8b94c.js      449.68 KiB                       134.98 KiB
+  dist/js/app.98dd1930.js      80.62 KiB                        27.03 KiB
   dist/css/app.1e590c7a.css    40.28 KiB                        4.88 KiB
```

> 2. What will say in changelog?

Make moment.js tree-shakable

> 3. Does this PR contains potential break change or other risk?

No

### Changelog description (Optional if not new feature)

> 1. English description

Make moment.js tree-shakable

> 2. Chinese description (optional)

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
