### PR TITLE
chore: use `czg` commitizen adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "cross-env": "^7.0.0",
     "css-loader": "^5.0.0",
     "css-minimizer-webpack-plugin": "^3.0.0",
+    "cz-git": "^1.3.8",
     "date-fns": "^2.24.0",
     "diacritics": "^1.3.0",
     "docsearch.js": "^2.6.3",
@@ -297,6 +298,12 @@
   "vetur": {
     "tags": "vetur/tags.json",
     "attributes": "vetur/attributes.json"
+  },
+  "config": {
+    "commitizen": {
+      "path": "node_modules/cz-git",
+      "czConfig": "./scripts/commitizen.js"
+    }
   },
   "web-types": "vetur/web-types.json"
 }

--- a/scripts/commitizen.js
+++ b/scripts/commitizen.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { execSync } = require('child_process');
+const fg = require('fast-glob');
+
+const components = fg.sync('*', { cwd: 'components', onlyDirectories: true });
+// precomputed scope
+const scopeComplete = execSync('git status --porcelain || true')
+  .toString()
+  .trim()
+  .split('\n')
+  .find(r => ~r.indexOf('M  '))
+  ?.replace(/(\/)/g, '%%')
+  ?.match(/components%%((\w|-)*)/)?.[1];
+
+/** @type {import('cz-git').CommitizenGitOptions} */
+module.exports = {
+  scopes: ['site', 'util', 'script', 'tool', ...components],
+  scopeFilters: ['__tests__', '_util'],
+  customScopesAlign: !scopeComplete ? 'top' : 'bottom',
+  defaultScope: scopeComplete,
+  maxHeaderLength: 100,
+  allowEmptyIssuePrefixs: false,
+  allowCustomIssuePrefixs: false,
+};


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [x] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.
> 2. Resolve what problem.
> 3. Related issue link.

Hi, I am the author of `cz-git`, I have checked the commit message of the project, I think it can be help maintainers who use commitizen CLI.
github: https://github.com/Zhengqbbb/cz-git
website | guide: https://cz-git.qbenben.com
中文文档: https://cz-git.qbenben.com/zh/

- **Friendly**: Supports search and selection on the command line, reducing spelling errors.
- **Lightweight**: Zero dependencies (1.5MB)
- **Highly Customizable**: The behavior of the CLI can be customized as project needed.

![demo](https://user-images.githubusercontent.com/40693636/175836268-c5663a5c-2c6a-44a3-806c-032e85a45f04.gif)

### Feature
Use the `git status` command to get the component name matched in the stag modification, and automatically pin the component name at the top in the scope list

![demo](https://user-images.githubusercontent.com/40693636/175836177-a8eb6fea-bd41-4dac-965c-fecd9222e256.gif)




### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
