### PR TITLE
docs: pass isZhCN prop to PrevAndNext

### DIFF
--- a/site/src/layouts/index.vue
+++ b/site/src/layouts/index.vue
@@ -64,7 +64,7 @@
             </a-avatar>
           </a-dropdown>
         </div>
-        <PrevAndNext :menus="menus" :current-menu-index="currentMenuIndex" />
+        <PrevAndNext :menus="menus" :current-menu-index="currentMenuIndex" :is-zh-c-n="isZhCN" />
         <Footer />
       </a-col>
     </a-row>


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

`site/src/layouts/index.vue` does not pass the isZhCN prop to PrevAndNext. When I click the prev or next anchor, It will go the default language page even I have chosen the ZhCN  language.

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
