### PR TITLE
fix: ModalFuncProps types which can be string text

### DIFF
--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -95,9 +95,9 @@ export interface ModalFuncProps {
   prefixCls?: string;
   class?: string;
   visible?: boolean;
-  title?: (() => VNodeTypes) | VNodeTypes;
+  title?: string | (() => VNodeTypes) | VNodeTypes;
   closable?: boolean;
-  content?: (() => VNodeTypes) | VNodeTypes;
+  content?: string | (() => VNodeTypes) | VNodeTypes;
   // TODO: find out exact types
   onOk?: (...args: any[]) => any;
   onCancel?: (...args: any[]) => any;
@@ -105,9 +105,9 @@ export interface ModalFuncProps {
   cancelButtonProps?: ButtonPropsType;
   centered?: boolean;
   width?: string | number;
-  okText?: (() => VNodeTypes) | VNodeTypes;
+  okText?: string | (() => VNodeTypes) | VNodeTypes;
   okType?: LegacyButtonType;
-  cancelText?: (() => VNodeTypes) | VNodeTypes;
+  cancelText?: string | (() => VNodeTypes) | VNodeTypes;
   icon?: (() => VNodeTypes) | VNodeTypes;
   /* Deprecated */
   iconType?: string;


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
> When I'm using `Modal.confirm`, I found some typescript error report and I checked those type definition then I got `ModalFuncProps`.
> ![image](https://user-images.githubusercontent.com/46062972/133714384-186c02fd-8367-4a5c-ad23-93a6ef2833f5.png)
> 2. Resolve what problem.
> 3. Related issue link.

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
