### PR TITLE
fix: radio-group re-support defaultValue argument

### DIFF
--- a/components/radio/Group.tsx
+++ b/components/radio/Group.tsx
@@ -45,7 +45,7 @@ export default defineComponent({
   setup(props, { slots, emit }) {
     const formItemContext = useInjectFormItemContext();
     const { prefixCls, direction, size } = useConfigInject('radio', props);
-    const stateValue = ref(props.value);
+    const stateValue = ref(props.value === undefined ? props.defaultValue : props.value);
     const updatingValue = ref<boolean>(false);
     watch(
       () => props.value,


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

在某些需要使用 createVNode 创建组件的场景时，需要使用到 radiogroup 的默认值。
例子地址：https://codesandbox.io/s/antd-radiogroup-defaultval-3du9tt ；
在 3.0.0.alpha0 版本可用
但是由于 https://github.com/vueComponent/ant-design-vue/commit/84341ef91251b78db6ac899cad6eddeebc02e22a 此次提交，去掉了 defaultValue 的支持。
所以之后的版本该例子无法正确刷新选中 radio
希望可以重新支持 defaultValue  参数
