### PR TITLE
fix: set the correct activce classname for stickyScrollBar

### DIFF
--- a/components/vc-table/stickyScrollBar.tsx
+++ b/components/vc-table/stickyScrollBar.tsx
@@ -230,7 +230,7 @@ export default defineComponent<StickyScrollBarProps>({
             onMousedown={onMouseDown}
             ref={scrollBarRef}
             class={classNames(`${prefixCls}-sticky-scroll-bar`, {
-              [`${prefixCls}-sticky-scroll-bar-active`]: isActive,
+              [`${prefixCls}-sticky-scroll-bar-active`]: isActive.value,
             })}
             style={{
               width: `${scrollBarWidth.value}px`,


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. 解决table组件中 `stickyScrollBar` 组件 `active` 态`className`被一直设置为激活的状态（未激活时也被设置了）

### API Realization (Optional if not new feature)

> none

### What's the effect? (Optional if not new feature)

> none

### Changelog description (Optional if not new feature)

> 1. English description
> 2. Chinese description (optional)

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
