### PR TITLE
feat(select): dropdown placement to 1.x

### DIFF
--- a/antdv-demo/docs/select/demo/dropdown-placement.md
+++ b/antdv-demo/docs/select/demo/dropdown-placement.md
@@ -1,0 +1,35 @@
+<cn>
+#### 设置下拉框出现位置
+使用 `dropdownPlacement` 控制下拉框出现位置。
+</cn>
+
+<us>
+#### Location of the dropdown box
+Use 'dropdownPlacement' to control where the dropdown box appears.
+</us>
+
+```vue
+<template>
+  <a-select
+    style="width: 200px;"
+    :dropdown-match-select-width="false"
+    :dropdown-style="{ width: '350px' }"
+    dropdown-placement="bottomRight"
+    placeholder="Dropdown placement"
+  >
+    <a-select-option label="label1" value="value1" style="height: 60px;">
+      <div>
+        Long long text1
+      </div>
+    </a-select-option>
+    <a-select-option label="label2" value="vlaue2" style="height: 60px;">
+      <div>
+        Long long text2
+      </div>
+    </a-select-option>
+  </a-select>
+</template>
+<script>
+export default {};
+</script>
+```

--- a/antdv-demo/docs/select/demo/index.vue
+++ b/antdv-demo/docs/select/demo/index.vue
@@ -14,6 +14,7 @@ import Suffix from './suffix';
 import HideSelected from './hide-selected';
 import CustomDropdownMenu from './custom-dropdown-menu';
 import OptionLabelProp from './option-label-prop';
+import DropdownPlacement from './dropdown-placement';
 
 import CN from '../index.zh-CN.md';
 import US from '../index.en-US.md';
