### PR TITLE
refactor(Table): props.components action

### DIFF
--- a/components/vc-table/Body/index.tsx
+++ b/components/vc-table/Body/index.tsx
@@ -5,11 +5,12 @@ import { getColumnsKey } from '../utils/valueUtil';
 import MeasureCell from './MeasureCell';
 import BodyRow from './BodyRow';
 import useFlattenRecords from '../hooks/useFlattenRecords';
-import { defineComponent, ref, toRef } from 'vue';
+import { computed, defineComponent, ref, toRef } from 'vue';
 import { useInjectResize } from '../context/ResizeContext';
 import { useInjectTable } from '../context/TableContext';
 import { useInjectBody } from '../context/BodyContext';
 import { useProvideHover } from '../context/HoverContext';
+import usePropsWithComponentType from '../hooks/usePropsWithComponentType';
 
 export interface BodyProps<RecordType> {
   data: RecordType[];
@@ -118,27 +119,26 @@ export default defineComponent<BodyProps<any>>({
       }
 
       const columnsKey = getColumnsKey(flattenColumns);
-
+      const children = computed(() => [
+        measureColumnWidth && (
+          <tr
+            aria-hidden="true"
+            class={`${prefixCls}-measure-row`}
+            style={{ height: 0, fontSize: 0 }}
+          >
+            {columnsKey.map(columnKey => (
+              <MeasureCell key={columnKey} columnKey={columnKey} onColumnResize={onColumnResize} />
+            ))}
+          </tr>
+        ),
+        rows,
+      ]);
       return (
-        <WrapperComponent class={`${prefixCls}-tbody`}>
-          {/* Measure body column width with additional hidden col */}
-          {measureColumnWidth && (
-            <tr
-              aria-hidden="true"
-              class={`${prefixCls}-measure-row`}
-              style={{ height: 0, fontSize: 0 }}
-            >
-              {columnsKey.map(columnKey => (
-                <MeasureCell
-                  key={columnKey}
-                  columnKey={columnKey}
-                  onColumnResize={onColumnResize}
-                />
-              ))}
-            </tr>
-          )}
-
-          {rows}
+        <WrapperComponent
+          {...usePropsWithComponentType({ class: `${prefixCls}-tbody` }, WrapperComponent, children)
+            .value}
+        >
+          {children.value}
         </WrapperComponent>
       );
     };

--- a/components/vc-table/Cell/index.tsx
+++ b/components/vc-table/Cell/index.tsx
@@ -28,6 +28,7 @@ import { useInjectSticky } from '../context/StickyContext';
 import { warning } from '../../vc-util/warning';
 import type { MouseEventHandler } from '../../_util/EventInterface';
 import eagerComputed from '../../_util/eagerComputed';
+import usePropsWithComponentType from '../hooks/usePropsWithComponentType';
 
 /** Check if cell is in hover range */
 function inHoverRange(cellStartRow: number, cellRowSpan: number, startRow: number, endRow: number) {
@@ -319,7 +320,7 @@ export default defineComponent<CellProps>({
           title = getTitle([childNode]);
         }
       }
-
+      const childNodes = computed(() => [appendNode, childNode, slots.dragHandle?.()]);
       const componentProps = {
         title,
         ...restCellProps,
@@ -355,12 +356,9 @@ export default defineComponent<CellProps>({
           ...cellStyle,
         },
       };
-
       return (
-        <Component {...componentProps}>
-          {appendNode}
-          {childNode}
-          {slots.dragHandle?.()}
+        <Component {...usePropsWithComponentType(componentProps, Component, childNodes).value}>
+          {childNodes.value}
         </Component>
       );
     };

--- a/components/vc-table/Header/Header.tsx
+++ b/components/vc-table/Header/Header.tsx
@@ -11,6 +11,7 @@ import type {
   DefaultRecordType,
 } from '../interface';
 import HeaderRow from './HeaderRow';
+import usePropsWithComponentType from '../hooks/usePropsWithComponentType';
 
 function parseHeaderRows<RecordType>(
   rootColumns: ColumnsType<RecordType>,
@@ -103,24 +104,26 @@ export default defineComponent<HeaderProps>({
       const WrapperComponent = getComponent(['header', 'wrapper'], 'thead');
       const trComponent = getComponent(['header', 'row'], 'tr');
       const thComponent = getComponent(['header', 'cell'], 'th');
+      const children = computed(() =>
+        rows.value.map((row, rowIndex) => (
+          <HeaderRow
+            key={rowIndex}
+            flattenColumns={flattenColumns}
+            cells={row}
+            stickyOffsets={stickyOffsets}
+            rowComponent={trComponent}
+            cellComponent={thComponent}
+            customHeaderRow={customHeaderRow}
+            index={rowIndex}
+          />
+        )),
+      );
       return (
-        <WrapperComponent class={`${prefixCls}-thead`}>
-          {rows.value.map((row, rowIndex) => {
-            const rowNode = (
-              <HeaderRow
-                key={rowIndex}
-                flattenColumns={flattenColumns}
-                cells={row}
-                stickyOffsets={stickyOffsets}
-                rowComponent={trComponent}
-                cellComponent={thComponent}
-                customHeaderRow={customHeaderRow}
-                index={rowIndex}
-              />
-            );
-
-            return rowNode;
-          })}
+        <WrapperComponent
+          {...usePropsWithComponentType({ class: `${prefixCls}-thead` }, WrapperComponent, children)
+            .value}
+        >
+          {children.value}
         </WrapperComponent>
       );
     };

--- a/components/vc-table/Table.tsx
+++ b/components/vc-table/Table.tsx
@@ -61,6 +61,7 @@ import { useProvideResize } from './context/ResizeContext';
 import { useProvideSticky } from './context/StickyContext';
 import pickAttrs from '../_util/pickAttrs';
 import { useProvideExpandedRow } from './context/ExpandedRowContext';
+import usePropsWithComponentType from './hooks/usePropsWithComponentType';
 
 // Used for conditions cache
 const EMPTY_DATA = [];
@@ -706,6 +707,16 @@ export default defineComponent<TableProps<DefaultRecordType>>({
             return 0;
           }) as number[];
         } else {
+          const children = computed(() => [
+            bodyColGroup(),
+            bodyTable(),
+            !fixFooter.value && summaryNode && (
+              <Footer stickyOffsets={stickyOffsets.value} flattenColumns={flattenColumns.value}>
+                {summaryNode}
+              </Footer>
+            ),
+          ]);
+
           bodyContent = () => (
             <div
               style={{
@@ -717,18 +728,18 @@ export default defineComponent<TableProps<DefaultRecordType>>({
               class={classNames(`${prefixCls}-body`)}
             >
               <TableComponent
-                style={{
-                  ...scrollTableStyle.value,
-                  tableLayout: mergedTableLayout.value,
-                }}
+                {...usePropsWithComponentType(
+                  {
+                    style: {
+                      ...scrollTableStyle.value,
+                      tableLayout: mergedTableLayout.value,
+                    },
+                  },
+                  TableComponent,
+                  children,
+                ).value}
               >
-                {bodyColGroup()}
-                {bodyTable()}
-                {!fixFooter.value && summaryNode && (
-                  <Footer stickyOffsets={stickyOffsets.value} flattenColumns={flattenColumns.value}>
-                    {summaryNode}
-                  </Footer>
-                )}
+                {children.value}
               </TableComponent>
             </div>
           );
@@ -799,6 +810,16 @@ export default defineComponent<TableProps<DefaultRecordType>>({
         );
       } else {
         // >>>>>> Unique table
+        const children = computed(() => [
+          bodyColGroup(),
+          showHeader !== false && <Header {...headerProps} {...columnContext.value} />,
+          bodyTable(),
+          summaryNode && (
+            <Footer stickyOffsets={stickyOffsets.value} flattenColumns={flattenColumns.value}>
+              {summaryNode}
+            </Footer>
+          ),
+        ]);
         groupTableNode = () => (
           <div
             style={{
@@ -810,16 +831,18 @@ export default defineComponent<TableProps<DefaultRecordType>>({
             ref={scrollBodyRef}
           >
             <TableComponent
-              style={{ ...scrollTableStyle.value, tableLayout: mergedTableLayout.value }}
+              {...usePropsWithComponentType(
+                {
+                  style: {
+                    ...scrollTableStyle.value,
+                    tableLayout: mergedTableLayout.value,
+                  },
+                },
+                TableComponent,
+                children,
+              ).value}
             >
-              {bodyColGroup()}
-              {showHeader !== false && <Header {...headerProps} {...columnContext.value} />}
-              {bodyTable()}
-              {summaryNode && (
-                <Footer stickyOffsets={stickyOffsets.value} flattenColumns={flattenColumns.value}>
-                  {summaryNode}
-                </Footer>
-              )}
+              {children.value}
             </TableComponent>
           </div>
         );

--- a/components/vc-table/hooks/usePropsWithComponentType.ts
+++ b/components/vc-table/hooks/usePropsWithComponentType.ts
@@ -1,0 +1,19 @@
+import type { ComputedRef } from 'vue';
+import { computed } from 'vue';
+const stringComponents = ['table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td'] as const;
+type ComponentType = (typeof stringComponents)[number] | Function;
+export default function usePropsWithComponentType(
+  props: Record<string, any>,
+  component: ComponentType,
+  children: ComputedRef<any>,
+) {
+  if (typeof component === 'string' && stringComponents.includes(component)) {
+    return computed(() => props);
+  }
+  const key = 'slots';
+  const newProps = computed(() => ({
+    ...props,
+    [key]: { default: () => children.value },
+  }));
+  return newProps;
+}


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

### 这个变动的性质是

- [x] 新特性提交
- [x] 日常 bug 修复
- [x] 站点、文档改进
- [x] 组件样式改进
- [x] TypeScript 定义更新
- [x] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 描述相关需求的来源。
增加 slots 参数
> 2. 要解决的问题。
table props.components 的回调函数 增加  slots 参数
deprecated width 属性
> 3. 相关的 issue 讨论链接。
#6434 
### 实现方案和 API（非新功能可选）

> 1. 基本的解决思路和其他可选方案。
增加 usePropsWithComponentType hook 处理 props 的 slots 存在与否问题
> 2. 列出最终的 API 实现和用法。
```vue
<a-table :columns="columns" :data-source="data" :components="{ body: { cell: TdCell } }"/>
<script lang="ts" setup>
// ...
    const TdCell = (props) => {
      const { onMouseEnter, onMouseLeave, slots, ...restProps } = props;
       return h('td', { ...restProps }, slots);
    };
</script>
```
> 3. 涉及 UI/交互变动需要有截图或 GIF。
### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
无
> 2. 是否有可能隐含的 break change 和其他风险？
无
### Changelog 描述（非新功能可选）

> 1. 英文描述
table'props.components ，the parameter of callbacks is incremented by slots for children
> 2. 中文描述（可选）
props.components 传入的回调函数的参数增加slots表示孩子
### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。