### PR TITLE
fix[data-picker]: hide `Now` when current time is disabled

### DIFF
--- a/components/vc-picker/PickerPanel.tsx
+++ b/components/vc-picker/PickerPanel.tsx
@@ -364,6 +364,7 @@ function PickerPanel<DateType>() {
           isMinuteStepValid.value ? minuteStep : 1,
           isSecondStepValid.value ? secondStep : 1,
         );
+
         const adjustedNow = setTime(
           generateConfig,
           now,
@@ -414,7 +415,6 @@ function PickerPanel<DateType>() {
           disabledDate,
           picker = 'date',
           tabindex = 0,
-          showNow,
           showTime,
           showToday,
           renderExtraFooter,
@@ -422,6 +422,14 @@ function PickerPanel<DateType>() {
           onOk,
           components,
         } = props;
+
+        let { showNow } = props;
+        const now = generateConfig.getNow();
+        // when NOW is invalid, hide NOW button
+        if (disabledDate?.(now)) {
+          showNow = false;
+        }
+
         if (operationRef && panelPosition.value !== 'right') {
           operationRef.value = {
             onKeydown: onInternalKeydown,
@@ -578,7 +586,7 @@ function PickerPanel<DateType>() {
         if (showToday && mergedMode.value === 'date' && picker === 'date' && !showTime) {
           const now = generateConfig.getNow();
           const todayCls = `${prefixCls}-today-btn`;
-          const disabled = disabledDate && disabledDate(now);
+          const disabled = disabledDate?.(now);
           todayNode = (
             <a
               class={classNames(todayCls, disabled && `${todayCls}-disabled`)}


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

- Resolve what problem.
When current time is invalid, I also can click `Now` button to set value.
- Related issue link.
fix #6151


### Changelog description (Optional if not new feature)

Chinese description (optional)
`disableDate` 函数里设置，今天是不可选的。但是，当你点击 `Now` ，你依然可以设置时间为今天。并且点击 `Now` 按钮，之后并不需要你点击 `ok` 去赋值，是点击完 `Now` 按钮之后一步完成了。所以有两种解决方案我认为：
- 如果当前时间 invalid，就隐藏 `Now`
- 点击 `Now` 按钮之后，不立即关闭这个 panel，需要点击 `ok` 后才关闭这个 panel

我比较倾向于第一种。

