### PR TITLE
Fix a-carousel (vc-slick) component memory leak problem when using img

### DIFF
--- a/components/vc-slick/inner-slider.jsx
+++ b/components/vc-slick/inner-slider.jsx
@@ -309,8 +309,8 @@ export default {
       const imagesCount = images.length;
       let loadedCount = 0;
       Array.prototype.forEach.call(images, image => {
-        if (!image['__init_src__'] != image.src) {
-          image['__init_slider__'] = image.src;
+        if (!image['__src__'] != image.src) {
+          image['__src__'] = image.src;
           const handler = () =>
             ++loadedCount && loadedCount >= imagesCount && this.onWindowResized();
           if (!image.onclick) {


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 当使用a-carousel来渲染图片时存在内存泄漏问题，页面长时间运行会导致崩溃

### 实现方案和 API（非新功能可选）
> 1. 减少不必要的图片检查
> 2. 解除闭包导致的内存泄漏

### 对用户的影响和可能的风险（非新功能可选）


### Changelog 描述（非新功能可选）

> 1. Fix the memory leak problem caused by vc-slick components in picture mode

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。
