### PR TITLE
refactor(vc-time-picker): input value is always synchronized with `sValue` #4084

### DIFF
--- a/components/vc-time-picker/TimePicker.jsx
+++ b/components/vc-time-picker/TimePicker.jsx
@@ -326,6 +326,11 @@ export default defineComponent({
         </a>
       );
     },
+    onInput() {
+      // input value is always synchronized with sValue
+      // ref: https://github.com/vueComponent/ant-design-vue/issues/4084
+      this.picker.value = (this.sValue && this.sValue.format(this.getFormat())) || '';
+    },
   },
 
   render() {
@@ -378,6 +383,7 @@ export default defineComponent({
             disabled={disabled}
             value={(sValue && sValue.format(this.getFormat())) || ''}
             autocomplete={autocomplete}
+            onInput={this.onInput}
             onFocus={onFocus}
             onBlur={onBlur}
             autofocus={autofocus}


### PR DESCRIPTION

First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

  ref: #4084
  
  出现这个问题是因为 vue 受控组件的行为与 react 的不一致。
  
  在 react 中，input 只要设置了 `value`，那么视图里面渲染的值只能通过 `onChange` 中的 `setState()` 来更新。
  但是在 vue 里面，视图的值改变了，input 绑定的 `value` 不一定会更新，所以导致上面 issue 提到的问题
  
  react demo: https://codesandbox.io/s/reverent-water-5byrb?file=/index.js
  vue demo: https://codesandbox.io/s/antdeisgnvue-timepicker-forked-7ophp?file=/src/App.vue

