### PR TITLE
fix(DirectoryTree): `selectedKeys` updating

### DIFF
--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -239,7 +239,7 @@ export default defineComponent({
         );
       } else {
         // Single click
-        newSelectedKeys = keys;
+        newSelectedKeys = [key];
         lastSelectedKey.value = key;
         cachedSelectedKeys.value = newSelectedKeys;
         newEvent.selectedNodes = convertDirectoryKeysToNodes(


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

In `multiple` mode, on single click on tree node item, it should emit single value instead of multiple values.

See original implementation of `ant-design`: https://github.com/ant-design/ant-design/blob/8d05774053138e807755c616ba1cf3fa296200dd/components/tree/DirectoryTree.tsx#L160-L166

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
