### PR TITLE
fix(table): not update when getCheckboxProps change

### DIFF
--- a/antdv-demo/components/WWAds.vue
+++ b/antdv-demo/components/WWAds.vue
@@ -1,26 +1,38 @@
 <template>
-  <div>
-    <div ref="inner" class="wwads-cn wwads-horizontal" data-id="62" style="max-width: 350px" />
+  <div id="rice">
+    <div class="wwads-cn wwads-horizontal" data-id="62" style="max-width: 350px" />
   </div>
 </template>
 <script>
-
 export default {
-  mounted() {
-    this.load();
-  },
-  methods: {
-    load() {
-      if (this.scriptDom) {
-        this.$el.removeChild(this.scriptDom);
-      }
-      this.$refs.inner.innerHTML = '';
-      const e = document.createElement('script');
-      e.src = 'https://wwads.cn/js/makemoney.js';
-      e.async = true;
-      this.$el.appendChild(e);
-      this.scriptDom = e;
-    },
-  },
+  // mounted() {
+  //   this.load();
+  // },
+  // methods: {
+  //   load() {
+  //     if (this.scriptDom) {
+  //       this.$el.removeChild(this.scriptDom);
+  //     }
+  //     this.$refs.inner.innerHTML = '';
+  //     const e = document.createElement('script');
+  //     e.src = 'https://wwads.cn/js/makemoney.js';
+  //     e.async = true;
+  //     this.$el.appendChild(e);
+  //     this.scriptDom = e;
+  //   },
+  // },
 };
 </script>
+<style scoped>
+#rice {
+  /* width: 180px; */
+  /* position: fixed; */
+  /* z-index: 19; */
+  padding: 10px;
+  border-radius: 3px;
+  font-size: 13px;
+  float: right;
+  /* background-color: red;
+  max-height: 150px; */
+}
+</style>

--- a/antdv-demo/components/layout.vue
+++ b/antdv-demo/components/layout.vue
@@ -14,7 +14,7 @@ import { isZhCN } from '../utils/util';
 import { Provider, create } from '../../components/_util/store';
 import NProgress from 'nprogress';
 import MobileMenu from '../../components/vc-drawer/src';
-// import TopAd from './top_ad';
+import WWAds from './WWAds.vue';
 import GoogleAds from './GoogleAds';
 import SurelyVue from './surelyVue';
 
@@ -303,6 +303,7 @@ export default {
               <a-col xxl={20} xl={19} lg={19} md={18} sm={24} xs={24}>
                 <section class="main-container main-container-component">
                   {showAd ? <GeektimeAds isMobile={isMobile} /> : null}
+                  <WWAds />
                   {!isMobile ? (
                     <div class={['toc-affix', isCN ? 'toc-affix-cn' : '']} style="width: 150px;">
                       {this.getSubMenu(isCN)}

--- a/antdv-demo/public/404.html
+++ b/antdv-demo/public/404.html
@@ -82,6 +82,7 @@
         </style>
       </div>
     </div>
+    <script type="text/javascript" src="https://cdn.wwads.cn/js/makemoney.js" async></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-151755889-1"></script>
     <script>

--- a/antdv-demo/public/index.html
+++ b/antdv-demo/public/index.html
@@ -47,6 +47,7 @@
     <div id="app">
       <router-view></router-view>
     </div>
+    <script type="text/javascript" src="https://cdn.wwads.cn/js/makemoney.js" async></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-151755889-1"></script>
     <script>

--- a/components/table/Table.jsx
+++ b/components/table/Table.jsx
@@ -141,10 +141,12 @@ export default {
       !props.expandedRowRender || !('scroll' in props) || !props.scroll.x,
       '`expandedRowRender` and `scroll` are not compatible. Please use one of them at one time.',
     );
+    const rowSelection = getRowSelection(this.$props);
+    this.prevGetCheckboxProps = rowSelection.getCheckboxProps;
     this.CheckboxPropsCache = {};
 
     this.store = (this.$root.constructor.observable || Vue.observable)({
-      selectedRowKeys: getRowSelection(this.$props).selectedRowKeys || [],
+      selectedRowKeys: rowSelection.selectedRowKeys || [],
       selectionDirty: false,
     });
     return {
@@ -177,7 +179,8 @@ export default {
         if (val && 'selectedRowKeys' in val) {
           this.store.selectedRowKeys = val.selectedRowKeys || [];
           const { rowSelection } = this;
-          if (rowSelection && val.getCheckboxProps !== rowSelection.getCheckboxProps) {
+          if (rowSelection && val.getCheckboxProps !== this.prevGetCheckboxProps) {
+            this.prevGetCheckboxProps = val.getCheckboxProps;
             this.CheckboxPropsCache = {};
           }
         } else if (oldVal && !val) {


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

[val.getCheckboxProps !== rowSelection.getCheckboxProps](https://github.com/vueComponent/ant-design-vue/blob/3a85220a57289f81b72722a06348d1276572a429/components/table/Table.jsx#L180) 此处比较永远都不可能为 `true`，因为 `val === rowSelection`，导致 `getCheckboxProps` 更新后 `CheckboxPropsCache` 无法清空。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed