### PR TITLE
fix(modal): allow Prop `getContainer` to be type of string & boolean

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -79,7 +79,7 @@ const modalProps = {
   wrapClassName: PropTypes.string,
   maskTransitionName: PropTypes.string,
   transitionName: PropTypes.string,
-  getContainer: PropTypes.func,
+  getContainer: PropTypes.any,
   zIndex: PropTypes.number,
   bodyStyle: PropTypes.style,
   maskStyle: PropTypes.style,
@@ -119,7 +119,7 @@ export interface ModalFuncProps {
   maskStyle?: CSSProperties;
   type?: string;
   keyboard?: boolean;
-  getContainer?: getContainerFunc;
+  getContainer?: getContainerFunc | boolean | string;
   autoFocusButton?: null | 'ok' | 'cancel';
   transitionName?: string;
   maskTransitionName?: string;

--- a/components/modal/__tests__/Modal.test.js
+++ b/components/modal/__tests__/Modal.test.js
@@ -65,4 +65,17 @@ describe('Modal', () => {
       expect(wrapper.html()).toMatchSnapshot();
     });
   });
+
+  it('should work with getContainer=false', async () => {
+    const wrapper1 = mount(Modal, {
+      sync: false,
+      props: {
+        getContainer: false,
+        visible: true,
+      },
+    });
+    await asyncExpect(() => {
+      expect(wrapper1.html()).toMatchSnapshot();
+    });
+  });
 });

--- a/components/modal/__tests__/__snapshots__/Modal.test.js.snap
+++ b/components/modal/__tests__/__snapshots__/Modal.test.js.snap
@@ -86,3 +86,26 @@ exports[`Modal render without footer 1`] = `
   <!--teleport end-->
 </div>
 `;
+
+exports[`Modal should work with getContainer=false 1`] = `
+<div class="ant-modal-root">
+  <div class="ant-modal-mask"></div>
+  <div tabindex="-1" class="ant-modal-wrap " role="dialog">
+    <div role="document" style="width: 520px;" class="ant-modal">
+      <div tabindex="0" style="width: 0px; height: 0px; overflow: hidden;" aria-hidden="true"></div>
+      <div class="ant-modal-content"><button type="button" aria-label="Close" class="ant-modal-close"><span class="ant-modal-close-x"><span role="img" aria-label="close" class="anticon anticon-close ant-modal-close-icon"><svg focusable="false" class="" data-icon="close" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"></path></svg></span></span></button>
+        <!---->
+        <div class="ant-modal-body"></div>
+        <div class="ant-modal-footer">
+          <div><button class="ant-btn" type="button">
+              <!----><span>Cancel</span>
+            </button><button class="ant-btn ant-btn-primary" type="button">
+              <!----><span>OK</span>
+            </button></div>
+        </div>
+      </div>
+      <div tabindex="0" style="width: 0px; height: 0px; overflow: hidden;" aria-hidden="true"></div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
`vc-dialog` 要求 `getContainer` 传入 `false` 来让弹窗渲染在当前dom里

https://github.com/vueComponent/ant-design-vue/blob/07f6d9edf0508a206dfdd7e4adc64049e7f7fbe0/components/vc-dialog/DialogWrap.jsx#L23

但是现在 `<a-modal>` 限制了 `getContainer` 只允许传入函数，导致用户无法指定弹窗在当前dom下显示，降低了灵活性。

然后在 `vc-dialog` 依赖的 [PortalWrapper](https://github.com/vueComponent/ant-design-vue/blob/next/components/_util/PortalWrapper.js#L61) 里还允许 `getContainer` 传入字符串

https://github.com/vueComponent/ant-design-vue/blob/07f6d9edf0508a206dfdd7e4adc64049e7f7fbe0/components/_util/PortalWrapper.js#L61

我也一并加上了

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)