### PR TITLE
fix(directory-tree): expose scrollTo method.

### DIFF
--- a/components/tree/DirectoryTree.tsx
+++ b/components/tree/DirectoryTree.tsx
@@ -18,6 +18,7 @@ import { conductExpandParent } from '../vc-tree/util';
 import { calcRangeKeys, convertDirectoryKeysToNodes } from './utils/dictUtil';
 import useConfigInject from '../_util/hooks/useConfigInject';
 import { filterEmpty } from '../_util/props-util';
+import { ScrollTo } from "../vc-tree/interface";
 
 export type ExpandAction = false | 'click' | 'doubleclick' | 'dblclick';
 
@@ -81,7 +82,11 @@ export default defineComponent({
     const cachedSelectedKeys = ref<Key[]>();
     const fieldNames = computed(() => fillFieldNames(props.fieldNames));
     const treeRef = ref();
+    const scrollTo: ScrollTo = scroll => {
+      treeRef.value?.scrollTo(scroll);
+    };
     expose({
+      scrollTo,
       selectedKeys: computed(() => treeRef.value?.selectedKeys),
       checkedKeys: computed(() => treeRef.value?.checkedKeys),
       halfCheckedKeys: computed(() => treeRef.value?.halfCheckedKeys),


### PR DESCRIPTION
### This is a ...
- [x] Bug fix

### What's the background?

1. Describe the source of requirement.
Directory-tree's scrollTo method is missing.
2. Resolve what problem.
This PR is expose scrollTo method to fix the above problem.
3. Related issue link.
https://github.com/vueComponent/ant-design-vue/issues/6064

### API Realization (Optional if not new feature)

1. Basic thought of solution and other optional proposal.
Add scrollTo method in Directory-Tree setup expose.
2. List final API realization and usage sample.
Like documentation.
3. GIF or snapshot should be provided if includes UI/interactive modification.
None.

### What's the effect? (Optional if not new feature)

 1. Does this PR affect user? Which part will be affected?
None.
2. What will say in changelog?
Fix the problem that Directory-tree's scrollTo method is missing.
3. Does this PR contains potential break change or other risk?
None

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

If this PR related with other PR or following info. You can type here.
None
