### PR TITLE
docs: fix document makdown display

### DIFF
--- a/components/spin/index.zh-CN.md
+++ b/components/spin/index.zh-CN.md
@@ -18,7 +18,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/8emPa3fjl/Alert.svg
 | ---------------- | -------------------------------------------- | ------------- | --------- |
 | delay            | 延迟显示加载效果的时间（防止闪烁）           | number (毫秒) | -         |
 | indicator        | 加载指示符                                   | vNode \| slot | -         |
-| size             | 组件大小，可选值为 `small` `default` `large` | string        | 'default' |
+| size             | 组件大小，可选值为 `small` `default` `large` | string        | `default` |
 | spinning         | 是否为加载中状态                             | boolean       | true      |
 | tip              | 当作为包裹元素时，可以自定义描述文案         | string        | -         |
 | wrapperClassName | 包装器的类属性                               | string        | -         |

--- a/components/tabs/index.zh-CN.md
+++ b/components/tabs/index.zh-CN.md
@@ -28,10 +28,10 @@ Ant Design 依次提供了三级选项卡，分别用于不同的场景。
 | animated | 是否使用动画切换 Tabs，在 `tabPosition=top | bottom` 时有效 | boolean \| {inkBar:boolean, tabPane:boolean} | true, 当 type="card" 时为 false |  |
 | centered | 标签居中展示 | boolean | false | 3.0 |
 | hideAdd | 是否隐藏加号图标，在 `type="editable-card"` 时有效 | boolean | false |  |
-| size | 大小，提供 `large` `default` 和 `small` 三种大小 | string | 'default' |  |
+| size | 大小，提供 `large` `default` 和 `small` 三种大小 | string | `default` |  |
 | tabBarStyle | tab bar 的样式对象 | object | - |  |
-| tabPosition | 页签位置，可选值有 `top` `right` `bottom` `left` | string | 'top' |  |
-| type | 页签的基本样式，可选 `line`、`card` `editable-card` 类型 | string | 'line' |  |
+| tabPosition | 页签位置，可选值有 `top` `right` `bottom` `left` | string | `top` |  |
+| type | 页签的基本样式，可选 `line`、`card` `editable-card` 类型 | string | `line` |  |
 | tabBarGutter | tabs 之间的间隙 | number | 无 |  |
 
 ### Tabs 插槽

--- a/components/upload/index.en-US.md
+++ b/components/upload/index.en-US.md
@@ -21,7 +21,7 @@ Uploading is the process of publishing information (web pages, text, pictures, v
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | accept | File types that can be accepted. See [input accept Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) | string | - |  |
 | action | Uploading URL | string\|(file) => `Promise` | - |  |
-| method | http method of upload request | string | 'post' | 1.5.0 |
+| method | http method of upload request | string | `post` | 1.5.0 |
 | directory | support upload whole directory ([caniuse](https://caniuse.com/#feat=input-file-directory)) | boolean | false |  |
 | beforeUpload | Hook function which will be executed before uploading. Uploading will be stopped with `false` or a rejected Promise returned. **Warning：this function is not supported in IE9**。 | (file, fileList) => `boolean | Promise` | - |  |
 | customRequest | override for the default xhr behavior allowing for additional customization and ability to implement your own XMLHttpRequest | Function | - |  |
@@ -29,9 +29,9 @@ Uploading is the process of publishing information (web pages, text, pictures, v
 | disabled | disable upload button | boolean | false |  |
 | fileList | List of files that have been uploaded (controlled). Here is a common issue [#2423](https://github.com/ant-design/ant-design/issues/2423) when using it | object\[] | - |  |
 | headers | Set request headers, valid above IE10. | object | - |  |
-| listType | Built-in stylesheets, support for three types: `text`, `picture` or `picture-card` | string | 'text' |  |
+| listType | Built-in stylesheets, support for three types: `text`, `picture` or `picture-card` | string | `text` |  |
 | multiple | Whether to support selected multiple file. `IE10+` supported. You can select multiple files with CTRL holding down while multiple is set to be true | boolean | false |  |
-| name | The name of uploading file | string | 'file' |  |
+| name | The name of uploading file | string | `file` |  |
 | previewFile | Customize preview file logic | (file: File \| Blob) => Promise<dataURL: string> | - | 1.5.0 |
 | showUploadList | Whether to show default upload list, could be an object to specify `showPreviewIcon` and `showRemoveIcon` individually | Boolean or { showPreviewIcon?: boolean, showRemoveIcon?: boolean } | true |  |
 | supportServerRender | Need to be turned on while the server side is rendering. | boolean | false |  |

--- a/components/upload/index.zh-CN.md
+++ b/components/upload/index.zh-CN.md
@@ -22,7 +22,7 @@ cover: https://gw.alipayobjects.com/zos/alicdn/QaeBt_ZMg/Upload.svg
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | accept | 接受上传的文件类型, 详见 [input accept Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) | string | 无 |  |
 | action | 上传的地址 | string\|(file) => `Promise` | 无 |  |
-| method | 上传请求的 http method | string | 'post' | 1.5.0 |
+| method | 上传请求的 http method | string | `post` | 1.5.0 |
 | directory | 支持上传文件夹（[caniuse](https://caniuse.com/#feat=input-file-directory)） | boolean | false |  |
 | beforeUpload | 上传文件之前的钩子，参数为上传的文件，若返回 `false` 则停止上传。支持返回一个 Promise 对象，Promise 对象 reject 时则停止上传，resolve 时开始上传（ resolve 传入 `File` 或 `Blob` 对象则上传 resolve 传入对象）。**注意：IE9 不支持该方法**。 | (file, fileList) => `boolean | Promise` | 无 |  |
 | customRequest | 通过覆盖默认的上传行为，可以自定义自己的上传实现 | Function | 无 |  |
@@ -30,9 +30,9 @@ cover: https://gw.alipayobjects.com/zos/alicdn/QaeBt_ZMg/Upload.svg
 | disabled | 是否禁用 | boolean | false |  |
 | fileList | 已经上传的文件列表（受控） | object\[] | 无 |  |
 | headers | 设置上传的请求头部，IE10 以上有效 | object | 无 |  |
-| listType | 上传列表的内建样式，支持三种基本样式 `text`, `picture` 和 `picture-card` | string | 'text' |  |
+| listType | 上传列表的内建样式，支持三种基本样式 `text`, `picture` 和 `picture-card` | string | `text` |  |
 | multiple | 是否支持多选文件，`ie10+` 支持。开启后按住 ctrl 可选择多个文件。 | boolean | false |  |
-| name | 发到后台的文件参数名 | string | 'file' |  |
+| name | 发到后台的文件参数名 | string | `file` |  |
 | previewFile | 自定义文件预览逻辑 | (file: File \| Blob) => Promise<dataURL: string> | 无 | 1.5.0 |
 | showUploadList | 是否展示 uploadList, 可设为一个对象，用于单独设定 showPreviewIcon 和 showRemoveIcon | Boolean or { showPreviewIcon?: boolean, showRemoveIcon?: boolean } | true |  |
 | supportServerRender | 服务端渲染时需要打开这个 | boolean | false |  |


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)


### What's the background?
some markdown symbols in bold are written as ' ' in the document. Actually, it should be \` \`

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

