### PR TITLE
fix(generator-types): Fixed some bugs (web-type.json)

### DIFF
--- a/antd-tools/generator-types/index.js
+++ b/antd-tools/generator-types/index.js
@@ -3,18 +3,21 @@ const pkg = require('../../package.json');
 const { parseAndWrite } = require('./lib/index.js');
 const rootPath = path.resolve(__dirname, '../../');
 
-try {
-  parseAndWrite({
-    version: pkg.version,
-    name: 'ant-design-vue',
-    path: path.resolve(rootPath, './components'),
-    // default match lang
-    test: /en-US\.md/,
-    outputDir: path.resolve(rootPath, './vetur'),
-    tagPrefix: 'a-',
+parseAndWrite({
+  version: pkg.version,
+  name: 'ant-design-vue',
+  path: path.resolve(rootPath, './components'),
+  typingsPath: path.resolve(rootPath, './typings/global.d.ts'),
+  // default match lang
+  test: /en-US\.md/,
+  outputDir: path.resolve(rootPath, './vetur'),
+  tagPrefix: 'a-',
+})
+  .then(result => {
+    // eslint-disable-next-line no-console
+    console.log(`generator types success: ${result} tags generated`);
+  })
+  .catch(error => {
+    console.error('generator types error', error);
+    return Promise.reject(error);
   });
-  // eslint-disable-next-line no-console
-  console.log('generator types success');
-} catch (e) {
-  console.error('generator types error', e);
-}

--- a/antd-tools/generator-types/src/formatter.ts
+++ b/antd-tools/generator-types/src/formatter.ts
@@ -34,14 +34,19 @@ function parserProps(tag: VueTag, line: any) {
   });
 }
 
-export function formatter(articals: Articals, componentName: string, tagPrefix = '') {
+export function formatter(
+  articals: Articals,
+  componentName: string,
+  kebabComponentName: string,
+  tagPrefix = '',
+) {
   if (!articals.length) {
     return;
   }
 
   const tags: VueTag[] = [];
   const tag: VueTag = {
-    name: getComponentName(componentName, tagPrefix),
+    name: kebabComponentName,
     slots: [],
     events: [],
     attributes: [],
@@ -80,9 +85,13 @@ export function formatter(articals: Articals, componentName: string, tagPrefix =
     }
 
     // 额外的子组件
-    if (tableTitle.includes(componentName) && !tableTitle.includes('events')) {
+    if (
+      tableTitle.includes(componentName) &&
+      !tableTitle.includes('events') &&
+      !tableTitle.includes('()')
+    ) {
       const childTag: VueTag = {
-        name: getComponentName(tableTitle.replace('.', ''), tagPrefix),
+        name: getComponentName(tableTitle.replaceAll('.', '').replaceAll('/', ''), tagPrefix),
         slots: [],
         events: [],
         attributes: [],
@@ -93,6 +102,7 @@ export function formatter(articals: Articals, componentName: string, tagPrefix =
       tags.push(childTag);
       return;
     }
+
     // 额外的子组件事件
     if (tableTitle.includes(componentName) && tableTitle.includes('events')) {
       const childTagName = getComponentName(

--- a/antd-tools/generator-types/src/parser.ts
+++ b/antd-tools/generator-types/src/parser.ts
@@ -27,7 +27,7 @@ function readLine(input: string) {
 function splitTableLine(line: string) {
   line = line.replace(/\\\|/g, 'JOIN');
 
-  const items = line.split('|').map(item => item.trim().replace('JOIN', '|'));
+  const items = line.split('|').map(item => item.trim().replaceAll('JOIN', '|'));
 
   // remove pipe character on both sides
   items.pop();
@@ -77,11 +77,6 @@ export function mdParser(input: string): Articals {
   const artical = [];
   let start = 0;
   const end = input.length;
-  // artical.push({
-  //   type: 'title',
-  //   content: title,
-  //   level: 0,
-  // });
 
   while (start < end) {
     const target = input.substr(start);
@@ -108,6 +103,5 @@ export function mdParser(input: string): Articals {
     }
   }
 
-  // artical[0].content = title
   return artical;
 }

--- a/antd-tools/generator-types/src/type.ts
+++ b/antd-tools/generator-types/src/type.ts
@@ -28,9 +28,9 @@ export type VueAttribute = {
 
 export type VueTag = {
   name: string;
-  slots?: VueSlot[];
-  events?: VueEvent[];
-  attributes?: VueAttribute[];
+  slots: VueSlot[];
+  events: VueEvent[];
+  attributes: VueAttribute[];
   description?: string;
 };
 
@@ -56,6 +56,7 @@ export type VeturResult = {
 export type Options = {
   name: string;
   path: PathLike;
+  typingsPath: PathLike;
   test: RegExp;
   version: string;
   outputDir?: string;

--- a/antd-tools/generator-types/src/utils.ts
+++ b/antd-tools/generator-types/src/utils.ts
@@ -1,6 +1,6 @@
 // myName -> my-name
-export function toKebabCase(input: string): string {
-  return input.replace(/[A-Z]/g, (val, index) => (index === 0 ? '' : '-') + val.toLowerCase());
+export function toKebabCase(camel: string): string {
+  return camel.replace(/((?<=[a-z\d])[A-Z]|(?<=[A-Z\d])[A-Z](?=[a-z]))/g, '-$1').toLowerCase();
 }
 
 // name `v2.0.0` -> name


### PR DESCRIPTION
Hello everyone!

I want to contribute to the development of the project, I hope I'm not the only one who faces syntax highlighting problems when working in IDEA (WebStorm).

### This is a ...

- [x] Bug fix

### What's the background?

Not all tags and attributes are highlighted in Intellij IDEA and WebStorm IDEs. Some attributes are incorrectly filled in.

File generation (**vetur/attributes.json, vetur/tag.json, vetur/web-type.json**) is performed by parsing files **/components/*/index.en-US.md**

In this regard, there were several parsing errors that I fixed.


1. Duplication of tags in the **web-type.json** file, for example, `a-anchor`, `a-card` and many others. Different objects have different properties filled in somewhere events, somewhere attributes and somewhere slots.

<img width="244" alt="Снимок экрана 2022-11-12 в 18 29 14" src="https://user-images.githubusercontent.com/16255706/201482378-20c69a6a-137d-490c-8038-ef074ca2a3d3.png">

Now they are all combined in a single object.

<img width="273" alt="Снимок экрана 2022-11-12 в 18 31 33" src="https://user-images.githubusercontent.com/16255706/201482423-35fe4ea6-56db-4bdc-98b1-0dd415690a58.png">


2. Some tags were incorrectly named, for example.

<img width="996" alt="Снимок экрана 2022-11-12 в 18 32 46" src="https://user-images.githubusercontent.com/16255706/201482469-61ac4239-d304-4e59-8d95-520d1c20f458.png">

<img width="1055" alt="Снимок экрана 2022-11-12 в 18 34 01" src="https://user-images.githubusercontent.com/16255706/201482471-4323d2c0-c48f-4adb-9cad-41d9761443ac.png">

<img width="1078" alt="Снимок экрана 2022-11-12 в 18 34 16" src="https://user-images.githubusercontent.com/16255706/201482474-d7d9783b-64df-476e-af5f-a0d639d2cb1f.png">


3. Some types of attribute values were filled in incorrectly, for example

<img width="1160" alt="Снимок экрана 2022-11-12 в 18 36 09" src="https://user-images.githubusercontent.com/16255706/201482516-13e6e018-4702-4fe0-a0fd-e75c79d58d94.png">

<img width="1177" alt="Снимок экрана 2022-11-12 в 18 36 18" src="https://user-images.githubusercontent.com/16255706/201482519-5f70636b-f6d3-4438-b5e2-6b995acdc55e.png">

<img width="1163" alt="Снимок экрана 2022-11-12 в 18 36 28" src="https://user-images.githubusercontent.com/16255706/201482521-d818c181-74f5-42a0-a752-e549ac5affb8.png">

It was:
<img width="454" alt="Снимок экрана 2022-11-12 в 19 11 31" src="https://user-images.githubusercontent.com/16255706/201483403-f6ae759a-3e17-4568-a5ca-54eaedd94d98.png">

Become:
<img width="430" alt="Снимок экрана 2022-11-12 в 19 12 59" src="https://user-images.githubusercontent.com/16255706/201483455-5e5222e9-ec7c-4b5e-af3d-cb85b3097351.png">


4. There are some tags, for example, such as `a-table-summary`, `a-table-summary-row`, `a-table-summary-cell`, which are either difficult to extract from MD files, or are missing there.
To parse such tags, I took **typings/global.d.ts** as a basis, unfortunately, so far without filling slots, events and attributes.
But now the list of tags has become more complete.

<img width="429" alt="Снимок экрана 2022-11-12 в 18 42 47" src="https://user-images.githubusercontent.com/16255706/201482560-b3116c40-18b3-48b4-a5d8-cfdf46f5b3f9.png">

It was:
<img width="550" alt="Снимок экрана 2022-11-12 в 19 05 12" src="https://user-images.githubusercontent.com/16255706/201483147-7b044b30-8d01-4fc3-8f84-0726c9329a56.png">

Become:
<img width="557" alt="Снимок экрана 2022-11-12 в 19 05 59" src="https://user-images.githubusercontent.com/16255706/201483168-86dedd72-2492-472c-829e-210604d58068.png">



### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
