### PR TITLE
fix: 修复Tabs组件AddIcon插槽渲染两次的BUG

### DIFF
--- a/components/tabs/src/TabNavList/index.tsx
+++ b/components/tabs/src/TabNavList/index.tsx
@@ -514,15 +514,17 @@ export default defineComponent({
               </ResizeObserver>
             </div>
           </ResizeObserver>
-          <OperationNode
-            {...props}
-            removeAriaLabel={locale?.removeAriaLabel}
-            v-slots={pick(slots, ['moreIcon'])}
-            ref={operationsRef}
-            prefixCls={pre}
-            tabs={hiddenTabs.value}
-            class={!hasDropdown && operationsHiddenClassName.value}
-          />
+          {hasDropdown && (
+            <OperationNode
+              {...props}
+              removeAriaLabel={locale?.removeAriaLabel}
+              v-slots={pick(slots, ['moreIcon'])}
+              ref={operationsRef}
+              prefixCls={pre}
+              tabs={hiddenTabs.value}
+              class={!hasDropdown && operationsHiddenClassName.value}
+            />
+          )}
 
           <ExtraContent position="right" prefixCls={pre} extra={slots.rightExtra} />
           <ExtraContent position="right" prefixCls={pre} extra={slots.tabBarExtraContent} />


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]

https://github.com/vueComponent/ant-design-vue/issues/5411#issue-1182960633

### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. Tabs中addIcon， 使用Popover ，通过 visible 属性控制浮层显示。会出现两个Popover。
> 2. Tabs组件AddIcon插槽中的内容会渲染两次。
> 3. [相关的 issue 讨论链接](https://github.com/vueComponent/ant-design-vue/issues/5411#issue-1182960633)。

### 实现方案和 API（非新功能可选）

> 1. 渲染两次的原因是分别在OperationNode组件和TabNavList组件都渲染了一次。
> 2. 列出最终的 API 实现和用法。
> 3. 涉及 UI/交互变动需要有截图或 GIF。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
> 2. 是否有可能隐含的 break change 和其他风险？

### Changelog 描述（非新功能可选）

> 1. Fix bug in Tabs component AddIcon slot rendering twice
> 2. 修复Tabs组件AddIcon插槽渲染两次的BUG

### 请求合并前的自查清单

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。