### PR TITLE
fix: Cannot use custom prefixCls with custom theme color #6052

### DIFF
--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -74,7 +74,7 @@ const setGlobalConfig = (params: GlobalConfigProviderProps & { theme?: Theme }) 
     Object.assign(globalConfigBySet, reactive(params));
   });
   if (params.theme) {
-    registerTheme(getGlobalPrefixCls(), params.theme);
+    registerTheme(params.prefixCls ?? getGlobalPrefixCls(), params.theme);
   }
 };
 


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. 自定义主题和自定义前缀无法同时使用
> 2. 经过排查，发现是因为在注册主题时，globalConfigForApi的prefixCls字段的值还没有更新


### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
