### PR TITLE
fix: fix avatar icon not real center & in menu component margin-right error

### DIFF
--- a/components/avatar/style/index.less
+++ b/components/avatar/style/index.less
@@ -7,13 +7,15 @@
   .reset-component();
 
   position: relative;
-  display: inline-block;
+  display: inline-flex;
   overflow: hidden;
   color: @avatar-color;
   white-space: nowrap;
-  text-align: center;
   vertical-align: middle;
   background: @avatar-bg;
+  justify-content: center;
+  align-items: center;
+  margin: 0;
 
   &-image {
     background: transparent;
@@ -44,7 +46,6 @@
 .avatar-size(@size, @font-size) {
   width: @size;
   height: @size;
-  line-height: @size;
   border-radius: 50%;
 
   &-string {
@@ -55,5 +56,8 @@
 
   &.@{avatar-prefix-cls}-icon {
     font-size: @font-size;
+    .@{iconfont-css-prefix} {
+      margin: 0;
+    }
   }
 }


### PR DESCRIPTION
### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 在Menu组件下图标会因为Menu里的margin-right导致无法居中
> 2. 在某些条件下line-height和height相同并不能真正的垂直居中

<img width="231" alt="Snipaste_2021-05-13_17-53-26" src="https://user-images.githubusercontent.com/23442840/118111690-a080ae00-b416-11eb-979e-135c742c2aec.png">
<img width="404" alt="Snipaste_2021-05-13_17-53-14" src="https://user-images.githubusercontent.com/23442840/118111693-a1b1db00-b416-11eb-80c9-7a9fbf245f5c.png">

### 对用户的影响和可能的风险（非新功能可选）

> 1. 仅样式改动

### Changelog 描述（非新功能可选）

> 1. fix icon not real center & in menu component margin-right error

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

