### PR TITLE
fix(mentions): chinese or japanese input error

### DIFF
--- a/components/vc-mentions/src/Mentions.jsx
+++ b/components/vc-mentions/src/Mentions.jsx
@@ -115,6 +115,9 @@ const Mentions = {
       const { measureText: prevMeasureText, measuring } = this.$data;
       const { prefix = '', validateSearch } = this.$props;
       const target = event.target;
+      if (target.composing) {
+        return;
+      }
       const selectionStartText = getBeforeSelectionText(target);
       const { location: measureIndex, prefix: measurePrefix } = getLastMeasureIndex(
         selectionStartText,


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

1. 我自己在使用过程中发现的问题，mentions 组件在输入中文或者日文字符时每次都会有吞字的现象出现
2. 解决在输入中文或者日文字符时吞字的问题

### 实现方案和 API（非新功能可选）

1. 我能想到的是两种解决方案。一种是在 onKeyUp 判断 event.target 的 composing 属性，如果是 true 证明当前正在输入中文或日文字符，这时不做处理直接返回。第二种就是在输入的过程中不去判断是否是中文或者日文字体。之前在 [#4520](https://github.com/vueComponent/ant-design-vue/pull/4520) 提交的是第二种方案，本次提交的是第一种。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
> 2. 是否有可能隐含的 break change 和其他风险？

### Changelog 描述（非新功能可选）

> 1. 英文描述
> 2. 中文描述（可选）

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。