### PR TITLE
fix(carousel): zindex misspelled in customArrows.vue demo

### DIFF
--- a/components/carousel/demo/customArrows.vue
+++ b/components/carousel/demo/customArrows.vue
@@ -19,7 +19,7 @@ Custom arrows display
 <template>
   <a-carousel arrows>
     <template #prevArrow>
-      <div class="custom-slick-arrow" style="left: 10px; zindex: 1">
+      <div class="custom-slick-arrow" style="left: 10px; z-index: 1">
         <left-circle-outlined />
       </div>
     </template>


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. it is a spelling error in doc page

### What's the effect? (Optional if not new feature)

> 1. no effect to feature

### Changelog description (Optional if not new feature)

> 1. fix zindex misspelled in customArrows.vue demo
> 2. 在跑马灯说明文档页面的demo中发现style部分代码的zindex拼写错误

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
