### PR TITLE
fix: range-picker input height

### DIFF
--- a/components/date-picker/style/RangePicker.less
+++ b/components/date-picker/style/RangePicker.less
@@ -115,10 +115,10 @@
   .@{calendar-prefix-cls}-input,
   .@{calendar-timepicker-prefix-cls}-input {
     .input();
-    height: @input-height-sm;
+    height: 22px;
     padding-right: 0;
     padding-left: 0;
-    line-height: @input-height-sm;
+    line-height: 1.5;
     border: 0;
     box-shadow: none;
 


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

同 [PR](https://github.com/vueComponent/ant-design-vue/pull/4597#issue-722566009)

### 这个变动的性质是

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [x] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 自定义主题
```
modifyVars: {
  'input-height-base': '36px',
  'input-height-lg': '40px',
  'input-height-sm': '32px',
  },
```
> 2. range-picker 中的日期显示底部的 border 出现被覆盖的情况（如下图）。

![wecom-temp-238ac88f76c3b4c7c66ac24a804edcfd](https://user-images.githubusercontent.com/30932683/131358160-606424b3-2261-4b68-a6af-7354fd85ab6b.png)

> 3. 相关的 issue 讨论链接。

### 实现方案和 API（非新功能可选）

> 1. 参考 datepicker 调整 rangepicker 展开面板 input 高度。
> 2. 列出最终的 API 实现和用法。
> 3. 涉及 UI/交互变动需要有截图或 GIF。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
> 2. 是否有可能隐含的 break change 和其他风险？

### Changelog 描述（非新功能可选）

> 1. Customize `input-height-sm`, Optimize the height of input when RangePicker panel display
> 2. 自定义 `input-height-sm`， 优化 RangePicker 展开面板 input 高度样式

### 请求合并前的自查清单

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。
