### PR TITLE
fix: add missing default option to mode prop on select component

### DIFF
--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -60,7 +60,7 @@ export const SelectProps = () => ({
   suffixIcon: PropTypes.VNodeChild,
   itemIcon: PropTypes.VNodeChild,
   size: PropTypes.oneOf(tuple('small', 'middle', 'large', 'default')),
-  mode: PropTypes.oneOf(tuple('multiple', 'tags', 'SECRET_COMBOBOX_MODE_DO_NOT_USE')),
+  mode: PropTypes.oneOf(tuple('multiple', 'tags', 'SECRET_COMBOBOX_MODE_DO_NOT_USE', 'default')),
   bordered: PropTypes.looseBool.def(true),
   transitionName: PropTypes.string.def('slide-up'),
   choiceTransitionName: PropTypes.string.def(''),


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
Getting the following warning in the console: `[VueTypes warn]: oneOf - value should be one of "multiple", "tags", "SECRET_COMBOBOX_MODE_DO_NOT_USE".`
> 2. Resolve what problem.
Added `default` to mode prop definition
> 3. Related issue link.
None

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
