### PR TITLE
fix(tree): tree node class props invalid

### DIFF
--- a/components/vc-tree/src/TreeNode.jsx
+++ b/components/vc-tree/src/TreeNode.jsx
@@ -543,7 +543,7 @@ const TreeNode = defineComponent({
     return (
       <li
         class={{
-          className,
+          [className]: className,
           [`${prefixCls}-treenode-disabled`]: disabled,
           [`${prefixCls}-treenode-switcher-${expanded ? 'open' : 'close'}`]: !isLeaf,
           [`${prefixCls}-treenode-checkbox-checked`]: checked,


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
`Tree` component's node's `class` prop doesn't work because of wrong usage of Vue template class syntax.

<img width="453" alt="图片" src="https://user-images.githubusercontent.com/12264626/111737650-f58ec080-88ba-11eb-8b66-412ab1884187.png">

No matter what class name provided, it's always rendered as `className`.

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
