### PR TITLE
fix: tree do not fire `dragenter` when drag object is from outside

### DIFF
--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -63,7 +63,7 @@ export interface TreeDragEvent {
 }
 
 export interface DropEvent {
-  dragNode: Record<string, any>;
+  dragNode?: Record<string, any>;
   dragNodesKeys: (string | number)[];
   dropPosition: number;
   dropToGap: boolean;


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
Tree component's `dragover` / `drop` / `dragleave` event will be fired when drag object is from outisde of tree, while `dragenter` event won't. This is inconsistent.

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
