### PR TITLE
Image component adds custom preview option function and documentation, demo description

### DIFF
--- a/components/badge/Badge.tsx
+++ b/components/badge/Badge.tsx
@@ -10,7 +10,7 @@ import Ribbon from './Ribbon';
 import { isPresetColor } from './utils';
 import useConfigInject from '../_util/hooks/useConfigInject';
 import isNumeric from '../_util/isNumeric';
-import type { PresetStatusColorType } from '../_util/colors';
+import { PresetColorTypes, PresetStatusColorType, PresetStatusColorTypes } from '../_util/colors';
 
 export const badgeProps = () => ({
   /** Number to show in badge */
@@ -91,9 +91,18 @@ export default defineComponent({
       },
       { immediate: true },
     );
-
+    const PresetColorRegex = new RegExp(`^(${PresetColorTypes.join('|')})(-inverse)?$`);
+    const PresetStatusColorRegex = new RegExp(`^(${PresetStatusColorTypes.join('|')})$`);
+    const presetColor = computed(() => {
+      const { color } = props;
+      if (!color) {
+        return false;
+      }
+      return PresetColorRegex.test(color) || PresetStatusColorRegex.test(color);
+    });
     // Shared styles
     const statusCls = computed(() => ({
+      [`${prefixCls.value}-${props.color}`]: presetColor.value,
       [`${prefixCls.value}-status-dot`]: hasStatus.value,
       [`${prefixCls.value}-status-${props.status}`]: !!props.status,
       [`${prefixCls.value}-status-${props.color}`]: isPresetColor(props.color),

--- a/components/badge/demo/colors.vue
+++ b/components/badge/demo/colors.vue
@@ -24,6 +24,16 @@ New feature after 3.16.0. We preset a series of colorful Badge styles for use in
     </div>
   </div>
   <a-divider orientation="left">Custom</a-divider>
+  <a-badge color="success" text="success" />
+  <br />
+  <a-badge color="processing" text="processing" />
+  <br />
+  <a-badge color="error" text="error" />
+  <br />
+  <a-badge color="warning" text="warning" />
+  <br />
+  <a-badge color="default" text="default" />
+  <br />
   <a-badge color="#f50" text="#f50" />
   <br />
   <a-badge color="#2db7f5" text="#2db7f5" />

--- a/components/badge/style/index.less
+++ b/components/badge/style/index.less
@@ -93,20 +93,7 @@
     }
 
     &-processing {
-      position: relative;
       background-color: @processing-color;
-
-      &::after {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        border: 1px solid @processing-color;
-        border-radius: 50%;
-        animation: antStatusProcessing 1.2s infinite ease-in-out;
-        content: '';
-      }
     }
 
     &-default {
@@ -121,16 +108,7 @@
       background-color: @warning-color;
     }
 
-    // mixin to iterate over colors and create CSS class for each one
-    .make-color-classes(@i: length(@preset-colors)) when (@i > 0) {
-      .make-color-classes(@i - 1);
-      @color: extract(@preset-colors, @i);
-      @darkColor: '@{color}-6';
-      &-@{color} {
-        background: @@darkColor;
-      }
-    }
-    .make-color-classes();
+
 
     &-text {
       margin-left: 8px;
@@ -151,6 +129,7 @@
   }
 
   &-not-a-wrapper {
+
     .@{badge-prefix-cls}-zoom-appear,
     .@{badge-prefix-cls}-zoom-enter {
       animation: antNoWrapperZoomBadgeIn @animation-duration-slow @ease-out-back;
@@ -177,6 +156,33 @@
       transform-origin: 50% 50%;
     }
   }
+
+  // mixin to iterate over colors and create CSS class for each one
+  .make-color-classes(@i: length(@preset-colors)) when (@i > 0) {
+    .make-color-classes(@i - 1);
+    @color: extract(@preset-colors, @i);
+    @darkColor: '@{color}-6';
+
+    &-@{color} {
+      background: @@darkColor;
+    }
+  }
+
+  .make-status-color-classes(@status, @cssVariableType) {
+    @bgColor: '@{cssVariableType}-color';
+
+    &-@{status} {
+      background: @@bgColor;
+    }
+  }
+
+  .make-color-classes();
+
+  .make-status-color-classes(success, success);
+  .make-status-color-classes(processing, processing);
+  .make-status-color-classes(error, error);
+  .make-status-color-classes(warning, warning);
+  .make-status-color-classes(default, normal);
 }
 
 @keyframes antStatusProcessing {
@@ -210,7 +216,7 @@
     transition: all @animation-duration-slow @ease-in-out;
     .safari-fix-motion;
 
-    > p.@{number-prefix-cls}-only-unit {
+    >p.@{number-prefix-cls}-only-unit {
       height: @badge-height;
       margin: 0;
       .safari-fix-motion;

--- a/components/image/demo/index.vue
+++ b/components/image/demo/index.vue
@@ -7,6 +7,7 @@
     <previewGroupVisibleVue />
     <previewSrc />
     <controlled-preview />
+    <show-type />
   </demo-sort>
 </template>
 
@@ -18,6 +19,7 @@ import previewSrc from './preview-src.vue';
 import PreviewGroup from './preview-group.vue';
 import ControlledPreview from './controlled-preview.vue';
 import previewGroupVisibleVue from './preview-group-visible.vue';
+import showType from './show-type.vue';
 
 import CN from '../index.zh-CN.md';
 import US from '../index.en-US.md';
@@ -33,6 +35,7 @@ export default defineComponent({
     PreviewGroup,
     ControlledPreview,
     previewGroupVisibleVue,
+    showType,
   },
 });
 </script>

--- a/components/image/demo/show-type.vue
+++ b/components/image/demo/show-type.vue
@@ -1,0 +1,46 @@
+<docs>
+---
+order: 7
+title:
+  zh-CN: 自定义预览选项
+  en-US: Customize Preview Options
+---
+
+## zh-CN
+
+可控制预览选项仅显示图标或仅显示文字或都显示。
+
+## en-US
+
+control the preview options to display only icons or only text or both.
+
+</docs>
+
+<template>
+  <div>
+    <div>
+      <a-image
+        :width="200"
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+      />
+    </div>
+    <div style="margin: 10px 0">
+      <a-image
+        :width="200"
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        show-type="icon"
+      />
+    </div>
+    <div>
+      <a-image
+        :width="200"
+        src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
+        show-type="text"
+      />
+    </div>
+  </div>
+</template>
+<script lang="ts">
+import { defineComponent } from 'vue';
+export default defineComponent({});
+</script>

--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -24,6 +24,7 @@ Previewable image.
 | src | Image path | string | - | 2.0.0 |
 | previewMask | custom mask | false \| function \| slot | - | 3.2.0 |
 | width | Image width | string \| number | - | 2.0.0 |
+| showType | customize preview options | both \| text \| icon | both | 3.2.10 |
 
 ### events
 

--- a/components/image/index.tsx
+++ b/components/image/index.tsx
@@ -43,8 +43,8 @@ const Image = defineComponent<ImageProps>({
       const imageLocale = configProvider.locale?.Image || defaultLocale.Image;
       const defaultPreviewMask = () => (
         <div class={`${prefixCls.value}-mask-info`}>
-          <EyeOutlined />
-          {imageLocale?.preview}
+          {props.showType === 'icon' || props.showType === 'both' ? <EyeOutlined /> : null}
+          {props.showType === 'text' || props.showType === 'both' ? imageLocale?.preview : null}
         </div>
       );
       const { previewMask = slots.previewMask || defaultPreviewMask } = props;

--- a/components/image/index.zh-CN.md
+++ b/components/image/index.zh-CN.md
@@ -25,6 +25,7 @@ cover: https://gw.alipayobjects.com/zos/antfincdn/D1dXz9PZqa/image.svg
 | src | 图片地址 | string | - | 2.0.0 |
 | previewMask | 自定义 mask | false \| function \| slot | - | 3.2.0 |
 | width | 图像宽度 | string \| number | - | 2.0.0 |
+| showType | 自定义预览选项 | both \| text \| icon | both | 3.2.10 |
 
 ### 事件
 

--- a/components/vc-image/src/Image.tsx
+++ b/components/vc-image/src/Image.tsx
@@ -42,6 +42,10 @@ export const imageProps = () => ({
     type: [Boolean, Object] as PropType<boolean | ImagePreviewType>,
     default: true as boolean | ImagePreviewType,
   },
+  showType: {
+    type: String as PropType<'both' | 'text' | 'icon'>,
+    default: 'both',
+  },
   onClick: {
     type: Function as PropType<MouseEventHandler>,
   },


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [√] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Image组件在设置很小的时候，文字出现错乱
> 2. Image组件新增showType属性
> 3. [Related issue link.](https://github.com/vueComponent/ant-design-vue/issues/5789)

### API Realization (Optional if not new feature)

> 1. Image组件新增showType属性
> 2. showType: 'both' | 'text' | 'icon'
> 3. 
![1](https://user-images.githubusercontent.com/35223515/179195179-24377e87-5a62-4ae3-a0cc-a077f7ee5f12.gif)


### What's the effect? (Optional if not new feature)

> 1. 不影响用户使用
> 2. Image组件新增showType属性来自定义预览选项
> 3. 不包含任何影响

### Changelog description (Optional if not new feature)

> 1. Image control the preview options to display only icons or only text
> 2. Image组件可控制预览选项仅显示图标或仅显示文字或都显示。

### Self Check before Merge

- [√] Doc is updated/provided or not needed
- [√ ] Demo is updated/provided or not needed
- [√] TypeScript definition is updated/provided or not needed
- [√ ] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
