### PR TITLE
fix generate web-types.json bug

### DIFF
--- a/antd-tools/generator-types/src/parser.ts
+++ b/antd-tools/generator-types/src/parser.ts
@@ -27,7 +27,7 @@ function readLine(input: string) {
 function splitTableLine(line: string) {
   line = line.replace(/\\\|/g, 'JOIN');
 
-  const items = line.split('|').map(item => item.trim().replace('JOIN', '|'));
+  const items = line.split('|').map(item => item.trim().replaceAll('JOIN', '|'));
 
   // remove pipe character on both sides
   items.pop();


### PR DESCRIPTION
https://github.com/vueComponent/ant-design-vue/pull/5674 生成的内容只替换了一个，改成全部替换，上次的修改只修复了一部分
eg. "type": "false | function JOIN slot" => "type": "false | function | slot",才是正确的

### This is a ...
- [x] Bug fix
### What's the background?

> 1. https://github.com/vueComponent/ant-design-vue/pull/5674

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

