### PR TITLE
feat(drawer): add Slot footer

### DIFF
--- a/components/drawer/__tests__/Drawer.test.js
+++ b/components/drawer/__tests__/Drawer.test.js
@@ -130,4 +130,21 @@ describe('Drawer', () => {
       expect(wrapper.html()).toMatchSnapshot();
     });
   });
+
+  it('footer should work', async () => {
+    const props = {
+      props: {
+        getContainer: false,
+      },
+      slots: {
+        default: () => 'Here is content of Drawer',
+        footer: () => 'Test footer',
+      },
+      sync: false,
+    };
+    const wrapper = mount(Drawer, props);
+    await asyncExpect(() => {
+      expect(wrapper.html()).toMatchSnapshot();
+    });
+  });
 });

--- a/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/Drawer.test.js.snap
@@ -11,6 +11,7 @@ exports[`Drawer class is test_drawer 1`] = `
             <!----><button aria-label="Close" class="ant-drawer-close"><span role="img" aria-label="close" class="anticon anticon-close"><svg focusable="false" class="" data-icon="close" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"></path></svg></span></button>
           </div>
           <div class="ant-drawer-body">Here is content of Drawer</div>
+          <!---->
         </div>
       </div>
       <!---->
@@ -28,6 +29,7 @@ exports[`Drawer closable is false 1`] = `
         <div class="ant-drawer-wrapper-body">
           <!---->
           <div class="ant-drawer-body">Here is content of Drawer</div>
+          <!---->
         </div>
       </div>
       <!---->
@@ -45,6 +47,27 @@ exports[`Drawer destroyOnClose is true 1`] = `
         <div class="ant-drawer-wrapper-body" style="opacity: 0; transition: opacity .3s;">
           <!---->
           <div class="ant-drawer-body">Here is content of Drawer</div>
+          <!---->
+        </div>
+      </div>
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Drawer footer should work 1`] = `
+<div class="">
+  <div class="ant-drawer ant-drawer-right" tabindex="-1">
+    <div class="ant-drawer-mask"></div>
+    <div class="ant-drawer-content-wrapper" style="transform: translateX(100%); width: 256px;">
+      <div class="ant-drawer-content">
+        <div class="ant-drawer-wrapper-body">
+          <div class="ant-drawer-header-no-title">
+            <!----><button aria-label="Close" class="ant-drawer-close"><span role="img" aria-label="close" class="anticon anticon-close"><svg focusable="false" class="" data-icon="close" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"></path></svg></span></button>
+          </div>
+          <div class="ant-drawer-body">Here is content of Drawer</div>
+          <div class="ant-drawer-footer">Test footer</div>
         </div>
       </div>
       <!---->
@@ -64,6 +87,7 @@ exports[`Drawer have a title 1`] = `
             <div class="ant-drawer-title">Test Title</div><button aria-label="Close" class="ant-drawer-close"><span role="img" aria-label="close" class="anticon anticon-close"><svg focusable="false" class="" data-icon="close" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"></path></svg></span></button>
           </div>
           <div class="ant-drawer-body">Here is content of Drawer</div>
+          <!---->
         </div>
       </div>
       <!---->
@@ -83,6 +107,7 @@ exports[`Drawer render correctly 1`] = `
             <!----><button aria-label="Close" class="ant-drawer-close"><span role="img" aria-label="close" class="anticon anticon-close"><svg focusable="false" class="" data-icon="close" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"></path></svg></span></button>
           </div>
           <div class="ant-drawer-body">Here is content of Drawer</div>
+          <!---->
         </div>
       </div>
       <!---->
@@ -102,6 +127,7 @@ exports[`Drawer render top drawer 1`] = `
             <!----><button aria-label="Close" class="ant-drawer-close"><span role="img" aria-label="close" class="anticon anticon-close"><svg focusable="false" class="" data-icon="close" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"></path></svg></span></button>
           </div>
           <div class="ant-drawer-body">Here is content of Drawer</div>
+          <!---->
         </div>
       </div>
       <!---->

--- a/components/drawer/__tests__/__snapshots__/DrawerEvent.test.js.snap
+++ b/components/drawer/__tests__/__snapshots__/DrawerEvent.test.js.snap
@@ -14,6 +14,7 @@ exports[`Drawer render correctly 1`] = `
               <!----><button aria-label="Close" class="ant-drawer-close"><span role="img" aria-label="close" class="anticon anticon-close"><svg focusable="false" class="" data-icon="close" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"></path></svg></span></button>
             </div>
             <div class="ant-drawer-body">Here is content of Drawer</div>
+            <!---->
           </div>
         </div>
         <!---->

--- a/components/drawer/index.tsx
+++ b/components/drawer/index.tsx
@@ -173,6 +173,12 @@ const Drawer = defineComponent({
         )
       );
     },
+    renderFooter(prefixCls: string) {
+      if (!this.$slots.footer) {
+        return null;
+      }
+      return <div class={`${prefixCls}-footer`}>{this.$slots.footer()}</div>;
+    },
     // render drawer body dom
     renderBody(prefixCls: string) {
       if (this.destroyClose && !this.visible) {
@@ -200,6 +206,7 @@ const Drawer = defineComponent({
           <div key="body" class={`${prefixCls}-body`} style={bodyStyle}>
             {this.$slots.default?.()}
           </div>
+          {this.renderFooter(prefixCls)}
         </div>
       );
     },

--- a/components/drawer/style/drawer.less
+++ b/components/drawer/style/drawer.less
@@ -184,6 +184,7 @@
     background: @drawer-bg;
     border-bottom: @border-width-base @border-style-base @border-color-split;
     border-radius: @border-radius-base @border-radius-base 0 0;
+    flex-shrink: 0;
   }
 
   &-header-no-title {
@@ -192,14 +193,23 @@
   }
 
   &-body {
+    flex: 1;
     padding: @drawer-body-padding;
     font-size: @font-size-base;
     line-height: @line-height-base;
     word-wrap: break-word;
+    overflow: auto;
   }
   &-wrapper-body {
     height: 100%;
-    overflow: auto;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &-footer {
+    padding: @drawer-footer-padding;
+    border-top: @border-width-base @border-style-base @border-color-split;
+    flex-shrink: 0;
   }
 
   &-mask {

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -829,6 +829,7 @@
 @drawer-header-padding: 16px 24px;
 @drawer-body-padding: 24px;
 @drawer-bg: @component-background;
+@drawer-footer-padding: 10px 16px;
 
 // Timeline
 // ---


### PR DESCRIPTION
有时候产品的需求里drawer的功能和弹窗很相似也有确定、取消按钮。虽然把这两个按钮放在drawer-body里也能实现，但是这样就导致drawer自己的body需要另外嵌套；body自己还有一个大padding，原来的样式难以复用。

我给drawer加入一个slot footer，这样与modal的dom结构保持一致。实际产品需求需要定制化样式时modal和drawer的css也容易复用

### This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)