### PR TITLE
improve: shadow dom supports

### DIFF
--- a/components/vc-picker/hooks/usePickerInput.ts
+++ b/components/vc-picker/hooks/usePickerInput.ts
@@ -2,8 +2,9 @@ import type { ComputedRef, HTMLAttributes, Ref } from 'vue';
 import { onBeforeUnmount, onMounted, watch, ref, computed } from 'vue';
 import type { FocusEventHandler } from '../../_util/EventInterface';
 import KeyCode from '../../_util/KeyCode';
-import { addGlobalMousedownEvent, getTargetFromEvent } from '../utils/uiUtil';
+import { addGlobalMousedownEvent } from '../utils/uiUtil';
 import raf from '../../_util/raf';
+import getTargetFromEvent from '../../vc-util/Dom/getTargetFromEvent';
 
 export default function usePickerInput({
   open,

--- a/components/vc-picker/utils/uiUtil.ts
+++ b/components/vc-picker/utils/uiUtil.ts
@@ -219,17 +219,6 @@ export function addGlobalMousedownEvent(callback: ClickEventHandler) {
   };
 }
 
-export function getTargetFromEvent(e: Event) {
-  const target = e.target as HTMLElement;
-
-  // get target if in shadow dom
-  if (e.composed && target.shadowRoot) {
-    return (e.composedPath?.()[0] || target) as HTMLElement;
-  }
-
-  return target;
-}
-
 // ====================== Mode ======================
 const getYearNextMode = (next: PanelMode): PanelMode => {
   if (next === 'month' || next === 'date') {

--- a/components/vc-select/hooks/useSelectTriggerControl.ts
+++ b/components/vc-select/hooks/useSelectTriggerControl.ts
@@ -1,17 +1,16 @@
 import type { Ref } from 'vue';
 import { onBeforeUnmount, onMounted } from 'vue';
 
+import getTargetFromEvent from '../../vc-util/Dom/getTargetFromEvent';
+
 export default function useSelectTriggerControl(
   refs: Ref[],
   open: Ref<boolean>,
   triggerOpen: (open: boolean) => void,
 ) {
   function onGlobalMouseDown(event: MouseEvent) {
-    let target = event.target as HTMLElement;
+    const target = getTargetFromEvent(event);
 
-    if (target.shadowRoot && event.composed) {
-      target = (event.composedPath()[0] || target) as HTMLElement;
-    }
     const elements = [refs[0]?.value, refs[1]?.value?.getPopupElement()];
     if (
       open.value &&

--- a/components/vc-trigger/Trigger.tsx
+++ b/components/vc-trigger/Trigger.tsx
@@ -21,6 +21,7 @@ import classNames from '../_util/classNames';
 import { cloneElement } from '../_util/vnode';
 import supportsPassive from '../_util/supportsPassive';
 import { useInjectTrigger, useProvidePortal } from './context';
+import getTargetFromEvent from '../vc-util/Dom/getTargetFromEvent';
 
 function noop() {}
 function returnEmptyString() {
@@ -362,11 +363,11 @@ export default defineComponent({
       }
     },
 
-    onDocumentClick(event) {
+    onDocumentClick(event: MouseEvent) {
       if (this.$props.mask && !this.$props.maskClosable) {
         return;
       }
-      const target = event.target;
+      const target = getTargetFromEvent(event);
       const root = this.getRootDomNode();
       const popupNode = this.getPopupDomNode();
       if (

--- a/components/vc-util/Dom/getTargetFromEvent.ts
+++ b/components/vc-util/Dom/getTargetFromEvent.ts
@@ -1,0 +1,10 @@
+export default function getTargetFromEvent(e: Event) {
+  const target = e.target as HTMLElement;
+
+  // get target if in shadow dom
+  if (e.composed && target.shadowRoot) {
+    return (e.composedPath?.()[0] || target) as HTMLElement;
+  }
+
+  return target;
+}


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

- add shadow dom supports to `vc-trigger`
- extract `getTargetFromEvent` function to a separate file

For now, when `VcTrigger` component is used in ShadowDOM environment(root element is in a shadowRoot), the condition `contains(root, target)` in `onDocumentClick` function will get wrong result. This is caused by event retargeting(https://javascript.info/shadow-dom-events)

### API Realization (Optional if not new feature)

> 1. Basic thought of solution and other optional proposal.
> 2. List final API realization and usage sample.
> 3. GIF or snapshot should be provided if includes UI/interactive modification.

### What's the effect? (Optional if not new feature)

> 1. Does this PR affect user? Which part will be affected?
> 2. What will say in changelog?
> 3. Does this PR contains potential break change or other risk?

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
