### PR TITLE
fix(vc-picker): global `mousedown` handler in `usePickerInput` hooks is never registered

### DIFF
--- a/components/vc-picker/hooks/usePickerInput.ts
+++ b/components/vc-picker/hooks/usePickerInput.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, HTMLAttributes, Ref } from 'vue';
-import { onBeforeUnmount, watchEffect, watch, ref, computed } from 'vue';
+import { onBeforeUnmount, onMounted, watch, ref, computed } from 'vue';
 import type { FocusEventHandler } from '../../_util/EventInterface';
 import KeyCode from '../../_util/KeyCode';
 import { addGlobalMousedownEvent, getTargetFromEvent } from '../utils/uiUtil';
@@ -148,30 +148,26 @@ export default function usePickerInput({
   });
   const globalMousedownEvent = ref();
   // Global click handler
-  watchEffect(
-    () =>
-      globalMousedownEvent.value &&
-      globalMousedownEvent.value()(
-        (globalMousedownEvent.value = addGlobalMousedownEvent((e: MouseEvent) => {
-          const target = getTargetFromEvent(e);
+  onMounted(() => {
+    globalMousedownEvent.value = addGlobalMousedownEvent((e: MouseEvent) => {
+      const target = getTargetFromEvent(e);
 
-          if (open) {
-            const clickedOutside = isClickOutside(target);
+      if (open.value) {
+        const clickedOutside = isClickOutside(target);
 
-            if (!clickedOutside) {
-              preventBlurRef.value = true;
+        if (!clickedOutside) {
+          preventBlurRef.value = true;
 
-              // Always set back in case `onBlur` prevented by user
-              raf(() => {
-                preventBlurRef.value = false;
-              });
-            } else if (!focused.value || clickedOutside) {
-              triggerOpen(false);
-            }
-          }
-        })),
-      ),
-  );
+          // Always set back in case `onBlur` prevented by user
+          raf(() => {
+            preventBlurRef.value = false;
+          });
+        } else if (!focused.value || clickedOutside) {
+          triggerOpen(false);
+        }
+      }
+    });
+  });
   onBeforeUnmount(() => {
     globalMousedownEvent.value && globalMousedownEvent.value();
   });


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [x] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

1. This is the original implementation in [`rc-picker`](https://github.com/react-component/picker/blob/master/src/hooks/usePickerInput.ts). it uses `useEffect` without any deps. Should we use `onMounted` directly in vue?

```tsx
useEffect(() =>
    addGlobalMouseDownEvent((e: MouseEvent) => {
      // ...
    }),
);
```

2. let's see the current implementation. `globalMousedownEvent.value` is initialized as `undefined`, so the condition `globalMousedownEvent.value && ...` will always be false and the global `mousedown` handler will never be registered.

```ts
const globalMousedownEvent = ref();
watchEffect(
    () =>
      globalMousedownEvent.value &&
      globalMousedownEvent.value()(
        (globalMousedownEvent.value = addGlobalMousedownEvent((e: MouseEvent) => {
    // ...
```

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
