### PR TITLE
Detach copyable button action, no longer bubble to parent component #5746

### DIFF
--- a/components/typography/Base.tsx
+++ b/components/typography/Base.tsx
@@ -233,6 +233,7 @@ const Base = defineComponent({
     // ================ Copy ================
     function onCopyClick(e: MouseEvent) {
       e.preventDefault();
+      e.stopPropagation();
       const { copyable } = props;
 
       const copyConfig = {

--- a/components/typography/demo/interactive.vue
+++ b/components/typography/demo/interactive.vue
@@ -53,9 +53,7 @@ Provide additional interactive capacity of editable and copyable.
     :editable="{ maxlength: 50, autoSize: { maxRows: 5, minRows: 3 } }"
   />
 
-  <a-typography-paragraph @click="handleClick" copyable>
-    This is a copyable text.
-  </a-typography-paragraph>
+  <a-typography-paragraph copyable>This is a copyable text.</a-typography-paragraph>
   <a-typography-paragraph :copyable="{ text: 'Hello, Ant Design!' }">
     Replace copy text.
   </a-typography-paragraph>
@@ -88,11 +86,6 @@ export default defineComponent({
     SmileOutlined,
     SmileFilled,
     CheckOutlined,
-  },
-  methods: {
-    handleClick(e) {
-      console.log(e);
-    },
   },
   setup() {
     const editableStr = ref('This is an editable text.');

--- a/components/typography/demo/interactive.vue
+++ b/components/typography/demo/interactive.vue
@@ -53,7 +53,9 @@ Provide additional interactive capacity of editable and copyable.
     :editable="{ maxlength: 50, autoSize: { maxRows: 5, minRows: 3 } }"
   />
 
-  <a-typography-paragraph copyable>This is a copyable text.</a-typography-paragraph>
+  <a-typography-paragraph @click="handleClick" copyable>
+    This is a copyable text.
+  </a-typography-paragraph>
   <a-typography-paragraph :copyable="{ text: 'Hello, Ant Design!' }">
     Replace copy text.
   </a-typography-paragraph>
@@ -86,6 +88,11 @@ export default defineComponent({
     SmileOutlined,
     SmileFilled,
     CheckOutlined,
+  },
+  methods: {
+    handleClick(e) {
+      console.log(e);
+    },
   },
   setup() {
     const editableStr = ref('This is an editable text.');


### PR DESCRIPTION
### This is a ...
Bug fix

### What's the background?

typography 组件中copy按钮事件冒泡至整个文本，导致如果在文本上自定义点击响应时，触发重复的问题

### API Realization (Optional if not new feature)

function onCopyClick(e: MouseEvent) {
      e.preventDefault();
      e.stopPropagation();
}
onCopyClick中阻止事件冒泡

### What's the effect? (Optional if not new feature)

仅影响当前组件，无破坏性更新

> If this PR related with other PR or following info. You can type here.
