### PR TITLE
fix: fix the bug with render class ant-upload-drag-container in dom

### DIFF
--- a/components/upload/Upload.tsx
+++ b/components/upload/Upload.tsx
@@ -394,7 +394,7 @@ export default defineComponent({
                 class={`${prefixCls.value}-btn`}
                 v-slots={slots}
               >
-                <div class={`${prefixCls}-drag-container`}>{slots.default?.()}</div>
+                <div class={`${prefixCls.value}-drag-container`}>{slots.default?.()}</div>
               </VcUpload>
             </div>
             {renderUploadList()}


### PR DESCRIPTION
Hello!
I have searched the [issues](https://github.com/vueComponent/ant-design-vue/issues) of this repository and believe that this is not a duplicate.

**Version**
3.2.16

**Environment**
ant-design-vue 3.2.16; 
vue-3.2.0

**Reproduction link**
 [https://codesandbox.io/s/a-upload-dragger-class-issue-nzg0v9?file=/src/App.vue](url)

**Steps to reproduce**
There is an incorrect rendering of the class "ant-upload-drag-container" in DOM. If we use an empty tag  `<a-upload-dragger></a-upload-dragger>`, the empty `<div>` with class` "[object Object]-drag-container"` renders in DOM. 
<img width="956" alt="upload_class_ids" src="https://user-images.githubusercontent.com/28844263/229358760-6b95601b-661b-46c7-933c-49fbf9b8d561.png">
This happens because of an error in string 397 of the Upload.tsx file. 
`<div class={`${prefixCls}-drag-container`}>{slots.default?.()}</div>`
prefixCls - ComputedRef<string>, not a string.
To fix this issue, we can modify the code to access the string value of the prefixCls object  - `prefixCls.value`
My suggestion:
`<div class={`${prefixCls.value}-drag-container`}>{slots.default?.()}</div>`

<img width="908" alt="upload-dragger-issue" src="https://user-images.githubusercontent.com/28844263/229476798-38d9c7ff-47b4-4227-9774-75e5ff1bac6c.png">

**What is expected?**
The class "ant-upload-dragger-container" should be rendered in DOM

**What is actually happening?**
The class "[object Object]-drag-container" renders in DOM