### PR TITLE
docs: complete missing prop of checkbox

### DIFF
--- a/components/checkbox/index.en-US.md
+++ b/components/checkbox/index.en-US.md
@@ -18,12 +18,13 @@ Checkbox component.
 
 #### Checkbox
 
-| Property         | Description                                 | Type    | Default | Version |
-| ---------------- | ------------------------------------------- | ------- | ------- | ------- |
-| autofocus        | get focus when component mounted            | boolean | false   |         |
-| checked(v-model) | Specifies whether the checkbox is selected. | boolean | false   |         |
-| disabled         | Disable checkbox                            | boolean | false   |         |
-| indeterminate    | indeterminate checked state of checkbox     | boolean | false   |         |
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| autofocus | get focus when component mounted | boolean | false |  |
+| checked(v-model) | Specifies whether the checkbox is selected. | boolean | false |  |
+| disabled | Disable checkbox | boolean | false |  |
+| indeterminate | indeterminate checked state of checkbox | boolean | false |  |
+| value | value of checkbox in CheckboxGroup | boolean \| string \| number | - |  |
 
 #### events
 

--- a/components/checkbox/index.en-US.md
+++ b/components/checkbox/index.en-US.md
@@ -18,13 +18,13 @@ Checkbox component.
 
 #### Checkbox
 
-| Property | Description | Type | Default | Version |
-| --- | --- | --- | --- | --- |
-| autofocus | get focus when component mounted | boolean | false |  |
-| checked(v-model) | Specifies whether the checkbox is selected. | boolean | false |  |
-| disabled | Disable checkbox | boolean | false |  |
-| indeterminate | indeterminate checked state of checkbox | boolean | false |  |
-| value | value of checkbox in CheckboxGroup | boolean \| string \| number | - |  |
+| Property         | Description                                 | Type    | Default | Version |
+| ---------------- | ------------------------------------------- | ------- | ------- | ------- |
+| autofocus        | get focus when component mounted            | boolean | false   |         |
+| checked(v-model) | Specifies whether the checkbox is selected. | boolean | false   |         |
+| disabled         | Disable checkbox                            | boolean | false   |         |
+| indeterminate    | indeterminate checked state of checkbox     | boolean | false   |         |
+| value            | value of checkbox in CheckboxGroup          | boolean \| string \| number | - |  |
 
 #### events
 

--- a/components/checkbox/index.zh-CN.md
+++ b/components/checkbox/index.zh-CN.md
@@ -19,12 +19,13 @@ cover: https://gw.alipayobjects.com/zos/alicdn/8nbVbHEm_/CheckBox.svg
 
 #### Checkbox
 
-| 参数             | 说明                                    | 类型    | 默认值 | 版本 |
-| ---------------- | --------------------------------------- | ------- | ------ | ---- |
-| autofocus        | 自动获取焦点                            | boolean | false  |      |
-| checked(v-model) | 指定当前是否选中                        | boolean | false  |      |
-| disabled         | 失效状态                                | boolean | false  |      |
-| indeterminate    | 设置 indeterminate 状态，只负责样式控制 | boolean | false  |      |
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| autofocus | 自动获取焦点 | boolean | false |  |
+| checked(v-model) | 指定当前是否选中 | boolean | false |  |
+| disabled | 失效状态 | boolean | false |  |
+| indeterminate | 设置 indeterminate 状态，只负责样式控制 | boolean | false |  |
+| value | 与 CheckboxGroup 组合使用时的值 | boolean \| string \| number | - |  |
 
 #### 事件
 

--- a/components/checkbox/index.zh-CN.md
+++ b/components/checkbox/index.zh-CN.md
@@ -19,13 +19,13 @@ cover: https://gw.alipayobjects.com/zos/alicdn/8nbVbHEm_/CheckBox.svg
 
 #### Checkbox
 
-| 参数 | 说明 | 类型 | 默认值 | 版本 |
-| --- | --- | --- | --- | --- |
-| autofocus | 自动获取焦点 | boolean | false |  |
-| checked(v-model) | 指定当前是否选中 | boolean | false |  |
-| disabled | 失效状态 | boolean | false |  |
-| indeterminate | 设置 indeterminate 状态，只负责样式控制 | boolean | false |  |
-| value | 与 CheckboxGroup 组合使用时的值 | boolean \| string \| number | - |  |
+| 参数             | 说明                                    | 类型    | 默认值 | 版本 |
+| ---------------- | --------------------------------------- | ------- | ------ | ---- |
+| autofocus        | 自动获取焦点                            | boolean | false  |      |
+| checked(v-model) | 指定当前是否选中                        | boolean | false  |      |
+| disabled         | 失效状态                                | boolean | false  |      |
+| indeterminate    | 设置 indeterminate 状态，只负责样式控制 | boolean | false  |      |
+| value            | 与 CheckboxGroup 组合使用时的值           | boolean \| string \| number | - |  |
 
 #### 事件
 


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

The `value` prop of `Checkbox` component is missing in its document. it should be displayed in document.

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
