### PR TITLE
docs(table): require `Column.key` prop if using template style api

### DIFF
--- a/antdv-demo/docs/table/index.en-US.md
+++ b/antdv-demo/docs/table/index.en-US.md
@@ -92,7 +92,7 @@ One of the Table `columns` prop for describing the table's columns, Column has t
 | filterMultiple | Whether multiple filters can be selected | boolean | `true` |  |
 | filters | Filter menu config | object\[] | - |  |
 | fixed | Set column to be fixed: `true`(same as left) `'left'` `'right'` | boolean\|string | `false` |  |
-| key | Unique key of this column, you can ignore this prop if you've set a unique `dataIndex` | string | - |  |
+| key | Unique key of this column, you can ignore this prop if you're not using [template style api](#components-table-demo-template-style-api) and you've set a unique `dataIndex` | string | - |  |
 | customRender | Renderer of the table cell. The return value should be a VNode, or an object for colSpan/rowSpan config | Function(text, record, index) {}\|slot-scope | - |  |
 | sorter | Sort function for local sort, see [Array.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)'s compareFunction. If you need sort buttons only, set to `true` | Function\|boolean | - |  |
 | sortOrder | Order of sorted values: `'ascend'` `'descend'` `false` | boolean\|string | - |  |

--- a/antdv-demo/docs/table/index.zh-CN.md
+++ b/antdv-demo/docs/table/index.zh-CN.md
@@ -92,7 +92,7 @@
 | filterMultiple | 是否多选 | boolean | true |  |
 | filters | 表头的筛选菜单项 | object\[] | - |  |
 | fixed | 列是否固定，可选 `true`(等效于 left) `'left'` `'right'` | boolean\|string | false |  |
-| key | Vue 需要的 key，如果已经设置了唯一的 `dataIndex`，可以忽略这个属性 | string | - |  |
+| key | Vue 需要的 key。如果没有使用 [template 风格的 API](#components-table-demo-template-style-api)，且已经设置了唯一的 `dataIndex`，可以忽略这个属性 | string | - |  |
 | customRender | 生成复杂数据的渲染函数，参数分别为当前行的值，当前行数据，行索引，@return 里面可以设置表格行/列合并,可参考 demo 表格行/列合并 | Function(text, record, index) {}\|slot-scope | - |  |
 | sorter | 排序函数，本地排序使用一个函数(参考 [Array.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) 的 compareFunction)，需要服务端排序可设为 true | Function\|boolean | - |  |
 | sortOrder | 排序的受控属性，外界可用此控制列的排序，可设置为 `'ascend'` `'descend'` `false` | boolean\|string | - |  |


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

If `Column.key` is ignored when using template style api, `Column.sorter` may fail.

Ref: #2501

### Self Check before Merge

- [x] Doc is updated/provided or not needed
