### PR TITLE
refactor(Progress): enhance size prop and add variants

### DIFF
--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -431,6 +431,188 @@ exports[`renders ./components/progress/demo/segment.vue correctly 1`] = `
 </div>
 `;
 
+exports[`renders ./components/progress/demo/size.vue correctly 1`] = `
+<div>
+  <div style="width: 50%;" class="ant-space css-dev-only-do-not-override-1etm4mv ant-space-vertical">
+    <div class="ant-space-item" style="margin-bottom: 8px;">
+      <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+        <div class="ant-progress-outer" style="width: 100%; height: 8px;">
+          <div class="ant-progress-inner">
+            <div class="ant-progress-bg" style="width: 50%; height: 8px;"></div>
+            <!---->
+          </div>
+        </div><span class="ant-progress-text" title="50%">50%</span>
+      </div>
+    </div>
+    <!---->
+    <div class="ant-space-item" style="margin-bottom: 8px;">
+      <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-small css-dev-only-do-not-override-1etm4mv">
+        <div class="ant-progress-outer" style="width: 100%; height: 6px;">
+          <div class="ant-progress-inner">
+            <div class="ant-progress-bg" style="width: 50%; height: 6px;"></div>
+            <!---->
+          </div>
+        </div><span class="ant-progress-text" title="50%">50%</span>
+      </div>
+    </div>
+    <!---->
+    <div class="ant-space-item">
+      <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-300,20 css-dev-only-do-not-override-1etm4mv">
+        <div class="ant-progress-outer" style="height: 20px;">
+          <div class="ant-progress-inner">
+            <div class="ant-progress-bg" style="width: 50%; height: 20px;"></div>
+            <!---->
+          </div>
+        </div><span class="ant-progress-text" title="50%">50%</span>
+      </div>
+    </div>
+    <!---->
+  </div><br><br>
+  <div class="ant-space css-dev-only-do-not-override-1etm4mv ant-space-horizontal ant-space-align-center">
+    <div class="ant-space-item" style="margin-right: 30px;">
+      <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+        <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+            <!---->
+            <path d="M 50,50 m 0,-47
+   a 47,47 0 1 1 0,94
+   a 47,47 0 1 1 0,-94" stroke-linecap="round" stroke-width="6" fill-opacity="0" class="ant-progress-circle-trail" style="stroke-dasharray: 295.3097094374406px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+            <path d="M 50,50 m 0,-47
+   a 47,47 0 1 1 0,94
+   a 47,47 0 1 1 0,-94" stroke="" stroke-linecap="round" stroke-width="6" opacity="1" fill-opacity="0" class="ant-progress-circle-path" style="stroke-dasharray: 147.6548547187203px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+            <path d="M 50,50 m 0,-47
+   a 47,47 0 1 1 0,94
+   a 47,47 0 1 1 0,-94" stroke="" stroke-linecap="round" stroke-width="6" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+          </svg><span class="ant-progress-text" title="50%">50%</span></div>
+      </div>
+    </div>
+    <!---->
+    <div class="ant-space-item" style="margin-right: 30px;">
+      <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-small css-dev-only-do-not-override-1etm4mv">
+        <div class="ant-progress-inner" style="width: 60px; height: 60px; font-size: 15px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+            <!---->
+            <path d="M 50,50 m 0,-47
+   a 47,47 0 1 1 0,94
+   a 47,47 0 1 1 0,-94" stroke-linecap="round" stroke-width="6" fill-opacity="0" class="ant-progress-circle-trail" style="stroke-dasharray: 295.3097094374406px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+            <path d="M 50,50 m 0,-47
+   a 47,47 0 1 1 0,94
+   a 47,47 0 1 1 0,-94" stroke="" stroke-linecap="round" stroke-width="6" opacity="1" fill-opacity="0" class="ant-progress-circle-path" style="stroke-dasharray: 147.6548547187203px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+            <path d="M 50,50 m 0,-47
+   a 47,47 0 1 1 0,94
+   a 47,47 0 1 1 0,-94" stroke="" stroke-linecap="round" stroke-width="6" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+          </svg><span class="ant-progress-text" title="50%">50%</span></div>
+      </div>
+    </div>
+    <!---->
+    <div class="ant-space-item">
+      <div role="progressbar" class="ant-progress ant-progress-inline-circle ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-20 css-dev-only-do-not-override-1etm4mv">
+        <div class="ant-progress-inner" style="width: 20px; height: 20px; font-size: 9px;">
+          <!----><span><svg class="ant-progress-circle" viewBox="0 0 100 100"><!----><path d="M 50,50 m 0,-42.5
+   a 42.5,42.5 0 1 1 0,85
+   a 42.5,42.5 0 1 1 0,-85" stroke-linecap="round" stroke-width="15" fill-opacity="0" class="ant-progress-circle-trail" style="stroke-dasharray: 267.0353755551324px 267.0353755551324px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path><path d="M 50,50 m 0,-42.5
+   a 42.5,42.5 0 1 1 0,85
+   a 42.5,42.5 0 1 1 0,-85" stroke="" stroke-linecap="round" stroke-width="15" opacity="1" fill-opacity="0" class="ant-progress-circle-path" style="stroke-dasharray: 133.5176877775662px 267.0353755551324px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path><path d="M 50,50 m 0,-42.5
+   a 42.5,42.5 0 1 1 0,85
+   a 42.5,42.5 0 1 1 0,-85" stroke="" stroke-linecap="round" stroke-width="15" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 267.0353755551324px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path></svg></span>
+        </div>
+      </div>
+    </div>
+    <!---->
+  </div><br><br>
+  <div class="ant-space css-dev-only-do-not-override-1etm4mv ant-space-horizontal ant-space-align-center">
+    <div class="ant-space-item" style="margin-right: 30px;">
+      <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+        <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+            <!---->
+            <path d="M 50,50 m 0,47
+   a 47,47 0 1 1 0,-94
+   a 47,47 0 1 1 0,94" stroke-linecap="round" stroke-width="6" fill-opacity="0" class="ant-progress-circle-trail" style="stroke-dasharray: 220.30970943744057px 295.3097094374406px; stroke-dashoffset: -37.5px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+            <path d="M 50,50 m 0,47
+   a 47,47 0 1 1 0,-94
+   a 47,47 0 1 1 0,94" stroke="" stroke-linecap="round" stroke-width="6" opacity="1" fill-opacity="0" class="ant-progress-circle-path" style="stroke-dasharray: 110.15485471872029px 295.3097094374406px; stroke-dashoffset: -37.5px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+            <path d="M 50,50 m 0,47
+   a 47,47 0 1 1 0,-94
+   a 47,47 0 1 1 0,94" stroke="" stroke-linecap="round" stroke-width="6" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 295.3097094374406px; stroke-dashoffset: -37.5px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+          </svg><span class="ant-progress-text" title="50%">50%</span></div>
+      </div>
+    </div>
+    <!---->
+    <div class="ant-space-item" style="margin-right: 30px;">
+      <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-small css-dev-only-do-not-override-1etm4mv">
+        <div class="ant-progress-inner" style="width: 60px; height: 60px; font-size: 15px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+            <!---->
+            <path d="M 50,50 m 0,47
+   a 47,47 0 1 1 0,-94
+   a 47,47 0 1 1 0,94" stroke-linecap="round" stroke-width="6" fill-opacity="0" class="ant-progress-circle-trail" style="stroke-dasharray: 220.30970943744057px 295.3097094374406px; stroke-dashoffset: -37.5px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+            <path d="M 50,50 m 0,47
+   a 47,47 0 1 1 0,-94
+   a 47,47 0 1 1 0,94" stroke="" stroke-linecap="round" stroke-width="6" opacity="1" fill-opacity="0" class="ant-progress-circle-path" style="stroke-dasharray: 110.15485471872029px 295.3097094374406px; stroke-dashoffset: -37.5px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+            <path d="M 50,50 m 0,47
+   a 47,47 0 1 1 0,-94
+   a 47,47 0 1 1 0,94" stroke="" stroke-linecap="round" stroke-width="6" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 295.3097094374406px; stroke-dashoffset: -37.5px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+          </svg><span class="ant-progress-text" title="50%">50%</span></div>
+      </div>
+    </div>
+    <!---->
+    <div class="ant-space-item">
+      <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-20 css-dev-only-do-not-override-1etm4mv">
+        <div class="ant-progress-inner" style="width: 20px; height: 20px; font-size: 9px;">
+          <!----><span><svg class="ant-progress-circle" viewBox="0 0 100 100"><!----><path d="M 50,50 m 0,42.5
+   a 42.5,42.5 0 1 1 0,-85
+   a 42.5,42.5 0 1 1 0,85" stroke-linecap="round" stroke-width="15" fill-opacity="0" class="ant-progress-circle-trail" style="stroke-dasharray: 192.03537555513242px 267.0353755551324px; stroke-dashoffset: -37.5px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path><path d="M 50,50 m 0,42.5
+   a 42.5,42.5 0 1 1 0,-85
+   a 42.5,42.5 0 1 1 0,85" stroke="" stroke-linecap="round" stroke-width="15" opacity="1" fill-opacity="0" class="ant-progress-circle-path" style="stroke-dasharray: 96.01768777756621px 267.0353755551324px; stroke-dashoffset: -37.5px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path><path d="M 50,50 m 0,42.5
+   a 42.5,42.5 0 1 1 0,-85
+   a 42.5,42.5 0 1 1 0,85" stroke="" stroke-linecap="round" stroke-width="15" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 267.0353755551324px; stroke-dashoffset: -37.5px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path></svg></span>
+        </div>
+      </div>
+    </div>
+    <!---->
+  </div><br><br>
+  <div class="ant-space css-dev-only-do-not-override-1etm4mv ant-space-horizontal ant-space-align-center">
+    <div class="ant-space-item" style="margin-right: 30px;">
+      <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+        <div class="ant-progress-steps-outer">
+          <div class="ant-progress-steps-item ant-progress-steps-item-active" style="width: 14px; height: 8px;"></div>
+          <div class="ant-progress-steps-item ant-progress-steps-item-active" style="width: 14px; height: 8px;"></div>
+          <div class="ant-progress-steps-item" style="width: 14px; height: 8px;"></div><span class="ant-progress-text" title="50%">50%</span>
+        </div>
+      </div>
+    </div>
+    <!---->
+    <div class="ant-space-item" style="margin-right: 30px;">
+      <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-small css-dev-only-do-not-override-1etm4mv">
+        <div class="ant-progress-steps-outer">
+          <div class="ant-progress-steps-item ant-progress-steps-item-active" style="width: 2px; height: 8px;"></div>
+          <div class="ant-progress-steps-item ant-progress-steps-item-active" style="width: 2px; height: 8px;"></div>
+          <div class="ant-progress-steps-item" style="width: 2px; height: 8px;"></div><span class="ant-progress-text" title="50%">50%</span>
+        </div>
+      </div>
+    </div>
+    <!---->
+    <div class="ant-space-item" style="margin-right: 30px;">
+      <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-20 css-dev-only-do-not-override-1etm4mv">
+        <div class="ant-progress-steps-outer">
+          <div class="ant-progress-steps-item ant-progress-steps-item-active" style="width: 20px; height: 20px;"></div>
+          <div class="ant-progress-steps-item ant-progress-steps-item-active" style="width: 20px; height: 20px;"></div>
+          <div class="ant-progress-steps-item" style="width: 20px; height: 20px;"></div><span class="ant-progress-text" title="50%">50%</span>
+        </div>
+      </div>
+    </div>
+    <!---->
+    <div class="ant-space-item">
+      <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-20,30 css-dev-only-do-not-override-1etm4mv">
+        <div class="ant-progress-steps-outer">
+          <div class="ant-progress-steps-item ant-progress-steps-item-active" style="width: 20px; height: 30px;"></div>
+          <div class="ant-progress-steps-item ant-progress-steps-item-active" style="width: 20px; height: 30px;"></div>
+          <div class="ant-progress-steps-item" style="width: 20px; height: 30px;"></div><span class="ant-progress-text" title="50%">50%</span>
+        </div>
+      </div>
+    </div>
+    <!---->
+  </div>
+</div>
+`;
+
 exports[`renders ./components/progress/demo/steps.vue correctly 1`] = `
 <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
   <div class="ant-progress-steps-outer">
@@ -457,6 +639,16 @@ exports[`renders ./components/progress/demo/steps.vue correctly 1`] = `
     <div class="ant-progress-steps-item ant-progress-steps-item-active" style="background-color: rgb(82, 196, 26); width: 2px; height: 8px;"></div>
     <div class="ant-progress-steps-item ant-progress-steps-item-active" style="background-color: rgb(82, 196, 26); width: 2px; height: 8px;"></div>
     <div class="ant-progress-steps-item ant-progress-steps-item-active" style="background-color: rgb(82, 196, 26); width: 2px; height: 8px;"></div><span class="ant-progress-text"><span role="img" aria-label="check-circle" class="anticon anticon-check-circle"><svg focusable="false" class="" data-icon="check-circle" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"></path></svg></span></span>
