### PR TITLE
fix[notification]: onClose event runs repeatedly

### DIFF
--- a/components/vc-notification/Notice.tsx
+++ b/components/vc-notification/Notice.tsx
@@ -46,9 +46,10 @@ export default defineComponent<NoticeProps>({
   ] as any,
   setup(props, { attrs, slots }) {
     let closeTimer: any;
-    const duration = computed(() => (props.duration === undefined ? 1.5 : props.duration));
+    let isUnMounted = false;
+    const duration = computed(() => (props.duration === undefined ? 4.5 : props.duration));
     const startCloseTimer = () => {
-      if (duration.value) {
+      if (duration.value && !isUnMounted) {
         closeTimer = setTimeout(() => {
           close();
         }, duration.value * 1000);
@@ -79,6 +80,7 @@ export default defineComponent<NoticeProps>({
       startCloseTimer();
     });
     onUnmounted(() => {
+      isUnMounted = true;
       clearCloseTimer();
     });
 


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
- Resolve what problem.
The mouseleave event of this component will create a timer after unmounted. So It may cause `onClose` event runs repeatedly.
- Related issue link.
fix #6144

## Chinese description 
使用 `notification` 的时候，它绑定了 `mouseLeave` 和 `mouseEnter` 事件。在我点击关闭按钮后，`unMounted` 事件运行后，又会运行 `mouseLeave`  事件，导致清除了定时器后又新建了一个定时器。所以会调用两次 `notification` 里 `onClose` 事件两次。