### PR TITLE
style: add dark style for `pre` and `code`

### DIFF
--- a/site/src/theme/static/highlight.dark.less
+++ b/site/src/theme/static/highlight.dark.less
@@ -1,0 +1,16 @@
+html[data-doc-theme='dark'] {
+  pre code {
+    background: #262626;
+    border-color: #262626;
+  }
+
+  code[class*='language-'],
+  pre[class*='language-'] {
+    color: black;
+  }
+
+  :not(pre) > code[class*='language-'],
+  pre[class*='language-'] {
+    background: #262626;
+  }
+}

--- a/site/src/theme/static/index.less
+++ b/site/src/theme/static/index.less
@@ -9,6 +9,7 @@
 @import './toc';
 @import './not-found';
 @import './highlight';
+@import './highlight.dark';
 @import './demo';
 @import './icons';
 @import './mock-browser';


### PR DESCRIPTION
### What's the background?

fix #6376
![image](https://user-images.githubusercontent.com/82451257/227240342-4b51f689-3b24-48bb-97d7-7fc71ede9955.png)



### What's the effect? (Optional if not new feature)

![K_K1DN(BG5ZET6K9(RQ0H](https://user-images.githubusercontent.com/82451257/227239481-bd03a0c9-983a-4c23-b807-daa8b8d46db8.png)