+  </div>
+</div>
+<br>
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-steps-outer">
+    <div class="ant-progress-steps-item ant-progress-steps-item-active" style="background-color: rgb(82, 196, 26); width: 14px; height: 8px;"></div>
+    <div class="ant-progress-steps-item ant-progress-steps-item-active" style="background-color: rgb(82, 196, 26); width: 14px; height: 8px;"></div>
+    <div class="ant-progress-steps-item ant-progress-steps-item-active" style="background-color: rgb(245, 34, 45); width: 14px; height: 8px;"></div>
+    <div class="ant-progress-steps-item" style="width: 14px; height: 8px;"></div>
+    <div class="ant-progress-steps-item" style="width: 14px; height: 8px;"></div><span class="ant-progress-text" title="60%">60%</span>
   </div>
 </div>
 `;

--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders ./components/progress/demo/circle.vue correctly 1`] = `
-<div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+<div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -15,8 +15,8 @@ exports[`renders ./components/progress/demo/circle.vue correctly 1`] = `
    a 47,47 0 1 1 0,-94" stroke="" stroke-linecap="round" stroke-width="6" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
     </svg><span class="ant-progress-text" title="75%">75%</span></div>
 </div>
-<div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-exception">
-  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+<div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -29,8 +29,8 @@ exports[`renders ./components/progress/demo/circle.vue correctly 1`] = `
    a 47,47 0 1 1 0,-94" stroke="" stroke-linecap="round" stroke-width="6" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
     </svg><span class="ant-progress-text"><span role="img" aria-label="close" class="anticon anticon-close"><svg focusable="false" class="" data-icon="close" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"></path></svg></span></span></div>
 </div>
-<div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-success">
-  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+<div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -47,8 +47,8 @@ exports[`renders ./components/progress/demo/circle.vue correctly 1`] = `
 
 exports[`renders ./components/progress/demo/circle-dynamic.vue correctly 1`] = `
 <div>
-  <div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-normal">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+  <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -61,13 +61,29 @@ exports[`renders ./components/progress/demo/circle-dynamic.vue correctly 1`] = `
    a 47,47 0 1 1 0,-94" stroke="" stroke-linecap="round" stroke-width="6" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
       </svg><span class="ant-progress-text" title="0%">0%</span></div>
   </div>
-  <div class="ant-btn-group"><button class="ant-btn ant-btn-icon-only" type="button"><span role="img" aria-label="minus" class="anticon anticon-minus"><svg focusable="false" class="" data-icon="minus" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M872 474H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h720c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"></path></svg></span></button><button class="ant-btn ant-btn-icon-only" type="button"><span role="img" aria-label="plus" class="anticon anticon-plus"><svg focusable="false" class="" data-icon="plus" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><defs><style></style></defs><path d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"></path><path d="M176 474h672q8 0 8 8v60q0 8-8 8H176q-8 0-8-8v-60q0-8 8-8z"></path></svg></span></button></div>
+  <div class="ant-btn-group css-dev-only-do-not-override-1etm4mv"><button class="css-dev-only-do-not-override-1etm4mv ant-btn ant-btn-default ant-btn-icon-only" type="button"><span role="img" aria-label="minus" class="anticon anticon-minus"><svg focusable="false" class="" data-icon="minus" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M872 474H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h720c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"></path></svg></span></button><button class="css-dev-only-do-not-override-1etm4mv ant-btn ant-btn-default ant-btn-icon-only" type="button"><span role="img" aria-label="plus" class="anticon anticon-plus"><svg focusable="false" class="" data-icon="plus" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><defs><style></style></defs><path d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"></path><path d="M176 474h672q8 0 8 8v60q0 8-8 8H176q-8 0-8-8v-60q0-8 8-8z"></path></svg></span></button></div>
+</div>
+`;
+
+exports[`renders ./components/progress/demo/circle-micro.vue correctly 1`] = `
+<div>
+  <div role="progressbar" class="ant-progress ant-progress-inline-circle ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-12 css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-inner" style="width: 12px; height: 12px; font-size: 7.8px;">
+      <!----><span><svg viewBox="0 0 100 100"><!----><path d="M 50,50 m 0,-40
+   a 40,40 0 1 1 0,80
+   a 40,40 0 1 1 0,-80" stroke="#e6f4ff" stroke-linecap="round" stroke-width="20" fill-opacity="0" class="ant-progress-circle-trail" style="stroke: #e6f4ff; stroke-dasharray: 251.32741228718345px 251.32741228718345px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path><path d="M 50,50 m 0,-40
+   a 40,40 0 1 1 0,80
+   a 40,40 0 1 1 0,-80" stroke="" stroke-linecap="round" stroke-width="20" opacity="1" fill-opacity="0" class="ant-progress-circle-path" style="stroke-dasharray: 150.79644737231007px 251.32741228718345px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path><path d="M 50,50 m 0,-40
+   a 40,40 0 1 1 0,80
+   a 40,40 0 1 1 0,-80" stroke="" stroke-linecap="round" stroke-width="20" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 251.32741228718345px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path></svg></span>
+    </div>
+  </div><span>代码发布</span>
 </div>
 `;
 
 exports[`renders ./components/progress/demo/circle-mini.vue correctly 1`] = `
