### PR TITLE
fix(vc-picker): fix picker display issue when process.env.NODE_ENV === 'test'

### DIFF
--- a/components/vc-picker/utils/uiUtil.ts
+++ b/components/vc-picker/utils/uiUtil.ts
@@ -272,8 +272,5 @@ export function elementsContains(
   elements: (HTMLElement | undefined | null)[],
   target: HTMLElement,
 ) {
-  if (process.env.NODE_ENV === 'test') {
-    return false;
-  }
   return elements.some(ele => ele && ele.contains(target));
 }


### PR DESCRIPTION
### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

https://github.com/vueComponent/ant-design-vue/issues/5842

原因分析：https://github.com/vueComponent/ant-design-vue/issues/5842#issuecomment-1314702517

### 实现方案和 API

当前 `elementsContains` 的逻辑：
https://github.com/vueComponent/ant-design-vue/blob/7246e628237b61db51f6fbea18987de49c7e65c3/components/vc-picker/utils/uiUtil.ts#L271-L279

这个方法为“判断元素集合中是否包含目标元素”，当 `process.env.NODE_ENV === 'test'` 时返回 `false`，应该是期望不影响 Jest 执行。但如果使用者的运行环境刚好为 `test`，则也会直接返回 `false`，误判断为不包含。

因此可以考虑两个方案：
**1、删除该判断逻辑**
经验证，可以成功执行测试用例
![image](https://user-images.githubusercontent.com/22230850/201826100-2b43c244-8d98-4811-b50f-c7573b4b81a7.png)

**2、考虑更换一个不易冲突的环境名称**
检索当前主分支代码，还有其他逻辑中使用 `process.env.NODE_ENV === 'test'`。
由于 `test` 名称重合率较高，会有一定的隐患，因此可以考虑更换为其它特有环境名称，减少冲突概率。

### Changelog 描述

fix `DatePicker` and `RangePicker` display issue when process.env.NODE_ENV === 'test'

修复 `process.env.NODE_ENV === 'test'` 时的 `DatePicker` 和 `RangePicker` 显示问题

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供