### PR TITLE
fix: onSelect error capture issue

### DIFF
--- a/components/select/__tests__/index.test.js
+++ b/components/select/__tests__/index.test.js
@@ -1,5 +1,4 @@
-import { createApp, render, onErrorCaptured, h, nextTick } from 'vue';
-import { mount, config } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import { asyncExpect, sleep } from '../../../tests/utils';
 import Select from '..';
 import CloseOutlined from '@ant-design/icons-vue/CloseOutlined';

--- a/components/vc-select/OptionList.tsx
+++ b/components/vc-select/OptionList.tsx
@@ -124,9 +124,9 @@ const OptionList = defineComponent({
     );
 
     // ========================== Values ==========================
-    const onSelectValue = (value?: RawValueType) => {
+    const onSelectValue = async (value?: RawValueType) => {
       if (value !== undefined) {
-        props.onSelect(value, { selected: !props.rawValues.has(value) });
+        await props.onSelect(value, { selected: !props.rawValues.has(value) });
       }
 
       // Single mode should always close by select
@@ -341,9 +341,9 @@ const OptionList = defineComponent({
                       }
                       setActive(itemIndex);
                     }}
-                    onClick={e => {
+                    onClick={async e => {
                       if (!disabled) {
-                        onSelectValue(value);
+                        await onSelectValue(value);
                       }
                       if (otherProps.onClick) {
                         otherProps.onClick(e);

--- a/components/vc-select/Select.tsx
+++ b/components/vc-select/Select.tsx
@@ -421,7 +421,7 @@ export default defineComponent({
     };
 
     // ========================= OptionList =========================
-    const triggerSelect = (val: RawValueType, selected: boolean) => {
+    const triggerSelect = async (val: RawValueType, selected: boolean) => {
       const getSelectEnt = (): [RawValueType | LabelInValueType, DefaultOptionType] => {
         const option = getMixedOption(val);
         return [
@@ -438,7 +438,7 @@ export default defineComponent({
 
       if (selected && props.onSelect) {
         const [wrappedValue, option] = getSelectEnt();
-        props.onSelect(wrappedValue, option);
+        await props.onSelect(wrappedValue, option);
       } else if (!selected && props.onDeselect) {
         const [wrappedValue, option] = getSelectEnt();
         props.onDeselect(wrappedValue, option);
@@ -446,7 +446,7 @@ export default defineComponent({
     };
 
     // Used for OptionList selection
-    const onInternalSelect = (val, info) => {
+    const onInternalSelect = async (val, info) => {
       let cloneValues: (RawValueType | DisplayValueType)[];
 
       // Single mode always trigger select only with option list
@@ -459,7 +459,7 @@ export default defineComponent({
       }
 
       triggerChange(cloneValues);
-      triggerSelect(val, mergedSelect);
+      await triggerSelect(val, mergedSelect);
 
       // Clean search value if single or configured
       if (props.mode === 'combobox') {


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
Please refer to #5204 

Test case provided.
> error thrown in [onSelect]

![image](https://user-images.githubusercontent.com/7044628/152961733-5493c1b9-a4c9-4bab-b97d-f0140f5c8c2e.png)


### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
No
> 2. What will say in changelog?
support promise rejection for event callback
> 3. Does this PR contains potential break change or other risk?
No


### Additional Plan? (Optional if not new feature)
This is a demo PR about how to fix #5204 .
It's supposed not to be merged for now.
We need to decide how to do that after code review.

> If this PR related with other PR or following info. You can type here.