### PR TITLE
feat(tabs): add tabs centered attribute - 1.x version

### DIFF
--- a/antdv-demo/docs/tabs/demo/centered.md
+++ b/antdv-demo/docs/tabs/demo/centered.md
@@ -1,0 +1,39 @@
+<cn>
+#### 居中
+标签居中展示。
+</cn>
+
+<us>
+#### Centered
+Centered tabs.
+</us>
+
+```vue
+<template>
+  <div>
+    <a-tabs default-active-key="1" @change="callback" centered>
+      <a-tab-pane key="1" tab="Tab 1">
+        Content of Tab Pane 1
+      </a-tab-pane>
+      <a-tab-pane key="2" tab="Tab 2" force-render>
+        Content of Tab Pane 2
+      </a-tab-pane>
+      <a-tab-pane key="3" tab="Tab 3">
+        Content of Tab Pane 3
+      </a-tab-pane>
+    </a-tabs>
+  </div>
+</template>
+<script>
+export default {
+  data() {
+    return {};
+  },
+  methods: {
+    callback(key) {
+      console.log(key);
+    },
+  },
+};
+</script>
+```

--- a/antdv-demo/docs/tabs/demo/index.vue
+++ b/antdv-demo/docs/tabs/demo/index.vue
@@ -4,6 +4,7 @@ import CardTop from './card-top';
 import Card from './card';
 import CustomAddTrigger from './custom-add-trigger';
 import Disabled from './disabled';
+import Centered from './centered';
 import EditableCard from './editable-card';
 import Extra from './extra';
 import Icon from './icon';
@@ -56,6 +57,7 @@ export default {
         <demo-sort cols={1}>
           <Basic />
           <Disabled />
+          <Centered />
           <Icon />
           <Slide />
           <Extra />

--- a/antdv-demo/docs/tabs/index.en-US.md
+++ b/antdv-demo/docs/tabs/index.en-US.md
@@ -7,6 +7,7 @@
 | activeKey(v-model) | Current TabPane's key | string | - |
 | animated | Whether to change tabs with animation. Only works while `tabPosition="top"\|"bottom"` | boolean \| {inkBar:boolean, tabPane:boolean} | `true`, `false` when `type="card"` |
 | defaultActiveKey | Initial active TabPane's key, if `activeKey` is not set. | string | - |
+| centered | Centers tabs | boolean | `false` |
 | hideAdd | Hide plus icon or not. Only works while `type="editable-card"` | boolean | `false` |
 | size | preset tab bar size | `large` \| `default` \| `small` | `default` |
 | tabBarExtraContent | Extra content in tab bar | slot | - |

--- a/antdv-demo/docs/tabs/index.zh-CN.md
+++ b/antdv-demo/docs/tabs/index.zh-CN.md
@@ -7,6 +7,7 @@
 | activeKey(v-model) | 当前激活 tab 面板的 key | string | 无 |
 | animated | 是否使用动画切换 Tabs，在 `tabPosition=top|bottom` 时有效 | boolean \| {inkBar:boolean, tabPane:boolean} | true, 当 type="card" 时为 false |
 | defaultActiveKey | 初始化选中面板的 key，如果没有设置 activeKey | string | 第一个面板 |
+| centered | 标签居中展示 | boolean | false |
 | hideAdd | 是否隐藏加号图标，在 `type="editable-card"` 时有效 | boolean | false |
 | size | 大小，提供 `large` `default` 和 `small` 三种大小 | string | 'default' |
 | tabBarExtraContent | tab bar 上额外的元素 | slot | 无 |

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -23,6 +23,12 @@
   overflow: hidden;
   .clearfix;
 
+  &-centered {
+    .@{tab-prefix-cls}-nav-container {
+      text-align: center;
+    }
+  }
+
   &-ink-bar {
     position: absolute;
     bottom: 1px;

--- a/components/tabs/tabs.jsx
+++ b/components/tabs/tabs.jsx
@@ -25,6 +25,7 @@ export default {
     prefixCls: PropTypes.string,
     activeKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     defaultActiveKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    centered: PropTypes.bool.def(false),
     hideAdd: PropTypes.bool.def(false),
     tabBarStyle: PropTypes.object,
     tabBarExtraContent: PropTypes.any,
@@ -78,6 +79,7 @@ export default {
       type = 'line',
       tabPosition,
       animated = true,
+      centered,
       hideAdd,
       renderTabBar,
     } = props;
@@ -93,6 +95,7 @@ export default {
       tabPaneAnimated = 'animated' in props ? tabPaneAnimated : false;
     }
     const cls = {
+      [`${prefixCls}-centered`]: centered,
       [`${prefixCls}-vertical`]: tabPosition === 'left' || tabPosition === 'right',
       [`${prefixCls}-${size}`]: !!size,
       [`${prefixCls}-card`]: type.indexOf('card') >= 0,


### PR DESCRIPTION

### This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

The centered attribute has been implemented in version 3.x, but not yet implemented in version 1.x.

### API Realization (Optional if not new feature)

Added an attribute called centered.

### What's the effect? (Optional if not new feature)

Use the centered attribute to center the tabs.

### Changelog description (Optional if not new feature)

> 1. English description
Centers tabs
> 2. Chinese description (optional)
标签居中展示

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
