### PR TITLE
fix: table-olgroup-col does not trigger onresize

### DIFF
--- a/components/vc-table/src/Table.jsx
+++ b/components/vc-table/src/Table.jsx
@@ -102,7 +102,10 @@ export default defineComponent({
   setup(props) {
     const columnManager = useColumnManager(toRef(props, 'columns'));
     const colsKeys = computed(() => getColumnsKey(columnManager.leafColumns.value));
-    const [colsWidths, updateColsWidths] = useLayoutState(new Map());
+    const initColsWidths = props.columns?.map(item => {
+      return [item.key ?? item.dataIndex, item.width];
+    });
+    const [colsWidths, updateColsWidths] = useLayoutState(new Map(initColsWidths));
     const pureColWidths = computed(() =>
       colsKeys.value.map(columnKey => colsWidths.value.get(columnKey)),
     );


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

>  一些国产浏览器 （搜狗 360 他们的Chrome内核版本较低 大概在 80.0.3987.87） 对 colgroup  col 支持不行  无法触发 onResize事件， 导致 多个td 固定的时候 left 都是0

### API Realization (Optional if not new feature)

>  useLayoutState(new Map())   添加初始化的 width , 不触发 onResize 也能获取width

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
