### PR TITLE
fix(input-number): don't use `this.inputRef` when the component is already unmounted

### DIFF
--- a/components/vc-input-number/src/index.js
+++ b/components/vc-input-number/src/index.js
@@ -292,7 +292,7 @@ export default defineComponent({
       });
       const value = this.getCurrentValidValue(this.$data.inputValue);
       const newValue = this.setValue(value);
-      if (this.$attrs.onBlur) {
+      if (this.$attrs.onBlur && this.inputRef) {
         const originValue = this.inputRef.value;
         const inputValue = this.getInputDisplayValue({ focused: false, sValue: newValue });
         this.inputRef.value = inputValue;


### PR DESCRIPTION
当input-number有焦点的时候，移除组件（unmount）时会首先触发blur事件，但是在blur里面使用了input框的ref，会导致报错。

![image](https://user-images.githubusercontent.com/6134068/118909319-6f900400-b955-11eb-95d5-796e3fcb4524.png)

既然用户已经移除了组件，肯定也不会希望收到blur事件。我觉得在ref为空时忽略掉blur事件就可以了

---

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)