### PR TITLE
fix(date-picker): Fix the bug that disabledDate is not supported when the mode of the DatePicker component is year, month, or decade

### DIFF
--- a/components/date-picker/style/DecadePanel.less
+++ b/components/date-picker/style/DecadePanel.less
@@ -72,6 +72,18 @@
   }
 }
 
+@{calendar-prefix-cls}-decade-panel-cell.@{calendar-prefix-cls}-decade-panel-disabled-cell .@{calendar-prefix-cls}-decade-panel-decade {
+  color: @disabled-color;
+  background: @disabled-bg;
+  cursor: not-allowed;
+
+  &:hover {
+    color: @disabled-color;
+    background: @disabled-bg;
+    cursor: not-allowed;
+  }
+}
+
 .@{calendar-prefix-cls}-decade-panel-last-century-cell,
 .@{calendar-prefix-cls}-decade-panel-next-century-cell {
   .@{calendar-prefix-cls}-decade-panel-decade {

--- a/components/date-picker/style/YearPanel.less
+++ b/components/date-picker/style/YearPanel.less
@@ -76,6 +76,18 @@
   }
 }
 
+@{calendar-prefix-cls}-year-panel-cell.@{calendar-prefix-cls}-year-panel-disabled-cell .@{calendar-prefix-cls}-year-panel-year {
+  color: @disabled-color;
+  background: @disabled-bg;
+  cursor: not-allowed;
+
+  &:hover {
+    color: @disabled-color;
+    background: @disabled-bg;
+    cursor: not-allowed;
+  }
+}
+
 .@{calendar-prefix-cls}-year-panel-last-decade-cell,
 .@{calendar-prefix-cls}-year-panel-next-decade-cell {
   .@{calendar-prefix-cls}-year-panel-year {

--- a/components/vc-calendar/src/Calendar.jsx
+++ b/components/vc-calendar/src/Calendar.jsx
@@ -331,6 +331,8 @@ const Calendar = defineComponent({
             prefixCls={prefixCls}
             monthCellRender={monthCellRender}
             monthCellContentRender={monthCellContentRender}
+            disabledMonth={disabledDate}
+            disabledDate={disabledDate}
           />
           {timePicker && showTimePicker ? (
             <div class={`${prefixCls}-time-picker`}>

--- a/components/vc-calendar/src/calendar/CalendarHeader.jsx
+++ b/components/vc-calendar/src/calendar/CalendarHeader.jsx
@@ -35,6 +35,7 @@ const CalendarHeader = {
     enablePrev: PropTypes.any.def(1),
     enableNext: PropTypes.any.def(1),
     disabledMonth: PropTypes.func,
+    disabledDate: PropTypes.func,
     mode: PropTypes.any,
     monthCellRender: PropTypes.func,
     monthCellContentRender: PropTypes.func,
@@ -151,6 +152,7 @@ const CalendarHeader = {
       enableNext,
       enablePrev,
       disabledMonth,
+      disabledDate,
       renderFooter,
     } = props;
 
@@ -177,6 +179,7 @@ const CalendarHeader = {
           locale={locale}
           value={value}
           rootPrefixCls={prefixCls}
+          disabledDate={disabledDate}
           onSelect={this.onYearSelect}
           onDecadePanelShow={this.showDecadePanel}
           renderFooter={renderFooter}
@@ -189,6 +192,7 @@ const CalendarHeader = {
           locale={locale}
           value={value}
           rootPrefixCls={prefixCls}
+          disabledDate={disabledDate}
           onSelect={this.onDecadeSelect}
           renderFooter={renderFooter}
         />

--- a/components/vc-calendar/src/decade/DecadePanel.jsx
+++ b/components/vc-calendar/src/decade/DecadePanel.jsx
@@ -29,6 +29,7 @@ export default {
     defaultValue: PropTypes.object,
     rootPrefixCls: PropTypes.string,
     renderFooter: PropTypes.func,
+    disabledDate: PropTypes.func,
   },
   data() {
     this.nextCentury = goYear.bind(this, 100);
@@ -69,6 +70,7 @@ export default {
     const footer = renderFooter && renderFooter('decade');
     const decadesEls = decades.map((row, decadeIndex) => {
       const tds = row.map(decadeData => {
+        const disabled = typeof this.disabledDate === 'function' ? this.disabledDate(decadeData) : false;
         const dStartDecade = decadeData.startDecade;
         const dEndDecade = decadeData.endDecade;
         const isLast = dStartDecade < startYear;
@@ -78,15 +80,18 @@ export default {
           [`${prefixCls}-selected-cell`]: dStartDecade <= currentYear && currentYear <= dEndDecade,
           [`${prefixCls}-last-century-cell`]: isLast,
           [`${prefixCls}-next-century-cell`]: isNext,
+          [`${prefixCls}-disabled-cell`]: disabled,
         };
         const content = `${dStartDecade}-${dEndDecade}`;
         let clickHandler = noop;
-        if (isLast) {
-          clickHandler = this.previousCentury;
-        } else if (isNext) {
-          clickHandler = this.nextCentury;
-        } else {
-          clickHandler = chooseDecade.bind(this, dStartDecade);
+        if (!disabled) {
+          if (isLast) {
+            clickHandler = this.previousCentury;
+          } else if (isNext) {
+            clickHandler = this.nextCentury;
+          } else {
+            clickHandler = chooseDecade.bind(this, dStartDecade);
+          }
         }
         return (
           <td key={dStartDecade} onClick={clickHandler} role="gridcell" class={classNameMap}>

--- a/components/vc-calendar/src/year/YearPanel.jsx
+++ b/components/vc-calendar/src/year/YearPanel.jsx
@@ -29,6 +29,7 @@ export default {
     defaultValue: PropTypes.object,
     locale: PropTypes.object,
     renderFooter: PropTypes.func,
+    disabledDate: PropTypes.func,
   },
   data() {
     this.nextDecade = goYear.bind(this, 10);
@@ -78,19 +79,23 @@ export default {
 
     const yeasEls = years.map((row, index) => {
       const tds = row.map(yearData => {
+        const disabled = typeof this.disabledDate === 'function' ? this.disabledDate(yearData.year) : false;
         const classNameMap = {
           [`${prefixCls}-cell`]: 1,
           [`${prefixCls}-selected-cell`]: yearData.year === currentYear,
           [`${prefixCls}-last-decade-cell`]: yearData.year < startYear,
           [`${prefixCls}-next-decade-cell`]: yearData.year > endYear,
+          [`${prefixCls}-disabled-cell`]: disabled,
         };
         let clickHandler = noop;
-        if (yearData.year < startYear) {
-          clickHandler = this.previousDecade;
-        } else if (yearData.year > endYear) {
-          clickHandler = this.nextDecade;
-        } else {
-          clickHandler = chooseYear.bind(this, yearData.year);
+        if (!disabled) {
+          if (yearData.year < startYear) {
+            clickHandler = this.previousDecade;
+          } else if (yearData.year > endYear) {
+            clickHandler = this.nextDecade;
+          } else {
+            clickHandler = chooseYear.bind(this, yearData.year);
+          }
         }
         return (
           <td


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

在 ant-design-vue@2.2.8 版本下，DatePicker 组件设置 mode 属性的值为 `"year"`, `"month"`, `"decade"` 时，不支持使用 `disabledDate` 控制禁用。

我阅读了源码后，发现 2.2.8 分支暂时还不支持，JS的逻辑部分以及CSS的样式都需要补充。

### API Realization (Optional if not new feature)

> 1. 修改JS逻辑，将对应的`disabledDate`传递到相关组件中。
> 2. 组件中通过`disabledDate`判断是否有`disabled`状态class。
> 3. disabled 状态下`clickHandler` 设置为 `noop`。
> 4. 样式文件补充`disabled`状态的样式。
> 5. 具体代码修改见 changes。
> 6. 效果图：
![image](https://user-images.githubusercontent.com/30487257/147453531-8da9aa16-4eb7-4d5c-908c-25e19cce9758.png)
![image](https://user-images.githubusercontent.com/30487257/147453583-ce64c929-e326-4d41-b033-3d3db8becb6d.png)
![image](https://user-images.githubusercontent.com/30487257/147453617-11da1bcb-6990-42ac-aa02-dc11d45ab316.png)
> 7. 具体用法
针对 year 类型，`disabledDate` 带出年份的值给调用方做判断；
```
disabledDate: (year: number) => {
  return year > 2021;
},
```
针对 month 类型，`disabledDate` 带出`Moment`类型的值给调用方做判断；
```
disabledDate: (date: Moment) => {
  return date.month() > 6;
},
```
针对 decade 类型，disabledDate` 带出对象（包括`startDecade`和`endDecade`属性）给调用方做判断；
```
disabledDate: ({ startDecade, endDecade }: { startDecade: number; endDecade: number }) => {
  return startDecade > 2021;
},
```

### What's the effect? (Optional if not new feature)

由于没有修改或删除其他属性，所以没有影响到现有功能。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
