### PR TITLE
fix(List): fix circular reference, which confuses vite (#4263)

### DIFF
--- a/components/list/Item.tsx
+++ b/components/list/Item.tsx
@@ -6,7 +6,7 @@ import { cloneElement } from '../_util/vnode';
 import { defineComponent, inject, ref } from 'vue';
 import ItemMeta from './ItemMeta';
 import useConfigInject from '../_util/hooks/useConfigInject';
-import { ListContextKey } from '.';
+import { ListContextKey } from './contextKey';
 
 export const ListItemProps = {
   prefixCls: PropTypes.string,

--- a/components/list/contextKey.ts
+++ b/components/list/contextKey.ts
@@ -1,0 +1,8 @@
+import type { InjectionKey, Ref } from 'vue';
+
+export interface ListContext {
+  grid?: Ref<any>;
+  itemLayout?: Ref<string>;
+}
+
+export const ListContextKey: InjectionKey<ListContext> = Symbol('ListContextKey');

--- a/components/list/index.tsx
+++ b/components/list/index.tsx
@@ -1,4 +1,4 @@
-import type { App, Plugin, ExtractPropTypes, PropType, InjectionKey, Ref } from 'vue';
+import type { App, Plugin, ExtractPropTypes, PropType } from 'vue';
 import { provide, defineComponent, ref, watch, computed, toRef } from 'vue';
 import PropTypes, { withUndefined } from '../_util/vue-types';
 import type { RenderEmptyHandler } from '../config-provider';
@@ -70,12 +70,7 @@ export interface ListLocale {
 
 export type ListProps = Partial<ExtractPropTypes<typeof listProps>>;
 
-export interface ListContext {
-  grid?: Ref<any>;
-  itemLayout?: Ref<string>;
-}
-
-export const ListContextKey: InjectionKey<ListContext> = Symbol('ListContextKey');
+import { ListContextKey } from './contextKey';
 
 const List = defineComponent({
   name: 'AList',


### PR DESCRIPTION
修复 #4263 

目前 `list/index.tsx` 引入了 `list/Item.tsx`，然后 `list/Item.tsx` 又引用了 `list/item.tsx`，出现了循环引用。

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)