-<div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-inner" style="width: 80px; height: 80px; font-size: 18px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+<div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-80 css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-inner" style="width: 80px; height: 80px; font-size: 18px;"><svg viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -80,8 +96,8 @@ exports[`renders ./components/progress/demo/circle-mini.vue correctly 1`] = `
    a 47,47 0 1 1 0,-94" stroke="" stroke-linecap="round" stroke-width="6" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
     </svg><span class="ant-progress-text" title="30%">30%</span></div>
 </div>
-<div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-exception">
-  <div class="ant-progress-inner" style="width: 80px; height: 80px; font-size: 18px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+<div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-80 css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-inner" style="width: 80px; height: 80px; font-size: 18px;"><svg viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -94,8 +110,8 @@ exports[`renders ./components/progress/demo/circle-mini.vue correctly 1`] = `
    a 47,47 0 1 1 0,-94" stroke="" stroke-linecap="round" stroke-width="6" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
     </svg><span class="ant-progress-text"><span role="img" aria-label="close" class="anticon anticon-close"><svg focusable="false" class="" data-icon="close" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"></path></svg></span></span></div>
 </div>
-<div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-success">
-  <div class="ant-progress-inner" style="width: 80px; height: 80px; font-size: 18px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+<div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-80 css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-inner" style="width: 80px; height: 80px; font-size: 18px;"><svg viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -112,8 +128,8 @@ exports[`renders ./components/progress/demo/circle-mini.vue correctly 1`] = `
 
 exports[`renders ./components/progress/demo/dashboard.vue correctly 1`] = `
 <div>
-  <div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-normal">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+  <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,47
    a 47,47 0 1 1 0,-94
@@ -131,22 +147,22 @@ exports[`renders ./components/progress/demo/dashboard.vue correctly 1`] = `
 
 exports[`renders ./components/progress/demo/dynamic.vue correctly 1`] = `
 <div>
-  <div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
-    <div class="ant-progress-outer">
+  <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-outer" style="width: 100%; height: 8px;">
       <div class="ant-progress-inner">
         <div class="ant-progress-bg" style="width: 0%; height: 8px;"></div>
         <!---->
       </div>
     </div><span class="ant-progress-text" title="0%">0%</span>
   </div>
-  <div class="ant-btn-group"><button class="ant-btn ant-btn-icon-only" type="button"><span role="img" aria-label="minus" class="anticon anticon-minus"><svg focusable="false" class="" data-icon="minus" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M872 474H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h720c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"></path></svg></span></button><button class="ant-btn ant-btn-icon-only" type="button"><span role="img" aria-label="plus" class="anticon anticon-plus"><svg focusable="false" class="" data-icon="plus" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><defs><style></style></defs><path d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"></path><path d="M176 474h672q8 0 8 8v60q0 8-8 8H176q-8 0-8-8v-60q0-8 8-8z"></path></svg></span></button></div>
+  <div class="ant-btn-group css-dev-only-do-not-override-1etm4mv"><button class="css-dev-only-do-not-override-1etm4mv ant-btn ant-btn-default ant-btn-icon-only" type="button"><span role="img" aria-label="minus" class="anticon anticon-minus"><svg focusable="false" class="" data-icon="minus" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M872 474H152c-4.4 0-8 3.6-8 8v60c0 4.4 3.6 8 8 8h720c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"></path></svg></span></button><button class="css-dev-only-do-not-override-1etm4mv ant-btn ant-btn-default ant-btn-icon-only" type="button"><span role="img" aria-label="plus" class="anticon anticon-plus"><svg focusable="false" class="" data-icon="plus" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><defs><style></style></defs><path d="M482 152h60q8 0 8 8v704q0 8-8 8h-60q-8 0-8-8V160q0-8 8-8z"></path><path d="M176 474h672q8 0 8 8v60q0 8-8 8H176q-8 0-8-8v-60q0-8 8-8z"></path></svg></span></button></div>
 </div>
 `;
 
 exports[`renders ./components/progress/demo/format.vue correctly 1`] = `
 <div>
-  <div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-normal">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+  <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -159,8 +175,8 @@ exports[`renders ./components/progress/demo/format.vue correctly 1`] = `
    a 47,47 0 1 1 0,-94" stroke="" stroke-linecap="round" stroke-width="6" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
       </svg><span class="ant-progress-text" title="75 Days">75 Days</span></div>
   </div>
-  <div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-success">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+  <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -173,8 +189,8 @@ exports[`renders ./components/progress/demo/format.vue correctly 1`] = `
    a 47,47 0 1 1 0,-94" stroke="" stroke-linecap="round" stroke-width="6" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
       </svg><span class="ant-progress-text" title="Done">Done</span></div>
   </div>
-  <div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-normal">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+  <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -192,43 +208,24 @@ exports[`renders ./components/progress/demo/format.vue correctly 1`] = `
 
 exports[`renders ./components/progress/demo/gradient-line.vue correctly 1`] = `
 <div>
-  <div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
-    <div class="ant-progress-outer">
+  <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-outer" style="width: 100%; height: 8px;">
       <div class="ant-progress-inner">
         <div class="ant-progress-bg" style="width: 99.9%; height: 8px;"></div>
         <!---->
       </div>
     </div><span class="ant-progress-text" title="99.9%">99.9%</span>
   </div>
-  <div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-active">
-    <div class="ant-progress-outer">
+  <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-outer" style="width: 100%; height: 8px;">
       <div class="ant-progress-inner">
         <div class="ant-progress-bg" style="width: 99.9%; height: 8px;"></div>
         <!---->
       </div>
     </div><span class="ant-progress-text" title="99.9%">99.9%</span>
   </div>
-  <div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-normal">
-    <div class="ant-progress-inner ant-progress-circle-gradient" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
-        <defs>
-          <linearGradient id="ant-progress-gradient-12" x1="100%" y1="0%" x2="0%" y2="0%">
-            <stop offset="0%" stop-color="#108ee9"></stop>
-            <stop offset="100%" stop-color="#87d068"></stop>
-          </linearGradient>
-        </defs>
-        <path d="M 50,50 m 0,-47
-   a 47,47 0 1 1 0,94
-   a 47,47 0 1 1 0,-94" stroke-linecap="round" stroke-width="6" fill-opacity="0" class="ant-progress-circle-trail" style="stroke-dasharray: 295.3097094374406px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
-        <path d="M 50,50 m 0,-47
-   a 47,47 0 1 1 0,94
-   a 47,47 0 1 1 0,-94" stroke="url(#ant-progress-gradient-12)" stroke-linecap="round" stroke-width="6" opacity="1" fill-opacity="0" class="ant-progress-circle-path" style="stroke: [object Object]; stroke-dasharray: 265.77873849369655px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
-        <path d="M 50,50 m 0,-47
-   a 47,47 0 1 1 0,94
-   a 47,47 0 1 1 0,-94" stroke="" stroke-linecap="round" stroke-width="6" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
-      </svg><span class="ant-progress-text" title="90%">90%</span></div>
-  </div>
-  <div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-success">
-    <div class="ant-progress-inner ant-progress-circle-gradient" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+  <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-inner ant-progress-circle-gradient" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
         <defs>
           <linearGradient id="ant-progress-gradient-13" x1="100%" y1="0%" x2="0%" y2="0%">
             <stop offset="0%" stop-color="#108ee9"></stop>
@@ -240,7 +237,26 @@ exports[`renders ./components/progress/demo/gradient-line.vue correctly 1`] = `
    a 47,47 0 1 1 0,-94" stroke-linecap="round" stroke-width="6" fill-opacity="0" class="ant-progress-circle-trail" style="stroke-dasharray: 295.3097094374406px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
         <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
