### PR TITLE
fix(tree-select): 删除父节点的最后一个子节点后选中了另外的子节点. #3508

### DIFF
--- a/components/vc-tree-select/src/util.js
+++ b/components/vc-tree-select/src/util.js
@@ -162,6 +162,7 @@ export function parseSimpleTreeData(treeData, { id, pId, rootPId }) {
 /**
  * Detect if position has relation.
  * e.g. 1-2 related with 1-2-3
+ * e.g. 1-2-3 related with 1-2-4
  * e.g. 1-3-2 related with 1
  * e.g. 1-2 not related with 1-21
  */
@@ -169,7 +170,14 @@ export function isPosRelated(pos1, pos2) {
   const fields1 = pos1.split('-');
   const fields2 = pos2.split('-');
 
-  const minLen = Math.min(fields1.length, fields2.length);
+  let minLen;
+  if (fields1.length === fields2.length) {
+    //  e.g. 1-2-3 related with 1-2-4
+    minLen = Math.max(fields1.length - 1, 0);
+  } else {
+    minLen = Math.min(fields1.length, fields2.length);
+  }
+
   for (let i = 0; i < minLen; i += 1) {
     if (fields1[i] !== fields2[i]) {
       return false;


### PR DESCRIPTION
### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 描述相关需求的来源。
> 2. 要解决的问题。
> 3. 相关的 issue 讨论链接。

删除父节点的最后一个子节点后选中了另外的子节点, 相关issue: #3508


### 实现方案和 API（非新功能可选）

**原因**：
isPosRelated方法判断节点的关系时，只判断了父子节点，没有判断兄弟节点，e.g. 1-2-3 related with 1-2-4

看了rc-tree-select，新版已经采用hooks来重写了，没这问题。
2.9.x版本有问题，可以看：http://react-component.github.io/tree-select/examples/basic.html

**修复方式**：isPosRelated增加对兄弟节点的判断，兄弟节点的关系返回true

**影响范围**：只在onMultipleSelectorRemove，删除节点的情况下采用


### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
