### PR TITLE
fix: fix props-util method filterProps bug

### DIFF
--- a/components/_util/props-util.js
+++ b/components/_util/props-util.js
@@ -38,7 +38,7 @@ const slotHasProp = (slot, prop) => {
 const filterProps = (props, propsData = {}) => {
   const res = {};
   Object.keys(props).forEach(k => {
-    if (k in propsData || props[k] !== undefined) {
+    if (k in propsData && props[k] !== undefined) {
       res[k] = props[k];
     }
   });


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 描述相关需求的来源。
公司内部在二次封装Tabs组件的时候，在jsx模式下直接继承props会导致Tabs功能异常（无法切换）
> 2. 要解决的问题。
解决二次封装Tabs组件的时候，在jsx模式下直接继承props会导致Tabs功能异常的bug
> 3. 相关的 issue 讨论链接。
无

### 实现方案和 API（非新功能可选）

> 1. 基本的解决思路和其他可选方案。
通过对比正常的Tabs的props与非正常情况（二次封装）下的props，发现Tabs组件内部调用了一个工具方法 - getOptionProps，在其内部发现了组件内部定义props与实际传入的props对比过滤的方法-filtrProps存在bug，导致部分不需要初始化的key传入了组件，进而导致了组件功能异常

> 2. 列出最终的 API 实现和用法。
> 3. 涉及 UI/交互变动需要有截图或 GIF。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
getOptionProps工具方法在众多组件都有用到，因此影响面是全部组件
> 2. 是否有可能隐含的 break change 和其他风险？
是
### Changelog 描述（非新功能可选）

> 1. 英文描述
Fix the problem of abnormal component function caused by inheriting props in JSX mode
> 2. 中文描述（可选）

### 请求合并前的自查清单

- [ ] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。
