### PR TITLE
fix: fix same order in card demo

### DIFF
--- a/components/card/demo/tabs.vue
+++ b/components/card/demo/tabs.vue
@@ -1,6 +1,6 @@
 <docs>
 ---
-order: 8
+order: 9
 title:
   zh-CN: 带页签的卡片
   en-US: With tabs


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. same order in `\components\card\demo\simple.vue` and `\components\card\demo\tabs.vue`
![Snipaste_2021-10-11_15-44-56](https://user-images.githubusercontent.com/23442840/136752587-c867d961-06ee-4122-b8f5-5735925fadee.png)

### Changelog description (Optional if not new feature)

> 1. fix same order in card demo
> 2. 修复卡片组件文档中相同的 `order`

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

