### PR TITLE
fix(Select): mergedValue shouldn't modified by outValue

### DIFF
--- a/components/vc-select/generate.tsx
+++ b/components/vc-select/generate.tsx
@@ -629,7 +629,10 @@ export default function generateSelector<
 
           props.onChange(outValue, isMultiple.value ? outOptions : outOptions[0]);
         }
-        mergedValue.value = outValue;
+
+        if (props.value === undefined) {
+          mergedValue.value = outValue;
+        }
       };
 
       const onInternalSelect = (


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
```
<Select :value="myValue" @change="handleChange">
```
现象：在 `handleChange` 中修改`myValue`（一个 ref 对象）的值，Select 展示的当前值和`myValue`的实际值不一致。

解决方法：`mergedValue`应当仅受 props 上的 `value`控制

