### PR TITLE
fix: prevent Pagination <a> tag to be crawled

### DIFF
--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -75,7 +75,7 @@ export default defineComponent({
         </button>
       );
       let jumpPrevIcon = (
-        <a class={`${pre}-item-link`}>
+        <a rel='nofollow' class={`${pre}-item-link`}>
           {/* You can use transition effects in the container :) */}
           <div class={`${pre}-item-container`}>
             <DoubleLeftOutlined class={`${pre}-item-link-icon`} />
@@ -84,7 +84,7 @@ export default defineComponent({
         </a>
       );
       let jumpNextIcon = (
-        <a class={`${pre}-item-link`}>
+        <a rel='nofollow' class={`${pre}-item-link`}>
           {/* You can use transition effects in the container :) */}
           <div class={`${pre}-item-container`}>
             <DoubleRightOutlined class={`${pre}-item-link-icon`} />


### PR DESCRIPTION

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

Related issue: https://github.com/ant-design/ant-design/issues/25627

### Description

Explicitly tell crawlers not to crawl Paginattion <A> links that can't be crawled anyway
No other effect.
