### PR TITLE
fix(dropdown): add dropdown destroyPopupOnHide type

### DIFF
--- a/antdv-demo/docs/dropdown/index.en-US.md
+++ b/antdv-demo/docs/dropdown/index.en-US.md
@@ -5,6 +5,7 @@
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
 | disabled | whether the dropdown menu is disabled | boolean | - |
+| destroyPopupOnHide | Whether destroy dropdown when hidden | boolean | false |  |
 | getPopupContainer | to set the container of the dropdown menu. The default is to create a `div` element in `body`, you can reset it to the scrolling area and make a relative reposition. [example](https://codepen.io/afc163/pen/zEjNOy?editors=0010) | Function(triggerNode) | `() => document.body` |
 | overlay(slot-scope) | the dropdown menu | [Menu](/components/menu) | - |
 | overlayClassName | Class name of the dropdown root element | string | - |

--- a/antdv-demo/docs/dropdown/index.zh-CN.md
+++ b/antdv-demo/docs/dropdown/index.zh-CN.md
@@ -5,6 +5,7 @@
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | disabled | 菜单是否禁用 | boolean | - |
+| destroyPopupOnHide | 关闭后是否销毁 Dropdown | boolean | false |  |
 | getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。 | Function(triggerNode) | `() => document.body` |
 | overlay(slot-scope) | 菜单 | [Menu](/components/menu-cn) | - |
 | overlayClassName | 下拉根元素的类名称 | string | - |

--- a/components/dropdown/getDropdownProps.js
+++ b/components/dropdown/getDropdownProps.js
@@ -23,4 +23,5 @@ export default () => ({
   mouseLeaveDelay: PropTypes.number,
   openClassName: PropTypes.string,
   minOverlayWidthMatchTrigger: PropTypes.bool,
+  destroyPopupOnHide: PropTypes.bool,
 });

--- a/components/vc-dropdown/src/Dropdown.jsx
+++ b/components/vc-dropdown/src/Dropdown.jsx
@@ -9,6 +9,7 @@ export default {
   mixins: [BaseMixin],
   props: {
     minOverlayWidthMatchTrigger: PropTypes.bool,
+    destroyPopupOnHide: PropTypes.bool.def(false),
     prefixCls: PropTypes.string.def('rc-dropdown'),
     transitionName: PropTypes.string,
     overlayClassName: PropTypes.string.def(''),
@@ -169,6 +170,7 @@ export default {
       overlayClassName,
       overlayStyle,
       trigger,
+      destroyPopupOnHide,
       ...otherProps
     } = this.$props;
     let triggerHideAction = hideAction;
@@ -180,6 +182,7 @@ export default {
       props: {
         ...otherProps,
         prefixCls,
+        destroyPopupOnHide,
         popupClassName: overlayClassName,
         popupStyle: overlayStyle,
         builtinPlacements: placements,


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
[dropdown to choose whether to destroy popup boxes when closing #4666 ](https://github.com/vueComponent/ant-design-vue/issues/4666)

### Changelog description (Optional if not new feature)

> 1. English description: Add destroyPopupOnHide to Dropdown
> 2. Chinese description: Dropdown 添加 destroyPopupOnHide 类型

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
