### PR TITLE
fix: tree component - autoExpandParent default value is wrong

### DIFF
--- a/components/vc-tree/Tree.tsx
+++ b/components/vc-tree/Tree.tsx
@@ -63,7 +63,7 @@ export default defineComponent({
     checkStrictly: false,
     draggable: false,
     defaultExpandParent: true,
-    autoExpandParent: false,
+    autoExpandParent: true,
     defaultExpandAll: false,
     defaultExpandedKeys: [],
     defaultCheckedKeys: [],


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[[English Template / 英文模板](https://github.com/vueComponent/ant-design-vue/compare/next...GauharChan:next?expand=1)](?expand=1)]

### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 描述相关需求的来源。
> 2. 要解决的问题。
> 3. 相关的 issue 讨论链接。


1. 文档与源码中的实现不一致。从文档得知，`tree组件`的`autoExpandParent`默认值应该为`true`，但是源码这个地方默认是`false`。也导致我在业务中使用`tree组件`的时候困扰了许久；文档明明说默认值为`true`，为什么不会自动展开父节点。并且在业务层面来说，`展开`大部分的场景下是需要`autoExpandParent`为true，因此提出了这个pr
2. `tree组件`的`autoExpandParent`默认值应该为`true`
3. 无

### 实现方案和 API（非新功能可选）

> 1. 基本的解决思路和其他可选方案。
> 2. 列出最终的 API 实现和用法。
> 3. 涉及 UI/交互变动需要有截图或 GIF。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
> 2. 是否有可能隐含的 break change 和其他风险？

### Changelog 描述（非新功能可选）

> 1. 英文描述
> 2. 中文描述（可选）

### 请求合并前的自查清单

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。