### PR TITLE
Enhanced Modal component width property 🍓

### DIFF
--- a/components/vc-dialog/Content.tsx
+++ b/components/vc-dialog/Content.tsx
@@ -43,10 +43,10 @@ export default defineComponent({
       const { width, height } = props;
       const contentStyle: CSSProperties = {};
       if (width !== undefined) {
-        contentStyle.width = typeof width === 'number' ? `${width}px` : width;
+        contentStyle.width = !Number.isNaN(Number(width)) ? `${width}px` : width;
       }
       if (height !== undefined) {
-        contentStyle.height = typeof height === 'number' ? `${height}px` : height;
+        contentStyle.height = !Number.isNaN(Number(height)) ? `${height}px` : height;
       }
       if (transformOrigin.value) {
         contentStyle.transformOrigin = transformOrigin.value;


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [x] Other (**Enhanced Modal component width property** ) 

### What's the background?

```vue
    <a-modal v-model:visible="visible" width="1000" title="Basic Modal" @ok="handleOk">
      <p>Some contents...</p>
      <p>Some contents...</p>
      <p>Some contents...</p>
    </a-modal>
```
上述代码将传入一个宽度字符串1000，但是在文件[components\vc-dialog\Content.tsx 46行中](https://github.com/vueComponent/ant-design-vue/blob/main/components/vc-dialog/Content.tsx#L46)通过```contentStyle.width = typeof width === 'number' ? `${width}px` : width;```判断，会导致无法给对话框赋予宽度1000px。所以我[修改了判断](https://github.com/24min/ant-design-vue/blob/fix/modal-width-string/components/vc-dialog/Content.tsx#L46)，改为```contentStyle.width = !Number.isNaN(Number(width)) ? `${width}px` : width;```,这样在传入宽度的值为字符串1000的情况下，也能设置对话框的宽度。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

