### PR TITLE
1.x-fix#4241

### DIFF
--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -212,7 +212,10 @@
 
       &-active {
         color: @tabs-highlight-color;
-        font-weight: 500;
+        // https://github.com/vueComponent/ant-design-vue/issues/4241
+        // Remove font-weight to keep pace with antd (#4241)
+        text-shadow: 0 0 0.25px currentColor;
+        // font-weight: 500;
       }
 
       &-disabled {


### PR DESCRIPTION
### 这个变动的性质是

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [x] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

card类型的tabs在切换选中时在windows系统上会导致tab移位
https://github.com/vueComponent/ant-design-vue/issues/4241

### 实现方案和 API（非新功能可选）

移除 .ant-tabs-nav .ant-tabs-tab-active中的font-weight:500。并加上text-shadow，以解决这个问题。


### Changelog 描述（非新功能可选）

style(tabs): keep pace with antd(#4241)

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

