### PR TITLE
chore: Add the exports property of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,27 @@
     "vetur",
     "typings/global.d.ts"
   ],
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "types": "./lib/index.d.ts"
+    },
+    "./antd.css": "./dist/antd.css",
+    "./antd.compact.css": "./dist/antd.compact.css",
+    "./antd.compact.less": "./dist/antd.compact.less",
+    "./antd.dark.css": "./dist/antd.dark.css",
+    "./antd.dark.less": "./dist/antd.dark.less",
+    "./antd.variable.css": "./dist/antd.variable.css",
+    "./antd.variable.less": "./dist/antd.variable.less",
+    "./antd-with-locales": "./dist/antd-with-locales.js",
+    "./dist/*": "./dist/*",
+    "./es/*": "./es/*",
+    "./lib/*": "./lib/*",
+    "./typings/*": "./typings/*",
+    "./scripts/*": "./scripts/*",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "predev": "npm run version && node node_modules/esbuild/install.js",
     "precompile": "npm run version",


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [x] Other (about what?)

### What's the background?

Add a custom path for the exports property of package.json to make the import of key resources more concise. for example:


Now: 
````
import 'ant-design-vue/dist/antd.css'
````

After
````
import 'ant-design-vue/antd.css';
````

In addition Node.js >= 12.7 has started to support [`exports`](https://nodejs.org/api/packages.html#exports) this field.

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
