### PR TITLE
fix: Support `customCell` set col/row Span

### DIFF
--- a/components/vc-table/src/TableCell.jsx
+++ b/components/vc-table/src/TableCell.jsx
@@ -76,8 +76,6 @@ export default {
         tdProps.props = text.props || {};
         tdProps.class = text.class;
         tdProps.style = text.style;
-        colSpan = tdProps.attrs.colSpan;
-        rowSpan = tdProps.attrs.rowSpan;
         text = text.children;
       }
     }
@@ -85,6 +83,10 @@ export default {
     if (column.customCell) {
       tdProps = mergeProps(tdProps, column.customCell(record, index));
     }
+    
+    // Support `customCell` set col/row Span
+    colSpan = tdProps.attrs.colSpan;
+    rowSpan = tdProps.attrs.rowSpan;
 
     // Fix https://github.com/ant-design/ant-design/issues/1202
     if (isInvalidRenderCellText(text)) {


### PR DESCRIPTION
### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 原版本只能在`customRender`中设置col/row Span才能正常生效，但是需要设置`children`属性。`customCell`也能设置col/row Span，但是表现异常。

### 实现方案和 API（非新功能可选）

> 1. 在判断col/row Span值前、合并`customCell`后，再取col/row Span值。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端没有影响
> 2. 没有可能隐含的 break change 和其他风险

### Changelog 描述（非新功能可选）

> 无

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 无