-   a 47,47 0 1 1 0,-94" stroke="url(#ant-progress-gradient-13)" stroke-linecap="round" stroke-width="6" opacity="1" fill-opacity="0" class="ant-progress-circle-path" style="stroke: [object Object]; stroke-dasharray: 295.3097094374406px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+   a 47,47 0 1 1 0,-94" stroke="url(#ant-progress-gradient-13)" stroke-linecap="round" stroke-width="6" opacity="1" fill-opacity="0" class="ant-progress-circle-path" style="stroke: [object Object]; stroke-dasharray: 265.77873849369655px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+        <path d="M 50,50 m 0,-47
+   a 47,47 0 1 1 0,94
+   a 47,47 0 1 1 0,-94" stroke="" stroke-linecap="round" stroke-width="6" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+      </svg><span class="ant-progress-text" title="90%">90%</span></div>
+  </div>
+  <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-inner ant-progress-circle-gradient" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+        <defs>
+          <linearGradient id="ant-progress-gradient-14" x1="100%" y1="0%" x2="0%" y2="0%">
+            <stop offset="0%" stop-color="#108ee9"></stop>
+            <stop offset="100%" stop-color="#87d068"></stop>
+          </linearGradient>
+        </defs>
+        <path d="M 50,50 m 0,-47
+   a 47,47 0 1 1 0,94
+   a 47,47 0 1 1 0,-94" stroke-linecap="round" stroke-width="6" fill-opacity="0" class="ant-progress-circle-trail" style="stroke-dasharray: 295.3097094374406px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
+        <path d="M 50,50 m 0,-47
+   a 47,47 0 1 1 0,94
+   a 47,47 0 1 1 0,-94" stroke="url(#ant-progress-gradient-14)" stroke-linecap="round" stroke-width="6" opacity="1" fill-opacity="0" class="ant-progress-circle-path" style="stroke: [object Object]; stroke-dasharray: 295.3097094374406px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
         <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
    a 47,47 0 1 1 0,-94" stroke="" stroke-linecap="round" stroke-width="6" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
@@ -250,40 +266,40 @@ exports[`renders ./components/progress/demo/gradient-line.vue correctly 1`] = `
 `;
 
 exports[`renders ./components/progress/demo/line.vue correctly 1`] = `
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-outer">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-outer" style="width: 100%; height: 8px;">
     <div class="ant-progress-inner">
       <div class="ant-progress-bg" style="width: 30%; height: 8px;"></div>
       <!---->
     </div>
   </div><span class="ant-progress-text" title="30%">30%</span>
 </div>
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-active">
-  <div class="ant-progress-outer">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-outer" style="width: 100%; height: 8px;">
     <div class="ant-progress-inner">
       <div class="ant-progress-bg" style="width: 50%; height: 8px;"></div>
       <!---->
     </div>
   </div><span class="ant-progress-text" title="50%">50%</span>
 </div>
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-exception">
-  <div class="ant-progress-outer">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-exception ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-outer" style="width: 100%; height: 8px;">
     <div class="ant-progress-inner">
       <div class="ant-progress-bg" style="width: 70%; height: 8px;"></div>
       <!---->
     </div>
   </div><span class="ant-progress-text"><span role="img" aria-label="close-circle" class="anticon anticon-close-circle"><svg focusable="false" class="" data-icon="close-circle" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"></path></svg></span></span>
 </div>
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-success">
-  <div class="ant-progress-outer">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-outer" style="width: 100%; height: 8px;">
     <div class="ant-progress-inner">
       <div class="ant-progress-bg" style="width: 100%; height: 8px;"></div>
       <!---->
     </div>
   </div><span class="ant-progress-text"><span role="img" aria-label="check-circle" class="anticon anticon-check-circle"><svg focusable="false" class="" data-icon="check-circle" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"></path></svg></span></span>
 </div>
-<div class="ant-progress ant-progress-line ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-outer">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-outer" style="width: 100%; height: 8px;">
     <div class="ant-progress-inner">
       <div class="ant-progress-bg" style="width: 50%; height: 8px;"></div>
       <!---->
@@ -295,32 +311,32 @@ exports[`renders ./components/progress/demo/line.vue correctly 1`] = `
 
 exports[`renders ./components/progress/demo/line-mini.vue correctly 1`] = `
 <div style="width: 170px;">
-  <div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-small ant-progress-status-normal">
-    <div class="ant-progress-outer">
+  <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-small css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-outer" style="width: 100%; height: 6px;">
       <div class="ant-progress-inner">
         <div class="ant-progress-bg" style="width: 30%; height: 6px;"></div>
         <!---->
       </div>
     </div><span class="ant-progress-text" title="30%">30%</span>
   </div>
-  <div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-small ant-progress-status-active">
-    <div class="ant-progress-outer">
+  <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-active ant-progress-show-info ant-progress-small css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-outer" style="width: 100%; height: 6px;">
       <div class="ant-progress-inner">
         <div class="ant-progress-bg" style="width: 50%; height: 6px;"></div>
         <!---->
       </div>
     </div><span class="ant-progress-text" title="50%">50%</span>
   </div>
-  <div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-small ant-progress-status-exception">
-    <div class="ant-progress-outer">
+  <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-exception ant-progress-show-info ant-progress-small css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-outer" style="width: 100%; height: 6px;">
       <div class="ant-progress-inner">
         <div class="ant-progress-bg" style="width: 70%; height: 6px;"></div>
         <!---->
       </div>
     </div><span class="ant-progress-text"><span role="img" aria-label="close-circle" class="anticon anticon-close-circle"><svg focusable="false" class="" data-icon="close-circle" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"></path></svg></span></span>
   </div>
-  <div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-small ant-progress-status-success">
-    <div class="ant-progress-outer">
+  <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-small css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-outer" style="width: 100%; height: 6px;">
       <div class="ant-progress-inner">
         <div class="ant-progress-bg" style="width: 100%; height: 6px;"></div>
         <!---->
@@ -332,16 +348,16 @@ exports[`renders ./components/progress/demo/line-mini.vue correctly 1`] = `
 
 exports[`renders ./components/progress/demo/linecap.vue correctly 1`] = `
 <div>
-  <div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
-    <div class="ant-progress-outer">
+  <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-outer" style="width: 100%; height: 8px;">
       <div class="ant-progress-inner">
         <div class="ant-progress-bg" style="width: 75%; height: 8px; border-radius: 0;"></div>
         <!---->
       </div>
     </div><span class="ant-progress-text" title="75%">75%</span>
   </div>
-  <div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-normal">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+  <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -354,8 +370,8 @@ exports[`renders ./components/progress/demo/linecap.vue correctly 1`] = `
    a 47,47 0 1 1 0,-94" stroke="" stroke-linecap="square" stroke-width="6" opacity="0" fill-opacity="0" class="ant-progress-circle-path" style="stroke: #52C41A; stroke-dasharray: 0px 295.3097094374406px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path>
       </svg><span class="ant-progress-text" title="75%">75%</span></div>
   </div>
-  <div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-normal">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+  <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,47
    a 47,47 0 1 1 0,-94
@@ -374,8 +390,8 @@ exports[`renders ./components/progress/demo/linecap.vue correctly 1`] = `
 exports[`renders ./components/progress/demo/segment.vue correctly 1`] = `
 <div>
   <!---->
-  <div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
-    <div class="ant-progress-outer">
+  <div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-outer" style="width: 100%; height: 8px;">
       <div class="ant-progress-inner">
         <div class="ant-progress-bg" style="width: 60%; height: 8px;"></div>
         <div class="ant-progress-success-bg" style="width: 30%; height: 8px;"></div>
@@ -383,8 +399,8 @@ exports[`renders ./components/progress/demo/segment.vue correctly 1`] = `
     </div><span class="ant-progress-text" title="60%">60%</span>
   </div>
   <!---->
-  <div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-normal">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+  <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -398,8 +414,8 @@ exports[`renders ./components/progress/demo/segment.vue correctly 1`] = `
       </svg><span class="ant-progress-text" title="60%">60%</span></div>
   </div>
   <!---->
-  <div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-normal">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+  <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,47
    a 47,47 0 1 1 0,-94
@@ -416,7 +432,7 @@ exports[`renders ./components/progress/demo/segment.vue correctly 1`] = `
 `;
 
 exports[`renders ./components/progress/demo/steps.vue correctly 1`] = `
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
   <div class="ant-progress-steps-outer">
     <div class="ant-progress-steps-item ant-progress-steps-item-active" style="width: 14px; height: 8px;"></div>
     <div class="ant-progress-steps-item ant-progress-steps-item-active" style="width: 14px; height: 8px;"></div>
@@ -424,7 +440,7 @@ exports[`renders ./components/progress/demo/steps.vue correctly 1`] = `
   </div>
 </div>
 <br>
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
   <div class="ant-progress-steps-outer">
     <div class="ant-progress-steps-item ant-progress-steps-item-active" style="width: 14px; height: 8px;"></div>
     <div class="ant-progress-steps-item ant-progress-steps-item-active" style="width: 14px; height: 8px;"></div>
@@ -434,7 +450,7 @@ exports[`renders ./components/progress/demo/steps.vue correctly 1`] = `
   </div>
 </div>
 <br>
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-small ant-progress-status-success">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-small css-dev-only-do-not-override-1etm4mv">
   <div class="ant-progress-steps-outer">
     <div class="ant-progress-steps-item ant-progress-steps-item-active" style="background-color: rgb(82, 196, 26); width: 2px; height: 8px;"></div>
     <div class="ant-progress-steps-item ant-progress-steps-item-active" style="background-color: rgb(82, 196, 26); width: 2px; height: 8px;"></div>

--- a/components/progress/__tests__/__snapshots__/demo.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/demo.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`renders ./components/progress/demo/circle.vue correctly 1`] = `
 <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -16,7 +16,7 @@ exports[`renders ./components/progress/demo/circle.vue correctly 1`] = `
     </svg><span class="ant-progress-text" title="75%">75%</span></div>
 </div>
 <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -30,7 +30,7 @@ exports[`renders ./components/progress/demo/circle.vue correctly 1`] = `
     </svg><span class="ant-progress-text"><span role="img" aria-label="close" class="anticon anticon-close"><svg focusable="false" class="" data-icon="close" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"></path></svg></span></span></div>
 </div>
 <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -48,7 +48,7 @@ exports[`renders ./components/progress/demo/circle.vue correctly 1`] = `
 exports[`renders ./components/progress/demo/circle-dynamic.vue correctly 1`] = `
 <div>
   <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -69,7 +69,7 @@ exports[`renders ./components/progress/demo/circle-micro.vue correctly 1`] = `
 <div>
   <div role="progressbar" class="ant-progress ant-progress-inline-circle ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-12 css-dev-only-do-not-override-1etm4mv">
     <div class="ant-progress-inner" style="width: 12px; height: 12px; font-size: 7.8px;">
-      <!----><span><svg viewBox="0 0 100 100"><!----><path d="M 50,50 m 0,-40
+      <!----><span><svg class="ant-progress-circle" viewBox="0 0 100 100"><!----><path d="M 50,50 m 0,-40
    a 40,40 0 1 1 0,80
    a 40,40 0 1 1 0,-80" stroke="#e6f4ff" stroke-linecap="round" stroke-width="20" fill-opacity="0" class="ant-progress-circle-trail" style="stroke: #e6f4ff; stroke-dasharray: 251.32741228718345px 251.32741228718345px; stroke-dashoffset: -0px; transition: stroke-dashoffset .3s ease 0s, stroke-dasharray .3s ease 0s, stroke .3s, stroke-width .06s ease .3s, opacity .3s ease 0s;"></path><path d="M 50,50 m 0,-40
    a 40,40 0 1 1 0,80
@@ -83,7 +83,7 @@ exports[`renders ./components/progress/demo/circle-micro.vue correctly 1`] = `
 
 exports[`renders ./components/progress/demo/circle-mini.vue correctly 1`] = `
 <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-80 css-dev-only-do-not-override-1etm4mv">
-  <div class="ant-progress-inner" style="width: 80px; height: 80px; font-size: 18px;"><svg viewBox="0 0 100 100">
+  <div class="ant-progress-inner" style="width: 80px; height: 80px; font-size: 18px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -97,7 +97,7 @@ exports[`renders ./components/progress/demo/circle-mini.vue correctly 1`] = `
     </svg><span class="ant-progress-text" title="30%">30%</span></div>
 </div>
 <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-exception ant-progress-show-info ant-progress-80 css-dev-only-do-not-override-1etm4mv">
-  <div class="ant-progress-inner" style="width: 80px; height: 80px; font-size: 18px;"><svg viewBox="0 0 100 100">
+  <div class="ant-progress-inner" style="width: 80px; height: 80px; font-size: 18px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -111,7 +111,7 @@ exports[`renders ./components/progress/demo/circle-mini.vue correctly 1`] = `
     </svg><span class="ant-progress-text"><span role="img" aria-label="close" class="anticon anticon-close"><svg focusable="false" class="" data-icon="close" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"></path></svg></span></span></div>
 </div>
 <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-80 css-dev-only-do-not-override-1etm4mv">
-  <div class="ant-progress-inner" style="width: 80px; height: 80px; font-size: 18px;"><svg viewBox="0 0 100 100">
+  <div class="ant-progress-inner" style="width: 80px; height: 80px; font-size: 18px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -129,7 +129,7 @@ exports[`renders ./components/progress/demo/circle-mini.vue correctly 1`] = `
 exports[`renders ./components/progress/demo/dashboard.vue correctly 1`] = `
 <div>
   <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,47
    a 47,47 0 1 1 0,-94
@@ -162,7 +162,7 @@ exports[`renders ./components/progress/demo/dynamic.vue correctly 1`] = `
 exports[`renders ./components/progress/demo/format.vue correctly 1`] = `
 <div>
   <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -176,7 +176,7 @@ exports[`renders ./components/progress/demo/format.vue correctly 1`] = `
       </svg><span class="ant-progress-text" title="75 Days">75 Days</span></div>
   </div>
   <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -190,7 +190,7 @@ exports[`renders ./components/progress/demo/format.vue correctly 1`] = `
       </svg><span class="ant-progress-text" title="Done">Done</span></div>
   </div>
   <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -225,7 +225,7 @@ exports[`renders ./components/progress/demo/gradient-line.vue correctly 1`] = `
     </div><span class="ant-progress-text" title="99.9%">99.9%</span>
   </div>
   <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-    <div class="ant-progress-inner ant-progress-circle-gradient" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+    <div class="ant-progress-inner ant-progress-circle-gradient" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
         <defs>
           <linearGradient id="ant-progress-gradient-13" x1="100%" y1="0%" x2="0%" y2="0%">
             <stop offset="0%" stop-color="#108ee9"></stop>
@@ -244,7 +244,7 @@ exports[`renders ./components/progress/demo/gradient-line.vue correctly 1`] = `
       </svg><span class="ant-progress-text" title="90%">90%</span></div>
   </div>
   <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-success ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-    <div class="ant-progress-inner ant-progress-circle-gradient" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+    <div class="ant-progress-inner ant-progress-circle-gradient" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
         <defs>
           <linearGradient id="ant-progress-gradient-14" x1="100%" y1="0%" x2="0%" y2="0%">
             <stop offset="0%" stop-color="#108ee9"></stop>
@@ -357,7 +357,7 @@ exports[`renders ./components/progress/demo/linecap.vue correctly 1`] = `
     </div><span class="ant-progress-text" title="75%">75%</span>
   </div>
   <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -371,7 +371,7 @@ exports[`renders ./components/progress/demo/linecap.vue correctly 1`] = `
       </svg><span class="ant-progress-text" title="75%">75%</span></div>
   </div>
   <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,47
    a 47,47 0 1 1 0,-94
@@ -400,7 +400,7 @@ exports[`renders ./components/progress/demo/segment.vue correctly 1`] = `
   </div>
   <!---->
   <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -415,7 +415,7 @@ exports[`renders ./components/progress/demo/segment.vue correctly 1`] = `
   </div>
   <!---->
   <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+    <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
         <!---->
         <path d="M 50,50 m 0,47
    a 47,47 0 1 1 0,-94

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Progress render dashboard 295 gapDegree 1`] = `
-<div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+<div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,47
    a 47,47 0 1 1 0,-94
@@ -18,8 +18,8 @@ exports[`Progress render dashboard 295 gapDegree 1`] = `
 `;
 
 exports[`Progress render dashboard 296 gapDegree 1`] = `
-<div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+<div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,47
    a 47,47 0 1 1 0,-94
@@ -35,8 +35,8 @@ exports[`Progress render dashboard 296 gapDegree 1`] = `
 `;
 
 exports[`Progress render dashboard zero gapDegree 1`] = `
-<div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+<div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,47
    a 47,47 0 1 1 0,-94
@@ -52,8 +52,8 @@ exports[`Progress render dashboard zero gapDegree 1`] = `
 `;
 
 exports[`Progress render format 1`] = `
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-outer">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-outer" style="width: 100%; height: 8px;">
     <div class="ant-progress-inner">
       <div class="ant-progress-bg" style="width: 50%; height: 8px;"></div>
       <div class="ant-progress-success-bg" style="width: 10%; height: 8px;"></div>
@@ -63,8 +63,8 @@ exports[`Progress render format 1`] = `
 `;
 
 exports[`Progress render negative progress 1`] = `
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-outer">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-outer" style="width: 100%; height: 8px;">
     <div class="ant-progress-inner">
       <div class="ant-progress-bg" style="width: 0%; height: 8px;"></div>
       <!---->
@@ -74,8 +74,8 @@ exports[`Progress render negative progress 1`] = `
 `;
 
 exports[`Progress render negative successPercent 1`] = `
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-outer">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-outer" style="width: 100%; height: 8px;">
     <div class="ant-progress-inner">
       <div class="ant-progress-bg" style="width: 50%; height: 8px;"></div>
       <div class="ant-progress-success-bg" style="width: 0%; height: 8px;"></div>
@@ -85,8 +85,8 @@ exports[`Progress render negative successPercent 1`] = `
 `;
 
 exports[`Progress render normal progress 1`] = `
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-outer">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-outer" style="width: 100%; height: 8px;">
     <div class="ant-progress-inner">
       <div class="ant-progress-bg" style="width: 0%; height: 8px;"></div>
       <!---->
@@ -96,8 +96,8 @@ exports[`Progress render normal progress 1`] = `
 `;
 
 exports[`Progress render out-of-range progress 1`] = `
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-success">
-  <div class="ant-progress-outer">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-outer" style="width: 100%; height: 8px;">
     <div class="ant-progress-inner">
       <div class="ant-progress-bg" style="width: 100%; height: 8px;"></div>
       <!---->
@@ -107,8 +107,8 @@ exports[`Progress render out-of-range progress 1`] = `
 `;
 
 exports[`Progress render out-of-range progress with info 1`] = `
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-success">
-  <div class="ant-progress-outer">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-success ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-outer" style="width: 100%; height: 8px;">
     <div class="ant-progress-inner">
       <div class="ant-progress-bg" style="width: 100%; height: 8px;"></div>
       <!---->
@@ -118,8 +118,8 @@ exports[`Progress render out-of-range progress with info 1`] = `
 `;
 
 exports[`Progress render strokeColor 1`] = `
-<div class="ant-progress ant-progress-circle ant-progress-show-info ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
+<div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94
@@ -135,8 +135,8 @@ exports[`Progress render strokeColor 1`] = `
 `;
 
 exports[`Progress render strokeColor 2`] = `
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-outer">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-outer" style="width: 100%; height: 8px;">
     <div class="ant-progress-inner">
       <div class="ant-progress-bg" style="width: 50%; height: 8px;"></div>
       <!---->
@@ -146,8 +146,8 @@ exports[`Progress render strokeColor 2`] = `
 `;
 
 exports[`Progress render strokeColor 3`] = `
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-outer">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-outer" style="width: 100%; height: 8px;">
     <div class="ant-progress-inner">
       <div class="ant-progress-bg" style="width: 50%; height: 8px;"></div>
       <!---->
@@ -157,8 +157,8 @@ exports[`Progress render strokeColor 3`] = `
 `;
 
 exports[`Progress render successColor progress 1`] = `
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-outer">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-outer" style="width: 100%; height: 8px;">
     <div class="ant-progress-inner">
       <div class="ant-progress-bg" style="width: 60%; height: 8px;"></div>
       <div class="ant-progress-success-bg" style="width: 30%; height: 8px; background-color: rgb(255, 255, 255);"></div>
@@ -168,8 +168,8 @@ exports[`Progress render successColor progress 1`] = `
 `;
 
 exports[`Progress render trailColor progress 1`] = `
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
-  <div class="ant-progress-outer">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
+  <div class="ant-progress-outer" style="width: 100%; height: 8px;">
     <div class="ant-progress-inner" style="background-color: rgb(255, 255, 255);">
       <div class="ant-progress-bg" style="width: 0%; height: 8px;"></div>
       <!---->
@@ -179,7 +179,7 @@ exports[`Progress render trailColor progress 1`] = `
 `;
 
 exports[`Progress should support steps 1`] = `
-<div class="ant-progress ant-progress-line ant-progress-show-info ant-progress-default ant-progress-status-normal">
+<div role="progressbar" class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
   <div class="ant-progress-steps-outer">
     <div class="ant-progress-steps-item" style="width: 14px; height: 8px;"></div>
     <div class="ant-progress-steps-item" style="width: 14px; height: 8px;"></div>

--- a/components/progress/__tests__/__snapshots__/index.test.js.snap
+++ b/components/progress/__tests__/__snapshots__/index.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Progress render dashboard 295 gapDegree 1`] = `
 <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,47
    a 47,47 0 1 1 0,-94
@@ -19,7 +19,7 @@ exports[`Progress render dashboard 295 gapDegree 1`] = `
 
 exports[`Progress render dashboard 296 gapDegree 1`] = `
 <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,47
    a 47,47 0 1 1 0,-94
@@ -36,7 +36,7 @@ exports[`Progress render dashboard 296 gapDegree 1`] = `
 
 exports[`Progress render dashboard zero gapDegree 1`] = `
 <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,47
    a 47,47 0 1 1 0,-94
@@ -119,7 +119,7 @@ exports[`Progress render out-of-range progress with info 1`] = `
 
 exports[`Progress render strokeColor 1`] = `
 <div role="progressbar" class="ant-progress ant-progress-circle ant-progress-status-normal ant-progress-show-info ant-progress-default css-dev-only-do-not-override-1etm4mv">
-  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg viewBox="0 0 100 100">
+  <div class="ant-progress-inner" style="width: 120px; height: 120px; font-size: 24px;"><svg class="ant-progress-circle" viewBox="0 0 100 100">
       <!---->
       <path d="M 50,50 m 0,-47
    a 47,47 0 1 1 0,94

--- a/components/progress/demo/circle-micro.vue
+++ b/components/progress/demo/circle-micro.vue
@@ -1,0 +1,32 @@
+<docs>
+---
+order: 13
+title:
+  zh-CN: 响应式进度圈
+  en-US: Responsive circular progress bar
+---
+
+## zh-CN
+
+响应式的圈形进度，当 `width` 小于等于 20 的时候，进度信息将不会显示在进度圈里面，而是以 Tooltip 的形式显示。
+
+## en-US
+
+Responsive circular progress bar. When `width` is smaller than 20, progress information will be displayed in Tooltip.
+
+
+</docs>
+
+<template>
+  <div>
+    <a-progress
+      type="circle"
+      trail-color="#e6f4ff"
+      :percent="60"
+      :stroke-width="20"
+      :size="12"
+      :format="number => `进行中，已完成${number}%`"
+    />
+    <span :style="{ marginLeft: 8 }">代码发布</span>
+  </div>
+</template>

--- a/components/progress/demo/circle-mini.vue
+++ b/components/progress/demo/circle-mini.vue
@@ -17,7 +17,7 @@ A smaller circular progress bar.
 </docs>
 
 <template>
-  <a-progress type="circle" :percent="30" :width="80" />
-  <a-progress type="circle" :percent="70" :width="80" status="exception" />
-  <a-progress type="circle" :percent="100" :width="80" />
+  <a-progress type="circle" :percent="30" :size="80" />
+  <a-progress type="circle" :percent="70" :size="80" status="exception" />
+  <a-progress type="circle" :percent="100" :size="80" />
 </template>

--- a/components/progress/demo/index.vue
+++ b/components/progress/demo/index.vue
@@ -13,6 +13,7 @@
     <line-cap />
     <gradient-line />
     <steps />
+    <Size />
   </demo-sort>
 </template>
 <script lang="ts">
@@ -32,6 +33,7 @@ import CircleMicro from './circle-micro.vue';
 import CN from '../index.zh-CN.md';
 import US from '../index.en-US.md';
 import { defineComponent } from 'vue';
+import Size from './size.vue';
 
 export default defineComponent({
   CN,
@@ -50,6 +52,7 @@ export default defineComponent({
     GradientLine,
     Steps,
     CircleMicro,
+    Size,
   },
   setup() {
     return {};

--- a/components/progress/demo/index.vue
+++ b/components/progress/demo/index.vue
@@ -4,6 +4,7 @@
     <circle-demo />
     <line-mini />
     <circle-mini />
+    <circle-micro />
     <dynamic />
     <circle-dynamic />
     <format />
@@ -27,6 +28,7 @@ import Segment from './segment.vue';
 import LineCap from './linecap.vue';
 import GradientLine from './gradient-line.vue';
 import Steps from './steps.vue';
+import CircleMicro from './circle-micro.vue';
 import CN from '../index.zh-CN.md';
 import US from '../index.en-US.md';
 import { defineComponent } from 'vue';
@@ -47,6 +49,7 @@ export default defineComponent({
     LineCap,
     GradientLine,
     Steps,
+    CircleMicro,
   },
   setup() {
     return {};

--- a/components/progress/demo/size.vue
+++ b/components/progress/demo/size.vue
@@ -1,0 +1,49 @@
+<docs>
+---
+order: 11
+title:
+  zh-CN: 进度条尺寸
+  en-US: Progress bar size
+---
+
+## zh-CN
+
+进度条尺寸。
+
+## en-US
+
+The size of progress.
+
+</docs>
+
+<template>
+  <div>
+    <a-space direction="vertical" style="width: 50%">
+      <a-progress :percent="50" />
+      <a-progress :percent="50" size="small" />
+      <a-progress :percent="50" :size="[300, 20]" />
+    </a-space>
+    <br />
+    <br />
+    <a-space :size="30">
+      <a-progress type="circle" :percent="50" />
+      <a-progress type="circle" :percent="50" size="small" />
+      <a-progress type="circle" :percent="50" :size="20" />
+    </a-space>
+    <br />
+    <br />
+    <a-space :size="30">
+      <a-progress type="dashboard" :percent="50" />
+      <a-progress type="dashboard" :percent="50" size="small" />
+      <a-progress type="dashboard" :percent="50" :size="20" />
+    </a-space>
+    <br />
+    <br />
+    <a-space :size="30">
+      <a-progress :steps="3" :percent="50" />
+      <a-progress :steps="3" :percent="50" size="small" />
+      <a-progress :steps="3" :percent="50" :size="20" />
+      <a-progress :steps="3" :percent="50" :size="[20, 30]" />
+    </a-space>
+  </div>
+</template>

--- a/components/progress/demo/steps.vue
+++ b/components/progress/demo/steps.vue
@@ -22,4 +22,6 @@ A progress bar with steps.
   <a-progress :percent="30" :steps="5" />
   <br />
   <a-progress :percent="100" :steps="5" size="small" stroke-color="#52c41a" />
+  <br />
+  <a-progress :percent="60" :steps="5" :stroke-color="['#52c41a', '#52c41a', '#f5222d']" />
 </template>

--- a/components/progress/index.en-US.md
+++ b/components/progress/index.en-US.md
@@ -24,30 +24,28 @@ Properties that shared by all types.
 | format | The template function of the content | function(percent, successPercent) | (percent) => percent + `%` |  |
 | percent | To set the completion percentage | number | 0 |  |
 | showInfo | Whether to display the progress value and the status icon | boolean | true |  |
-| size | To set the size of the progress | `default` \| `small` | `default` |
 | status | To set the status of the Progress, options: `success` `exception` `normal` `active`(line only) | string | - |  |
 | strokeColor | The color of progress bar | string | - |  |
-| strokeLinecap | To set the style of the progress linecap | `round` \| `square` | `round` |  |
+| strokeLinecap | To set the style of the progress linecap | `round` \| `butt` \| `square`, see [stroke-linecap](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-linecap) | `round` | - |
 | success | Configs of successfully progress bar | { percent: number, strokeColor: string } | - |  |
 | title | html dom title | string | - | 3.0 |
 | trailColor | The color of unfilled part | string | - |  |
 | type | To set the type, options: `line` `circle` `dashboard` | string | `line` |  |
+| size | Progress size | number \| \[number, number] \| "small" \| "default" | "default" |  |
 
 ### `type="line"`
 
-| Property | Description | Type | Default |
-| --- | --- | --- | --- |
-| steps | The total step count | number | - |
-| strokeColor | The color of progress bar, render `linear-gradient` when passing an object | string \| { from: string; to: string; direction: string } | - |
-| strokeWidth | To set the width of the progress bar, unit: `px` | number | 10 |
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| steps | The total step count | number | - | - |
+| strokeColor | The color of progress bar, render `linear-gradient` when passing an object, could accept `string[]` when has `steps`. | string \| string[] \| { from: string; to: string; direction: string } | - | - |
 
 ### `type="circle"`
 
-| Property | Description | Type | Default |
-| --- | --- | --- | --- |
-| strokeColor | The color of circular progress, render `linear-gradient` when passing an object | string \| object | - |
-| strokeWidth | To set the width of the circular progress, unit: percentage of the canvas width | number | 6 |
-| width | To set the canvas width of the circular progress, unit: `px` | number | 132 |
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| strokeColor | The color of circular progress, render `linear-gradient` when passing an object | string \| object | - | - |
+| strokeWidth | To set the width of the circular progress, unit: percentage of the canvas width | number | 6 | - |
 
 ### `type="dashboard"`
 
@@ -56,4 +54,3 @@ Properties that shared by all types.
 | gapDegree | The gap degree of half circle, 0 ~ 295 | number | 75 |
 | gapPosition | The gap position, options: `top` `bottom` `left` `right` | string | `bottom` |
 | strokeWidth | To set the width of the dashboard progress, unit: percentage of the canvas width | number | 6 |
-| width | To set the canvas width of the dashboard progress, unit: `px` | number | 132 |

--- a/components/progress/index.zh-CN.md
+++ b/components/progress/index.zh-CN.md
@@ -25,36 +25,33 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*HJH8Tb1lcYAAAA
 | format | 内容的模板函数 | function(percent, successPercent) | (percent) => percent + `%` |  |
 | percent | 百分比 | number | 0 |  |
 | showInfo | 是否显示进度数值或状态图标 | boolean | true |  |
-| size | 进度条大小 | `default` \| `small` | `default` |
 | status | 状态，可选：`success` `exception` `normal` `active`(仅限 line) | string | - |  |
 | strokeColor | 进度条的色彩 | string | - |  |
-| strokeLinecap | 进度条的样式 | `round` \| `square` | `round` |  |
+| strokeLinecap | 进度条的样式 | `round` \| `butt` \| `square`，区别详见 [stroke-linecap](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-linecap) | `round` | - |
 | success | 成功进度条相关配置 | { percent: number, strokeColor: string } | - |  |
 | title | html 标签 title | string | - | 3.0 |
 | trailColor | 未完成的分段的颜色 | string | - |  |
 | type | 类型，可选 `line` `circle` `dashboard` | string | `line` |  |
+| size | 进度条的尺寸 | number \| \[number, number] \| "small" \| "default" | "default" |  |
 
 ### `type="line"`
 
-| 属性 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| steps | 进度条总共步数 | number | - |
-| strokeColor | 进度条的色彩，传入 object 时为渐变 | string \| { from: string; to: string; direction: string } | - |
-| strokeWidth | 进度条线的宽度，单位 px | number | 10 |
+| 属性 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| steps | 进度条总共步数 | number | - | - |
+| strokeColor | 进度条的色彩，传入 object 时为渐变。当有 `steps` 时支持传入一个数组。 | string \| string[] \| { from: string; to: string; direction: string } | - | - |
 
 ### `type="circle"`
 
-| 属性        | 说明                                             | 类型             | 默认值 |
-| ----------- | ------------------------------------------------ | ---------------- | ------ |
-| strokeColor | 圆形进度条线的色彩，传入 object 时为渐变         | string \| object | -      |
-| strokeWidth | 圆形进度条线的宽度，单位是进度条画布宽度的百分比 | number           | 6      |
-| width       | 圆形进度条画布宽度，单位 px                      | number           | 132    |
+| 属性 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| strokeColor | 圆形进度条线的色彩，传入 object 时为渐变 | string \| object | - | - |
+| strokeWidth | 圆形进度条线的宽度，单位是进度条画布宽度的百分比 | number | 6 | - |
 
 ### `type="dashboard"`
 
-| 属性 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| gapDegree | 仪表盘进度条缺口角度，可取值 0 ~ 295 | number | 75 |
-| gapPosition | 仪表盘进度条缺口位置 | `top` \| `bottom` \| `left` \| `right` | `bottom` |
-| strokeWidth | 仪表盘进度条线的宽度，单位是进度条画布宽度的百分比 | number | 6 |
-| width | 仪表盘进度条画布宽度，单位 px | number | 132 |
+| 属性 | 说明 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| gapDegree | 仪表盘进度条缺口角度，可取值 0 ~ 295 | number | 75 | - |
+| gapPosition | 仪表盘进度条缺口位置 | `top` \| `bottom` \| `left` \| `right` | `bottom` | - |
+| strokeWidth | 仪表盘进度条线的宽度，单位是进度条画布宽度的百分比 | number | 6 | - |

--- a/components/progress/props.ts
+++ b/components/progress/props.ts
@@ -1,5 +1,5 @@
 import type { VueNode } from '../_util/type';
-import { functionType, stringType, anyType, objectType } from '../_util/type';
+import { someType, functionType, stringType, anyType, objectType } from '../_util/type';
 import type { ExtractPropTypes } from 'vue';
 
 export const progressStatuses = ['normal', 'exception', 'active', 'success'] as const;
@@ -7,7 +7,7 @@ export type ProgressStatusesType = (typeof progressStatuses)[number];
 const ProgressType = ['line', 'circle', 'dashboard'] as const;
 export type ProgressType = (typeof ProgressType)[number];
 const ProgressSize = ['default', 'small'] as const;
-export type ProgressSize = (typeof ProgressSize)[number];
+export type ProgressSize = (typeof ProgressSize)[number] | number | [number, number];
 export type StringGradients = { [percentage: string]: string };
 type FromToGradients = { from: string; to: string };
 export type ProgressGradient = { direction?: string } & (StringGradients | FromToGradients);
@@ -28,17 +28,19 @@ export const progressProps = () => ({
   showInfo: { type: Boolean, default: undefined },
   strokeWidth: Number,
   strokeLinecap: stringType<'butt' | 'square' | 'round'>(),
-  strokeColor: anyType<string | ProgressGradient>(),
+  strokeColor: anyType<string | string[] | ProgressGradient>(),
   trailColor: String,
+  /** @deprecated Use `size` instead */
   width: Number,
   success: objectType<SuccessProps>(),
   gapDegree: Number,
   gapPosition: stringType<'top' | 'bottom' | 'left' | 'right'>(),
-  size: stringType<ProgressSize>(),
+  size: someType<ProgressSize>([String, Number, Array]),
   steps: Number,
   /** @deprecated Use `success` instead */
   successPercent: Number,
   title: String,
+  progressStatus: stringType<ProgressStatusesType>(),
 });
 
 export type ProgressProps = Partial<ExtractPropTypes<ReturnType<typeof progressProps>>>;

--- a/components/progress/utils.ts
+++ b/components/progress/utils.ts
@@ -42,3 +42,55 @@ export function getStrokeColor({
   const { strokeColor: successColor } = success;
   return [successColor || presetPrimaryColors.green, strokeColor || null!];
 }
+
+export const getSize = (
+  size: ProgressProps['size'],
+  type: ProgressProps['type'] | 'step',
+  extra?: {
+    steps?: number;
+    strokeWidth?: number;
+  },
+): { width: number; height: number } => {
+  let width = -1;
+  let height = -1;
+  if (type === 'step') {
+    const steps = extra!.steps!;
+    const strokeWidth = extra!.strokeWidth!;
+    if (typeof size === 'string' || typeof size === 'undefined') {
+      width = size === 'small' ? 2 : 14;
+      height = strokeWidth ?? 8;
+    } else if (typeof size === 'number') {
+      [width, height] = [size, size];
+    } else {
+      [width = 14, height = 8] = size;
+    }
+    width *= steps;
+  } else if (type === 'line') {
+    const strokeWidth = extra?.strokeWidth;
+    if (typeof size === 'string' || typeof size === 'undefined') {
+      height = strokeWidth || (size === 'small' ? 6 : 8);
+    } else if (typeof size === 'number') {
+      [width, height] = [size, size];
+    } else {
+      [width = -1, height = 8] = size;
+    }
+  } else if (type === 'circle' || type === 'dashboard') {
+    if (typeof size === 'string' || typeof size === 'undefined') {
+      [width, height] = size === 'small' ? [60, 60] : [120, 120];
+    } else if (typeof size === 'number') {
+      [width, height] = [size, size];
+    } else {
+      if (process.env.NODE_ENV !== 'production') {
+        devWarning(
+          false,
+          'Progress',
+          'Type "circle" and "dashboard" do not accept array as `size`, please use number or preset size instead.',
+        );
+      }
+
+      width = size[0] ?? size[1] ?? 120;
+      height = size[0] ?? size[1] ?? 120;
+    }
+  }
+  return { width, height };
+};

--- a/components/vc-progress/src/Circle.tsx
+++ b/components/vc-progress/src/Circle.tsx
@@ -4,7 +4,6 @@ import { propTypes } from './types';
 import { computed, defineComponent, ref } from 'vue';
 import initDefaultProps from '../../_util/props-util/initDefaultProps';
 import useRefs from '../../_util/hooks/useRefs';
-import classNames from '../../_util/classNames';
 
 let gradientSeed = 0;
 
@@ -127,7 +126,6 @@ export default defineComponent({
         trailColor,
         strokeLinecap,
         strokeColor,
-        class: className,
         ...restProps
       } = props;
       const { pathString, pathStyle } = getPathStyles(
@@ -152,11 +150,7 @@ export default defineComponent({
         style: pathStyle,
       };
       return (
-        <svg
-          class={classNames(`${prefixCls}-circle`, className)}
-          viewBox="0 0 100 100"
-          {...restProps}
-        >
+        <svg class={`${prefixCls}-circle`} viewBox="0 0 100 100" {...restProps}>
           {gradient && (
             <defs>
               <linearGradient

--- a/components/vc-progress/src/Circle.tsx
+++ b/components/vc-progress/src/Circle.tsx
@@ -4,6 +4,7 @@ import { propTypes } from './types';
 import { computed, defineComponent, ref } from 'vue';
 import initDefaultProps from '../../_util/props-util/initDefaultProps';
 import useRefs from '../../_util/hooks/useRefs';
+import classNames from '../../_util/classNames';
 
 let gradientSeed = 0;
 
@@ -151,7 +152,11 @@ export default defineComponent({
       };
 
       return (
-        <svg class={`${prefixCls}-circle`} viewBox="0 0 100 100" {...restProps}>
+        <svg
+          class={classNames(`${prefixCls}-circle`, props.class)}
+          viewBox="0 0 100 100"
+          {...restProps}
+        >
           {gradient && (
             <defs>
               <linearGradient

--- a/components/vc-progress/src/Circle.tsx
+++ b/components/vc-progress/src/Circle.tsx
@@ -127,6 +127,7 @@ export default defineComponent({
         trailColor,
         strokeLinecap,
         strokeColor,
+        class: className,
         ...restProps
       } = props;
       const { pathString, pathStyle } = getPathStyles(
@@ -150,10 +151,9 @@ export default defineComponent({
         class: `${prefixCls}-circle-trail`,
         style: pathStyle,
       };
-
       return (
         <svg
-          class={classNames(`${prefixCls}-circle`, props.class)}
+          class={classNames(`${prefixCls}-circle`, className)}
           viewBox="0 0 100 100"
           {...restProps}
         >

--- a/components/vc-progress/src/types.ts
+++ b/components/vc-progress/src/types.ts
@@ -25,7 +25,6 @@ export const propTypes = {
   trailColor: String,
   trailWidth: Number,
   transition: String,
-  class: String,
 };
 
 export type ProgressProps = Partial<ExtractPropTypes<typeof propTypes>>;

--- a/components/vc-progress/src/types.ts
+++ b/components/vc-progress/src/types.ts
@@ -25,6 +25,7 @@ export const propTypes = {
   trailColor: String,
   trailWidth: Number,
   transition: String,
+  class: String,
 };
 
 export type ProgressProps = Partial<ExtractPropTypes<typeof propTypes>>;


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

### 这个变动的性质是

- [x] 新特性提交
- [x] 日常 bug 修复
- [x] 站点、文档改进
- [x] 组件样式改进
- [x] TypeScript 定义更新
- [x] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 描述相关需求的来源。
增强 size 属性
deprecated width 属性
> 2. 要解决的问题。
增强 size 属性
deprecated width 属性
> 3. 相关的 issue 讨论链接。
#6355
### 实现方案和 API（非新功能可选）

> 1. 基本的解决思路和其他可选方案。
增加 getsize 函数 处理 以往兼容性问题
重构 size<= 20时触发变体
> 2. 列出最终的 API 实现和用法。
```vue
<template>
  <div>
    <a-progress
      type="circle"
      trail-color="#e6f4ff"
      :percent="60"
      :stroke-width="20"
      :size="12"
      :format="number => `进行中，已完成${number}%`"
    />
    <span :style="{ marginLeft: 8 }">代码发布</span>
  </div>
</template>
```
> 3. 涉及 UI/交互变动需要有截图或 GIF。
<img width="726" alt="image" src="https://user-images.githubusercontent.com/79909910/228839105-61d23c18-c74e-448f-8527-4ff16f2c71f5.png">
### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
Progress 组件
```ts
if (process.env.NODE_ENV !== 'production') {
  devWarning(
    'successPercent' in props,
    'Progress',
    '`successPercent` is deprecated. Please use `success.percent` instead.',
  );
  devWarning('width' in props, 'Progress', '`width` is deprecated. Please use `size` instead.');
}
```
progress 下 line 组件
```ts
if (process.env.NODE_ENV !== 'production') {
  devWarning(
    'strokeWidth' in props,
    'Progress',
    '`strokeWidth` is deprecated. Please use `size` instead.',
  );
}
```
> 2. 是否有可能隐含的 break change 和其他风险？
无
### Changelog 描述（非新功能可选）

> 1. 英文描述
enhance size prop and add variants
> 2. 中文描述（可选）
增强 size prop和添加变体
### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。