### PR TITLE
Color and status concepts in unified badge components

### DIFF
--- a/components/badge/Badge.tsx
+++ b/components/badge/Badge.tsx
@@ -10,7 +10,8 @@ import Ribbon from './Ribbon';
 import { isPresetColor } from './utils';
 import useConfigInject from '../_util/hooks/useConfigInject';
 import isNumeric from '../_util/isNumeric';
-import type { PresetStatusColorType } from '../_util/colors';
+import type { PresetColorType, PresetStatusColorType } from '../_util/colors';
+import type { LiteralUnion } from '../_util/type';
 
 export const badgeProps = () => ({
   /** Number to show in badge */
@@ -22,9 +23,11 @@ export const badgeProps = () => ({
   dot: { type: Boolean, default: undefined },
   prefixCls: String,
   scrollNumberPrefixCls: String,
-  status: { type: String as PropType<PresetStatusColorType> },
+  // status: { type: String as PropType<PresetStatusColorType> },
   size: { type: String as PropType<'default' | 'small'>, default: 'default' },
-  color: String,
+  color: {
+    type: String as PropType<LiteralUnion<PresetColorType | PresetStatusColorType, string>>,
+  },
   text: PropTypes.any,
   offset: Array as unknown as PropType<[number | string, number | string]>,
   numberStyle: { type: Object as PropType<CSSProperties>, default: undefined as CSSProperties },
@@ -51,11 +54,7 @@ export default defineComponent({
       ) as string | number | null;
     });
 
-    const hasStatus = computed(
-      () =>
-        (props.status !== null && props.status !== undefined) ||
-        (props.color !== null && props.color !== undefined),
-    );
+    const hasStatus = computed(() => props.color !== null && props.color !== undefined);
 
     const isZero = computed(
       () => numberedDisplayCount.value === '0' || numberedDisplayCount.value === 0,
@@ -95,7 +94,6 @@ export default defineComponent({
     // Shared styles
     const statusCls = computed(() => ({
       [`${prefixCls.value}-status-dot`]: hasStatus.value,
-      [`${prefixCls.value}-status-${props.status}`]: !!props.status,
       [`${prefixCls.value}-status-${props.color}`]: isPresetColor(props.color),
     }));
 
@@ -113,7 +111,6 @@ export default defineComponent({
       [`${prefixCls.value}-count-sm`]: props.size === 'small',
       [`${prefixCls.value}-multiple-words`]:
         !isDotRef.value && displayCount.value && displayCount.value.toString().length > 1,
-      [`${prefixCls.value}-status-${props.status}`]: !!props.status,
       [`${prefixCls.value}-status-${props.color}`]: isPresetColor(props.color),
     }));
 

--- a/components/badge/demo/status.vue
+++ b/components/badge/demo/status.vue
@@ -16,19 +16,19 @@ Standalone badge with status.
 </docs>
 
 <template>
-  <a-badge status="success" />
-  <a-badge status="error" />
-  <a-badge status="default" />
-  <a-badge status="processing" />
-  <a-badge status="warning" />
+  <a-badge color="success" />
+  <a-badge color="error" />
+  <a-badge color="default" />
+  <a-badge color="processing" />
+  <a-badge color="warning" />
   <br />
-  <a-badge status="success" text="Success" />
+  <a-badge text="Success" />
   <br />
-  <a-badge status="error" text="Error" />
+  <a-badge color="error" text="Error" />
   <br />
-  <a-badge status="default" text="Default" />
+  <a-badge color="default" text="Default" />
   <br />
-  <a-badge status="processing" text="Processing" />
+  <a-badge color="processing" text="Processing" />
   <br />
-  <a-badge status="warning" text="warning" />
+  <a-badge color="warning" text="warning" />
 </template>

--- a/components/badge/demo/status.vue
+++ b/components/badge/demo/status.vue
@@ -22,7 +22,7 @@ Standalone badge with status.
   <a-badge color="processing" />
   <a-badge color="warning" />
   <br />
-  <a-badge text="Success" />
+  <a-badge color="success" text="Success" />
   <br />
   <a-badge color="error" text="Error" />
   <br />

--- a/components/badge/index.en_US.md
+++ b/components/badge/index.en_US.md
@@ -33,8 +33,7 @@ Badge normally appears in proximity to notifications or user avatars with eye-ca
 | offset | set offset of the badge dot, like [x, y] | [number\|string, number\|string] | - |  |
 | overflowCount | Max count to show | number | 99 |  |
 | showZero | Whether to show badge when `count` is zero | boolean | `false` |  |
-| status | Set Badge as a status dot | `success` \| `processing` \| `default` \| `error` \| `warning` | `''` |  |
-| text | If `status` is set, `text` sets the display text of the status `dot` | string | `''` |  |
+| text | `text` sets the display text of the status `dot` | string | `''` |  |
 | numberStyle | sets the display style of the status `dot` | object | '' |  |
 | title | Text to show when hovering over the badge | string | `count` |  |
 

--- a/components/badge/index.zh-CN.md
+++ b/components/badge/index.zh-CN.md
@@ -35,8 +35,7 @@ cover: https://gw.alipayobjects.com/zos/antfincdn/6%26GF9WHwvY/Badge.svg
 | offset | 设置状态点的位置偏移，格式为 [x, y] | [number\|string, number\|string] | - |  |
 | overflowCount | 展示封顶的数字值 | number | 99 |  |
 | showZero | 当数值为 0 时，是否展示 Badge | boolean | false |  |
-| status | 设置 Badge 为状态点 | Enum{ 'success', 'processing, 'default', 'error', 'warning' } | '' |  |
-| text | 在设置了 `status` 的前提下有效，设置状态点的文本 | string | '' |  |
+| text | 设置状态点的文本 | string | '' |  |
 | title | 设置鼠标放在状态点上时显示的文字 | string | `count` |  |
 
 ### Badge.Ribbon (2.0.1+)

--- a/components/badge/utils.ts
+++ b/components/badge/utils.ts
@@ -1,5 +1,8 @@
-import { PresetColorTypes } from '../_util/colors';
+import { PresetColorTypes, PresetStatusColorTypes } from '../_util/colors';
 
 export function isPresetColor(color?: string): boolean {
-  return (PresetColorTypes as any[]).indexOf(color) !== -1;
+  return (
+    (PresetColorTypes as any[]).indexOf(color) !== -1 ||
+    (PresetStatusColorTypes as any[]).indexOf(color) !== -1
+  );
 }


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[[English Template / 英文模板](https://github.com/vueComponent/ant-design-vue/compare/main...wuyadan:ant-design-vue:main?expand=1)](?expand=1)]

### 这个变动的性质是

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 来源：issue #5730.
> 2. 要解决的问题:①Unify the concepts of color and status in the badge component, similar to the concept of color in the tag component。②badge组件的text属性不止是在设置了`status`的前提下有效
> 3. issue链接：https://github.com/vueComponent/ant-design-vue/issues/5730

### 实现方案和 API（非新功能可选）

> 1. 方案：①合并status属性和color属性于color属性，②修改text属性的api说明文档。
> 2. 用法：color可使用'success', 'processing, 'default', 'error', 'warning'等状态、预设色彩和色值。
> 3. 截图：![image](https://user-images.githubusercontent.com/33799081/177237305-fcce230a-6b52-4766-8f5a-c5bf97f0930f.png)
>    。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
> 2. 是否有可能隐含的 break change 和其他风险？

### Changelog 描述（非新功能可选）

Unify the concepts of color and status in the badge component, similar to the concept of color in the tag component。

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供