### PR TITLE
docs: fix typos in `Input`

### DIFF
--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -27,7 +27,7 @@ A basic widget for getting the user input is a text field. Keyboard and mouse ca
 | prefix | The prefix icon for the Input. | string\|slot |  |  |
 | size | The size of the input box. Note: in the context of a form, the `large` size is used. Available: `large` `default` `small` | string | `default` |  |
 | suffix | The suffix icon for the Input. | string\|slot |  |  |
-| type | The type of input, see: [MDN](https://developer.mozilla.org/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types)(use `Input.TextArea` instead of `type="textarea"`) | string | `text` |  |
+| type | The type of input, see: [MDN](https://developer.mozilla.org/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types)(use `<a-textarea />` instead of `type="textarea"`) | string | `text` |  |
 | value(v-model) | The input content value | string |  |  |
 | allowClear | allow to remove input content with clear icon | boolean |  |  |
 
@@ -40,7 +40,7 @@ A basic widget for getting the user input is a text field. Keyboard and mouse ca
 
 > When `Input` is used in a `Form.Item` context, if the `Form.Item` has the `id` and `options` props defined then `value`, `defaultValue`, and `id` props of `Input` are automatically set.
 
-### Input.TextArea
+### TextArea
 
 | Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- | --- |
@@ -50,13 +50,13 @@ A basic widget for getting the user input is a text field. Keyboard and mouse ca
 | allowClear | allow to remove input content with clear icon | boolean |  | 1.5.0 |
 | showCount | Whether show text count | boolean | false |  |
 
-### Input.TextArea Events
+### TextArea Events
 
 | Events Name | Description                                                        | Arguments   |
 | ----------- | ------------------------------------------------------------------ | ----------- |
 | pressEnter  | The callback function that is triggered when Enter key is pressed. | function(e) |
 
-The rest of the props of `Input.TextArea` are the same as the original [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
+The rest of the props of `TextArea` are the same as the original [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea).
 
 #### Input.Search
 

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -28,7 +28,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/xS9YEJhfe/Input.svg
 | prefix | 带有前缀图标的 input | string\|slot |  |  |
 | size | 控件大小。注：标准表单内的输入框大小限制为 `large`。可选 `large` `default` `small` | string | `default` |  |
 | suffix | 带有后缀图标的 input | string\|slot |  |  |
-| type | 声明 input 类型，同原生 input 标签的 type 属性，见：[MDN](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/input#属性)(请直接使用 `Input.TextArea` 代替 `type="textarea"`)。 | string | `text` |  |
+| type | 声明 input 类型，同原生 input 标签的 type 属性，见：[MDN](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/input#属性)(请直接使用 `<a-textarea />` 代替 `type="textarea"`)。 | string | `text` |  |
 | value(v-model) | 输入框内容 | string |  |  |
 | allowClear | 可以点击清除图标删除内容 | boolean |  |  |
 
@@ -41,7 +41,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/xS9YEJhfe/Input.svg
 
 > 如果 `Input` 在 `Form.Item` 内，并且 `Form.Item` 设置了 `id` 和 `options` 属性，则 `value` `defaultValue` 和 `id` 属性会被自动设置。
 
-### Input.TextArea
+### TextArea
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- | --- |
@@ -51,13 +51,13 @@ cover: https://gw.alipayobjects.com/zos/alicdn/xS9YEJhfe/Input.svg
 | allowClear | 可以点击清除图标删除内容 | boolean |  | 1.5.0 |
 | showCount | 是否展示字数 | boolean | false |  |
 
-### Input.TextArea 事件
+### TextArea 事件
 
 | 事件名称   | 说明           | 回调参数    |
 | ---------- | -------------- | ----------- |
 | pressEnter | 按下回车的回调 | function(e) |
 
-`Input.TextArea` 的其他属性和浏览器自带的 [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) 一致。
+`Textarea` 的其他属性和浏览器自带的 [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) 一致。
 
 #### Input.Search
 


### PR DESCRIPTION
close: #4826

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Typos in document, see #4826 to get details.
> 2. Fix the typos.
> 3. Related issue: #4826.

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
