### PR TITLE
fix: vue@3.2.42 Watch multiple values, oldvalue is directly deconstructed and error is reported

### DIFF
--- a/components/_util/PortalWrapper.tsx
+++ b/components/_util/PortalWrapper.tsx
@@ -136,7 +136,7 @@ export default defineComponent({
       let init = false;
       watch(
         [() => props.visible, () => props.getContainer],
-        ([visible, getContainer], [prevVisible, prevGetContainer]) => {
+        ([visible, getContainer], [prevVisible, prevGetContainer] = []) => {
           // Update count
           if (supportDom && getParent(props.getContainer) === document.body) {
             if (visible && !prevVisible) {


### PR DESCRIPTION
### This is a Bug fix


### What's the background?

On the afternoon of 2022/11/09, vue released a version  `3.2.42`
- fix(runtime-core): watching multiple values - handle undefined as initial values (fix: #5032
修复了监视多个值-将`undefind`作为初始值处理。
commit https://github.com/vuejs/core/commit/bc167b5c6c7c5756f3b7720a7d3ddcdb2c7f717f
<img width="819" alt="image" src="https://user-images.githubusercontent.com/33514252/200830275-6d3ebde1-2de9-4ae1-8055-78792837b889.png">


**This causes an error when oldvalue is deconstructed directly, affecting the `a-modal`  and ` a-drawer` components.**

![image](https://user-images.githubusercontent.com/33514252/200829351-86fb7968-30ed-400f-97d7-17850ce0747d.png)

After debugging, it's located here 
https://github.com/vueComponent/ant-design-vue/blob/main/components/_util/PortalWrapper.tsx#L139

### codesandbox Demo
[codesandbox](https://codesandbox.io/s/exciting-hermann-k0dwfb?file=/src/App.vue)



