### PR TITLE
Add "format" prop for time-picker demo

### DIFF
--- a/components/form/demo/time-related-controls.vue
+++ b/components/form/demo/time-related-controls.vue
@@ -56,7 +56,7 @@ or use `valueFormat` to format.
       />
     </a-form-item>
     <a-form-item name="time-picker" label="TimePicker" v-bind="config">
-      <a-time-picker v-model:value="formState['time-picker']" value-format="HH:mm:ss" />
+      <a-time-picker v-model:value="formState['time-picker']" format="HH:mm:ss" value-format="HH:mm:ss" />
     </a-form-item>
     <a-form-item
       :wrapper-col="{


### PR DESCRIPTION
Add the `format` prop to the time-picker demo, which is used to format the display value of the time-picker.

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

> 1. Describe the source of requirement.

I want to format the display of time-picker to `HH:mm`, but the [documentation](https://antdv.com/components/form#components-form-demo-time-related-controls) here only has `value-format` which was not reflected onto the UI.
Reference from AntDesign official docs: https://github.com/ant-design/ant-design/blob/master/components/time-picker/demo/hide-column.tsx

> 2. Resolve what problem.

Avoid confusing developers because we don't know if there is a `format` prop that should be used to format the display value.

> 3. Related issue link.

I don't know.

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
