### PR TITLE
Fixed a flash of pictures when previewing was turned off ✨

### DIFF
--- a/components/vc-image/src/PreviewGroup.tsx
+++ b/components/vc-image/src/PreviewGroup.tsx
@@ -150,7 +150,7 @@ const Group = defineComponent({
     );
     watchEffect(
       () => {
-        if (!isShowPreview.value && isControlled.value) {
+        if (isShowPreview.value && isControlled.value) {
           setCurrent(currentControlledKey.value);
         }
       },


### PR DESCRIPTION
### This is a ...

- [X] Bug fix
- [ ] Site / document update
- [ ] New feature
- [ ] Code style optimization
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> [Image - Ant Design Vue (antdv.com)](https://www.antdv.com/components/image#components-image-demo-preview-group-visible)
>
> A flash of pictures when previewing from one image was turned off [**Preview from one image**]
>
> 当使用相册模式预览的时候，在关闭预览的时候，会有一个一闪而过的图片（默认展示的图片）

###  Reproduce the GIF

![previewImage](https://user-images.githubusercontent.com/32154293/188889635-abeeb0b5-db1a-4954-8719-07cc3a7a2df2.gif)
