### PR TITLE
fix: use fromPairs replace Object.fromEntries

### DIFF
--- a/components/_util/reactivePick.ts
+++ b/components/_util/reactivePick.ts
@@ -1,5 +1,6 @@
 import type { UnwrapRef } from 'vue';
 import { reactive, toRef } from 'vue';
+import fromPairs from 'lodash/fromPairs';
 
 /**
  * Reactively pick fields from a reactive object
@@ -10,5 +11,5 @@ export function reactivePick<T extends object, K extends keyof T>(
   obj: T,
   ...keys: K[]
 ): { [S in K]: UnwrapRef<T[S]> } {
-  return reactive(Object.fromEntries(keys.map(k => [k, toRef(obj, k)]))) as any;
+  return reactive(fromPairs(keys.map(k => [k, toRef(obj, k)]))) as any;
 }

--- a/components/_util/reactivePick.ts
+++ b/components/_util/reactivePick.ts
@@ -1,6 +1,6 @@
 import type { UnwrapRef } from 'vue';
 import { reactive, toRef } from 'vue';
-import fromPairs from 'lodash/fromPairs';
+import fromPairs from 'lodash-es/fromPairs';
 
 /**
  * Reactively pick fields from a reactive object


### PR DESCRIPTION
### This is a bugfix

### What's the background?

> 1. fix: [#5168](https://github.com/vueComponent/ant-design-vue/issues/5168)

### API Realization (Optional if not new feature)

> 1. use lodash fromPairs replace Object.fromEntries

### What's the effect? (Optional if not new feature)

> 1. we can run it in a development environment with earlier versions of browsers

### Changelog description (Optional if not new feature)

> 1. fix: use fromPairs replace Object.fromEntries
