### PR TITLE
fix: type of minute in props disabledDateTime of DatePicker

### DIFF
--- a/components/vc-picker/panels/TimePanel/TimeBody.tsx
+++ b/components/vc-picker/panels/TimePanel/TimeBody.tsx
@@ -190,7 +190,7 @@ const TimeBody = defineComponent({
         0,
         59,
         props.secondStep ?? 1,
-        mergedDisabledSeconds.value && mergedDisabledSeconds.value(originHour.value, minute),
+        mergedDisabledSeconds.value && mergedDisabledSeconds.value(originHour.value, minute.value),
       ),
     );
 


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [X ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

Resolve the problem [The type of minute in porps disabledDateTime of DatePicker should be number, not a ComputedRef . #6231](https://github.com/vueComponent/ant-design-vue/issues/6231)

### Self Check before Merge

- [x]  Doc is updated/provided or not needed
- [x]  Demo is updated/provided or not needed
- [x]  TypeScript definition is updated/provided or not needed
- [x]  Changelog is provided or not needed
