### PR TITLE
doc: correct invaild name of api

### DIFF
--- a/components/pagination/index.en-US.md
+++ b/components/pagination/index.en-US.md
@@ -41,6 +41,6 @@ A long list can be divided into several pages using `Pagination`, and only one p
 ### events
 
 | Events Name | Description | Arguments |
-| --- | --- | --- | --- |
-| change | a callback function, executed when the page number is changed, and it takes the resulting page number and pageSize as its arguments | Function(page, pageSize) | noop |
-| showSizeChange | a callback function, executed when `pageSize` is changed | Function(current, size) | noop |
+| --- | --- | --- |
+| onChange | a callback function, executed when the page number is changed, and it takes the resulting page number and pageSize as its arguments | Function(page, pageSize) |
+| onShowSizeChange | a callback function, executed when `pageSize` is changed | Function(current, size) |

--- a/components/pagination/index.zh-CN.md
+++ b/components/pagination/index.zh-CN.md
@@ -35,6 +35,6 @@ cover: https://gw.alipayobjects.com/zos/alicdn/1vqv2bj68/Pagination.svg
 ### 事件
 
 | 事件名称       | 说明                                         | 回调参数                 |
-| -------------- | -------------------------------------------- | ------------------------ | ---- |
-| change         | 页码改变的回调，参数是改变后的页码及每页条数 | Function(page, pageSize) | noop |
-| showSizeChange | pageSize 变化的回调                          | Function(current, size)  | noop |
+| -------------- | -------------------------------------------- | ------------------------ |
+| onChange         | 页码改变的回调，参数是改变后的页码及每页条数 | Function(page, pageSize) |
+| onShowSizeChange | pageSize 变化的回调                          | Function(current, size)  |


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

The API name in the official document is incorrect, so it cannot be called correctly. It has been modified.

The specific API is that the event names of "change" and "showSizeChange" in pagination should be changed to "onChange" and "onShowSizeChange".

I noticed that there were marks in these two places in the document, so I deleted the marks together after modification.

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
