### PR TITLE
fix(descriptions): let breakpoint to be partial

### DIFF
--- a/components/descriptions/index.tsx
+++ b/components/descriptions/index.tsx
@@ -42,7 +42,7 @@ export const DescriptionsItem = defineComponent({
   },
 });
 
-const DEFAULT_COLUMN_MAP: Record<Breakpoint, number> = {
+const DEFAULT_COLUMN_MAP: Partial<Record<Breakpoint, number>> = {
   xxl: 3,
   xl: 3,
   lg: 3,


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

### 这个变动的性质是

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [x] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 要解决的问题。
当在tsx 中使用`Descriptions` 组件的column 属性时，如果只使用部分响应式属性，会出现下列提示，属性应为可选
```Type '{ xs: number; sm: number; }' is missing the following properties from type 'Record<Breakpoint, number>': md, lg, xxl, xl```

### 实现方案和 API（非新功能可选）

> 1. 基本的解决思路和其他可选方案。
将`DEFAULT_COLUMN_MAP` 定义为`Partial<Record<Breakpoint, number>>` 可使生成的类型声明正常

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。