### PR TITLE
fix: date picker change panel button not work (#4789)

### DIFF
--- a/components/vc-calendar/src/Calendar.jsx
+++ b/components/vc-calendar/src/Calendar.jsx
@@ -100,8 +100,8 @@ const Calendar = {
   },
   methods: {
     onPanelChange(value, mode) {
-      const { sValue } = this;
-      if (!hasProp(this, 'mode')) {
+      const { sValue, timePicker } = this;
+      if (!!timePicker || !hasProp(this, 'mode')) {
         this.setState({ sMode: mode });
       }
       this.__emit('panelChange', value || sValue, mode);


### PR DESCRIPTION
 ### 这个变动的性质是
  
  - [ ] 新特性提交
  - [x] 日常 bug 修复
  - [ ] 站点、文档改进
  - [ ] 组件样式改进
  - [ ] TypeScript 定义更新
  - [ ] 重构
  - [ ] 代码风格优化
  - [ ] 分支合并
  - [ ] 其他改动（是关于什么的改动？）
  
  ### 需求背景
  
  > 1. 以DatePicker组件为基础再封装。
  > 2. 业务需要默认给mode属性传参的同时也需要设置show-time属性，但mode传入参数后，导致show-time传入true后无法切换为时间选择器。
  > 3. https://github.com/vueComponent/ant-design-vue/issues/4789
  
  ### 请求合并前的自查清单
  
  - [x] 文档已补充或无须补充
  - [x] 代码演示已提供或无须提供
  - [x] TypeScript 定义已补充或无须补充
  - [x] Changelog 已提供或无须提供