### PR TITLE
fix: table dragging css class should only be effective in table compo…

### DIFF
--- a/components/table/style/resize.less
+++ b/components/table/style/resize.less
@@ -23,7 +23,7 @@
   }
 }
 
-.dragging {
+.@{table-prefix-cls}-resize-handle.dragging {
   .@{table-prefix-cls}-resize-handle-line {
     opacity: 1;
   }


### PR DESCRIPTION
…nent

First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

related see issue  #5639 

Seems like conflicts between these two css class caused this problem. Adding css specificity of `dragging` will solve it.

![image](https://user-images.githubusercontent.com/20528478/170205341-c3acd7f4-385e-4758-a0a2-87cccdc5b220.png)

![image](https://user-images.githubusercontent.com/20528478/170205730-8c2ad966-46fc-47b7-ae58-655cbaa2dc4d.png)


### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
