### PR TITLE
fix: fix typescript version limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "through2": "^3.0.0",
     "ts-jest": "^26.4.1",
     "ts-loader": "^9.1.0",
-    "typescript": "^4.2.0",
+    "typescript": "~4.3.5",
     "umi-mock-middleware": "^1.0.0",
     "umi-request": "^1.3.5",
     "url-loader": "^3.0.0",


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
> 2. Resolve what problem.
> 3. Related issue link.

1. 今天在编译的时候一直在报 ts 文件编译的错误，后来试了几次发现应该是 4.4.0 以上版本的 breaking changes 影响了现有的代码，所以对 package.json 里面的 typescript 依赖版本做了限制，如果马上要对代码中 ts 的定义进行修复和升级的话就不用管这个 pr 了。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
