### PR TITLE
fix(date-picker): when default slot is a comment node, date-picker will not display

### DIFF
--- a/components/_util/props-util/index.js
+++ b/components/_util/props-util/index.js
@@ -341,6 +341,10 @@ export function isEmptyElement(c) {
   );
 }
 
+export function isEmptySlot(c) {
+  return !c || c().every(isEmptyElement);
+}
+
 export function isStringElement(c) {
   return c && c.type === Text;
 }

--- a/components/date-picker/createPicker.tsx
+++ b/components/date-picker/createPicker.tsx
@@ -14,6 +14,7 @@ import { hasProp, getOptionProps, getComponent, isValidElement } from '../_util/
 import { cloneElement } from '../_util/vnode';
 import { formatDate } from './utils';
 import { getDataAndAriaProps } from '../_util/util';
+import { isEmptySlot } from '../_util/props-util';
 
 export interface PickerProps {
   value?: moment.Moment;
@@ -255,7 +256,7 @@ export default function createPicker<P>(
         >
           <VcDatePicker
             {...vcDatePickerProps}
-            v-slots={{ default: input, ...$slots }}
+            v-slots={{ ...$slots, default: isEmptySlot($slots.default) ? input : $slots.default }}
           ></VcDatePicker>
         </span>
       );


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
> 2. Resolve what problem.
当 date-picker 中有注释节点时，date-picker不会显示，因为注释节点也可以作为一个 default slot,它会覆盖默认的input

```html
  <a-date-picker>
    <!-- aaa -->
  </a-date-picker>
```
> 3. Related issue link.
https://codesandbox.io/s/zen-nightingale-kwntz?file=/src/App.vue

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
判断下default slot是否是空节点，假如是空节点，则使用默认的input，否则使用传进来的default slot。
其他方法：
- 不使用 default slot作为默认的自定义渲染，但是需要修改文档且有破坏性更新
> 2. List final API realization and usage sample.
判断下default slot是否是空节点，假如是空节点，则使用默认的input，否则使用传进来的default slot
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