@@ -57,6 +58,7 @@ export default {
           <HideSelected />
           <CustomDropdownMenu />
           <OptionLabelProp />
+          <DropdownPlacement />
         </demo-sort>
         <api>
           <CN slot="cn" />

--- a/antdv-demo/docs/select/index.en-US.md
+++ b/antdv-demo/docs/select/index.en-US.md
@@ -21,6 +21,7 @@
 | dropdownRender | Customize dropdown content | (menuNode: VNode, props) => VNode | - |
 | dropdownStyle | style of dropdown menu | object | - |
 | dropdownMenuStyle | additional style applied to dropdown menu | object | - |
+| dropdownPlacement | the location where the dropdown appears | `bottomLeft` `bottomRight` `topLeft` `topRight` | - |
 | filterOption | If true, filter options by input, if function, filter options against it. The function will receive two arguments, `inputValue` and `option`, if the function returns `true`, the option will be included in the filtered set; Otherwise, it will be excluded. | boolean or function(inputValue, option) | true |
 | firstActiveValue | Value of action option by default | string\|string\[] | - |
 | getPopupContainer | Parent Node which the selector should be rendered to. Default to `body`. When position issues happen, try to modify it into scrollable content and position it relative. | function(triggerNode) | () => document.body |

--- a/antdv-demo/docs/select/index.zh-CN.md
+++ b/antdv-demo/docs/select/index.zh-CN.md
@@ -21,6 +21,7 @@
 | dropdownRender | 自定义下拉框内容 | (menuNode: VNode, props) => VNode | - |
 | dropdownStyle | 下拉菜单的 style 属性 | object | - |
 | dropdownMenuStyle | dropdown 菜单自定义样式 | object | - |
+| dropdownPlacement | dropdown 出现的位置 | `bottomLeft` `bottomRight` `topLeft` `topRight` | - |
 | filterOption | 是否根据输入项进行筛选。当其为一个函数时，会接收 `inputValue` `option` 两个参数，当 `option` 符合筛选条件时，应返回 `true`，反之则返回 `false`。 | boolean or function(inputValue, option) | true |
 | firstActiveValue | 默认高亮的选项 | string\|string\[] | - |
 | getPopupContainer | 菜单渲染父节点。默认渲染到 body 上，如果你遇到菜单滚动定位问题，试试修改为滚动的区域，并相对其定位。 | Function(triggerNode) | () => document.body |

--- a/components/select/index.jsx
+++ b/components/select/index.jsx
@@ -31,6 +31,7 @@ const AbstractSelectProps = () => ({
   dropdownStyle: PropTypes.any,
   dropdownMenuStyle: PropTypes.any,
   dropdownMatchSelectWidth: PropTypes.bool,
+  dropdownPlacement: PropTypes.oneOf(['bottomLeft', 'bottomRight', 'topLeft', 'topRight']),
   // onSearch: (value: string) => any,
   filterOption: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   autoFocus: PropTypes.bool,

--- a/components/vc-select/Select.jsx
+++ b/components/vc-select/Select.jsx
@@ -94,6 +94,7 @@ const Select = {
     dropdownMatchSelectWidth: PropTypes.bool.def(true),
     dropdownStyle: SelectPropTypes.dropdownStyle.def(() => ({})),
     dropdownMenuStyle: PropTypes.object.def(() => ({})),
+    dropdownPlacement: PropTypes.oneOf(['bottomLeft', 'bottomRight', 'topLeft', 'topRight']),
     optionFilterProp: SelectPropTypes.optionFilterProp.def('value'),
     optionLabelProp: SelectPropTypes.optionLabelProp.def('value'),
     notFoundContent: PropTypes.any.def('Not Found'),
@@ -1641,6 +1642,7 @@ const Select = {
     };
     return (
       <SelectTrigger
+        dropdownPlacement={props.dropdownPlacement}
         dropdownAlign={props.dropdownAlign}
         dropdownClassName={props.dropdownClassName}
         dropdownMatchSelectWidth={props.dropdownMatchSelectWidth}

--- a/components/vc-select/SelectTrigger.jsx
+++ b/components/vc-select/SelectTrigger.jsx
@@ -24,6 +24,22 @@ const BUILT_IN_PLACEMENTS = {
       adjustY: 1,
     },
   },
+  bottomRight: {
+    points: ['tr', 'br'],
+    offset: [0, 4],
+    overflow: {
+      adjustX: 0,
+      adjustY: 1,
+    },
+  },
+  topRight: {
+    points: ['br', 'tr'],
+    offset: [0, -4],
+    overflow: {
+      adjustX: 0,
+      adjustY: 1,
+    },
+  },
 };
 
 export default {
@@ -35,6 +51,7 @@ export default {
     dropdownMatchSelectWidth: PropTypes.bool,
     defaultActiveFirstOption: PropTypes.bool,
     dropdownAlign: PropTypes.object,
+    dropdownPlacement: PropTypes.oneOf(['bottomLeft', 'bottomRight', 'topLeft', 'topRight']),
     visible: PropTypes.bool,
     disabled: PropTypes.bool,
     showSearch: PropTypes.bool,
@@ -181,6 +198,7 @@ export default {
       dropdownClassName,
       dropdownStyle,
       dropdownMatchSelectWidth,
+      dropdownPlacement,
       options,
       getPopupContainer,
       showAction,
@@ -217,13 +235,14 @@ export default {
     if (this.dropdownWidth) {
       popupStyle[widthProp] = `${this.dropdownWidth}px`;
     }
+
     const triggerProps = {
       props: {
         ...$props,
         showAction: disabled ? [] : showAction,
         hideAction,
         ref: 'triggerRef',
-        popupPlacement: 'bottomLeft',
+        popupPlacement: dropdownPlacement || 'bottomLeft',
         builtinPlacements: BUILT_IN_PLACEMENTS,
         prefixCls: dropdownPrefixCls,
         popupTransitionName: this.getDropdownTransitionName(),

--- a/types/select/select.d.ts
+++ b/types/select/select.d.ts
@@ -76,7 +76,10 @@ export declare class Select extends AntdComponent {
    * @type object
    */
   dropdownStyle: object;
-
+  /**
+   * location of dropdown menu
+   */
+  dropdownPlacement: 'bottomLeft' | 'bottomRight' | 'topLeft' | 'topRight';
   /**
    * If true, filter options by input, if function, filter options against it. The function will receive two arguments, inputValue and option,
    * if the function returns true, the option will be included in the filtered set; Otherwise, it will be excluded.


### PR DESCRIPTION
### 这个变动的性质是

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景
如下图，当 select 位于窗口右上且下拉项宽度过大时，dropdown 出现位置是下左，导致展示不全。
期望：通过参数控制 dropdown 出现位置，解决类似问题

![image](https://user-images.githubusercontent.com/90079525/146483923-d1916b8f-3379-40ac-bd14-fa225d80209c.png)

具体代码示例：
https://codesandbox.io/s/great-sky-m4zgw?file=/src/App.vue:0-1456

### 实现方案和 API（非新功能可选）
> 1. 基本的解决思路和其他可选方案。
select 增加 dropdownPlacement prop，透传vc-select，并增加对应 popupPlacement 配置

> 2. 列出最终的 API 实现和用法。
```vue
<template>
  <a-select
    style="width: 200px;"
    :dropdown-match-select-width="false"
    :dropdown-style="{ width: '350px' }"
    dropdown-placement="bottomRight"
    placeholder="Dropdown placement"
  >
    <a-select-option label="label1" value="value1" style="height: 60px;">
      <div>
        Long long text1
      </div>
    </a-select-option>
    <a-select-option label="label2" value="vlaue2" style="height: 60px;">
      <div>
        Long long text2
      </div>
    </a-select-option>
  </a-select>
</template>
<script>
export default {};
</script>
```
> 3. 涉及 UI/交互变动需要有截图或 GIF。
![image](https://user-images.githubusercontent.com/90079525/146484484-5001d4b1-45c2-4ae9-801c-ce2ebc18fa92.png)


### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
无影响
> 2. 是否有可能隐含的 break change 和其他风险？
若用户之前有传过 dropdownPlacement，则会出现展示UI变动，但该情况应属于用户自身问题

### Changelog 描述（非新功能可选）

> 1. 英文描述
Select support 'dropdownPlacement' to control where the dropdown box appears.

> 2. 中文描述（可选）

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）
无