### PR TITLE
fix(vc-slick): #6100 - Fix content responsiveness in carousel component slot.

### DIFF
--- a/components/_util/vnode.ts
+++ b/components/_util/vnode.ts
@@ -3,11 +3,12 @@ import type { VNode, VNodeProps } from 'vue';
 import { cloneVNode } from 'vue';
 import warning from './warning';
 import type { RefObject } from './createRef';
+type NodeProps = Record<string, any> &
+  Omit<VNodeProps, 'ref'> & { ref?: VNodeProps['ref'] | RefObject };
 
 export function cloneElement<T, U>(
   vnode: VNode<T, U> | VNode<T, U>[],
-  nodeProps: Record<string, any> &
-    Omit<VNodeProps, 'ref'> & { ref?: VNodeProps['ref'] | RefObject } = {},
+  nodeProps: NodeProps = {},
   override = true,
   mergeRef = false,
 ): VNode<T, U> {
@@ -28,4 +29,21 @@ export function cloneElement<T, U>(
 
 export function cloneVNodes(vnodes, nodeProps = {}, override = true) {
   return vnodes.map(vnode => cloneElement(vnode, nodeProps, override));
+}
+
+export function deepCloneElement<T, U>(
+  vnode: VNode<T, U> | VNode<T, U>[],
+  nodeProps: NodeProps = {},
+  override = true,
+  mergeRef = false,
+) {
+  if (Array.isArray(vnode)) {
+    return vnode.map(item => deepCloneElement(item, nodeProps, override, mergeRef));
+  } else {
+    const cloned = cloneElement(vnode, nodeProps, override, mergeRef);
+    if (Array.isArray(cloned.children)) {
+      cloned.children = deepCloneElement(cloned.children as VNode<T, U>[]);
+    }
+    return cloned;
+  }
 }

--- a/components/vc-slick/track.jsx
+++ b/components/vc-slick/track.jsx
@@ -1,7 +1,8 @@
 import { createVNode } from 'vue';
 import classnames from '../_util/classNames';
 import { flattenChildren } from '../_util/props-util';
-import { lazyStartIndex, lazyEndIndex, getPreClones, cloneElement } from './utils/innerSliderUtils';
+import { lazyStartIndex, lazyEndIndex, getPreClones } from './utils/innerSliderUtils';
+import { deepCloneElement } from '../_util/vnode';
 
 // given specifications/props for a slide, fetch all the classes that need to be applied to the slide
 const getSlideClasses = spec => {
@@ -103,7 +104,7 @@ const renderSlides = function (spec, children) {
     let slideClasses = getSlideClasses({ ...spec, index });
     // push a cloned element of the desired slide
     slides.push(
-      cloneElement(child, {
+      deepCloneElement(child, {
         key: 'original' + getKey(child, index),
         tabindex: '-1',
         'data-index': index,
@@ -129,7 +130,7 @@ const renderSlides = function (spec, children) {
         }
         slideClasses = getSlideClasses({ ...spec, index: key });
         preCloneSlides.push(
-          cloneElement(child, {
+          deepCloneElement(child, {
             key: 'precloned' + getKey(child, key),
             class: classnames(slideClasses, slideClass),
             tabindex: '-1',
@@ -153,7 +154,7 @@ const renderSlides = function (spec, children) {
         }
         slideClasses = getSlideClasses({ ...spec, index: key });
         postCloneSlides.push(
-          cloneElement(child, {
+          deepCloneElement(child, {
             key: 'postcloned' + getKey(child, key),
             tabindex: '-1',
             'data-index': key,

--- a/components/vc-slick/track.jsx
+++ b/components/vc-slick/track.jsx
@@ -1,8 +1,7 @@
 import { createVNode } from 'vue';
 import classnames from '../_util/classNames';
-import { cloneElement } from '../_util/vnode';
 import { flattenChildren } from '../_util/props-util';
-import { lazyStartIndex, lazyEndIndex, getPreClones } from './utils/innerSliderUtils';
+import { lazyStartIndex, lazyEndIndex, getPreClones, cloneElement } from './utils/innerSliderUtils';
 
 // given specifications/props for a slide, fetch all the classes that need to be applied to the slide
 const getSlideClasses = spec => {
@@ -84,7 +83,6 @@ const renderSlides = function (spec, children) {
   const childrenCount = children.length;
   const startIndex = lazyStartIndex(spec);
   const endIndex = lazyEndIndex(spec);
-
   children.forEach((elem, index) => {
     let child;
     const childOnClickOptions = {
@@ -182,6 +180,7 @@ const renderSlides = function (spec, children) {
 
 const Track = (_, { attrs, slots }) => {
   const slides = renderSlides(attrs, flattenChildren(slots?.default()));
+  // const slides = renderSlides(attrs,  slots?.default);
   const { onMouseenter, onMouseover, onMouseleave } = attrs;
   const mouseEvents = { onMouseenter, onMouseover, onMouseleave };
   const trackProps = {

--- a/components/vc-slick/utils/innerSliderUtils.js
+++ b/components/vc-slick/utils/innerSliderUtils.js
@@ -1,5 +1,4 @@
 // import supportsPassive from '../../../_util/supportsPassive';
-import { cloneElement as cloneVnode } from '../../_util/vnode';
 
 export function clamp(number, lowerBound, upperBound) {
   return Math.max(lowerBound, Math.min(number, upperBound));
@@ -789,27 +788,3 @@ export const slidesOnLeft = ({ slidesToShow, centerMode, rtl, centerPadding }) =
 
 export const canUseDOM = () =>
   !!(typeof window !== 'undefined' && window.document && window.document.createElement);
-
-export const cloneElement = (vnode, nodeProps) => {
-  const node = cloneVnode(vnode, nodeProps);
-
-  if (!Array.isArray(vnode.children)) {
-    return node;
-  }
-
-  const children = [];
-  node.children.forEach(el => {
-    if (Array.isArray(el)) {
-      const newItem = [];
-      el.forEach(item => {
-        newItem.push(cloneElement(item));
-      });
-      children.push(newItem);
-    } else {
-      children.push(cloneElement(el));
-    }
-  });
-  node.children = children;
-
-  return node;
-};

--- a/components/vc-slick/utils/innerSliderUtils.js
+++ b/components/vc-slick/utils/innerSliderUtils.js
@@ -1,4 +1,5 @@
 // import supportsPassive from '../../../_util/supportsPassive';
+import { cloneElement as cloneVnode } from '../../_util/vnode';
 
 export function clamp(number, lowerBound, upperBound) {
   return Math.max(lowerBound, Math.min(number, upperBound));
@@ -788,3 +789,27 @@ export const slidesOnLeft = ({ slidesToShow, centerMode, rtl, centerPadding }) =
 
 export const canUseDOM = () =>
   !!(typeof window !== 'undefined' && window.document && window.document.createElement);
+
+export const cloneElement = (vnode, nodeProps) => {
+  const node = cloneVnode(vnode, nodeProps);
+
+  if (!Array.isArray(vnode.children)) {
+    return node;
+  }
+
+  const children = [];
+  node.children.forEach(el => {
+    if (Array.isArray(el)) {
+      const newItem = [];
+      el.forEach(item => {
+        newItem.push(cloneElement(item));
+      });
+      children.push(newItem);
+    } else {
+      children.push(cloneElement(el));
+    }
+  });
+  node.children = children;
+
+  return node;
+};


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

fix issue #6100 

### 实现方案和 API（非新功能可选）

> 分析：该问题的原因是 vue 中的 cloneVNode 方法在 clone 时未对 children 进行深度 clone；导致同一个 vnode 生成了两份 dom；从而导致该了问题。如下图所示：
<img width="1258" alt="image" src="https://user-images.githubusercontent.com/1281760/206703298-d71d95e0-2487-4ccc-b1b3-7da89fdd80a2.png">

> 解决方案：在原来的 cloneElement 基础上做了一层封装，对 vnode 做深度 clone。另因  _util/vnode.ts  的 cloneElement 方法存在大面积的使用，故将实现放在了  vc-slick/utils/innerSliderUtils.js 中

> 思考是否可以在 vue 中实现，是不是 vue 的 bug，有待进一步了解。

### 对用户的影响和可能的风险（非新功能可选）

> 无

### Changelog 描述（非新功能可选）

> 1. fix(vc-slick): Fix content responsiveness in carousel component slot. #6100
> 2. 修复轮播组件插槽中的内容响应。#6100

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。
