### PR TITLE
fix(cascader): fix TS type error

### DIFF
--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -366,7 +366,15 @@ const Cascader = defineComponent({
       }
     },
 
-    generateFilteredOptions(prefixCls: string | undefined, renderEmpty: RenderEmptyHandler) {
+    generateFilteredOptions(
+      prefixCls: string | undefined,
+      renderEmpty: RenderEmptyHandler,
+    ): {
+      [x: string]: any;
+      __IS_FILTERED_OPTION?: boolean;
+      path?: CascaderOptionType[];
+      disabled: boolean;
+    }[] {
       const { showSearch, notFoundContent } = this;
       const names: FilledFieldNamesType = getFilledFieldNames(this.$props);
       const {


### PR DESCRIPTION
fix `Property 'disabled' of type 'boolean' is not assignable to string index type 'void | Element'`

![image](https://user-images.githubusercontent.com/6134068/105146120-902c8680-5b3a-11eb-9dec-900cc8857b08.png)

这是因为ts编译器自动推断出来的 `void | JSX.Element` 和 `boolean` 冲突导致的，所以需要显式的指定为any

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)
