### PR TITLE
Support for patch method

### DIFF
--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -70,7 +70,7 @@ export const UploadProps = {
   action: PropsTypes.oneOfType([PropsTypes.string, PropsTypes.func]),
   directory: PropsTypes.looseBool,
   data: PropsTypes.oneOfType([PropsTypes.object, PropsTypes.func]),
-  method: PropsTypes.oneOf(tuple('POST', 'PUT', 'post', 'put')),
+  method: PropsTypes.oneOf(tuple('POST', 'PUT', 'PATCH', 'post', 'put', 'patch')),
   headers: PropsTypes.object,
   showUploadList: PropsTypes.oneOfType([PropsTypes.looseBool, ShowUploadListInterface]),
   multiple: PropsTypes.looseBool,


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

### This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

I tried to pass `method=patch` to the upload component, but it doesn't pass the check. The only supported methods are POST and PUT. This is unnecessary restrictive.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?

User can use RESTful API with the PATCH semantic

> 2. What will say in changelog?

Support PATCH method in the upload component

> 3. Does this PR contains potential break change or other risk?

Some very old browsers doesn't support the PATCH method at all

### Changelog description (Optional if not new feature)

> 1. English description

Support PATCH method in the upload component

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

:pray: 