### PR TITLE
fix(pageSizeOptions): fix type

### DIFF
--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -22,7 +22,7 @@ export const paginationProps = () => ({
   pageSize: Number,
   hideOnSinglePage: { type: Boolean, default: undefined },
   showSizeChanger: { type: Boolean, default: undefined },
-  pageSizeOptions: Array as PropType<(string | number)[]>,
+  pageSizeOptions: Array as PropType<string[]>,
   buildOptionText: Function as PropType<(opt: { value: any }) => any>,
   showQuickJumper: {
     type: [Boolean, Object] as PropType<boolean | { goButton?: any }>,

--- a/components/vc-pagination/Pagination.tsx
+++ b/components/vc-pagination/Pagination.tsx
@@ -47,7 +47,7 @@ export default defineComponent({
     showPrevNextJumpers: { type: Boolean, default: true },
     showQuickJumper: PropTypes.oneOfType([PropTypes.looseBool, PropTypes.object]).def(false),
     showTitle: { type: Boolean, default: true },
-    pageSizeOptions: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+    pageSizeOptions: PropTypes.arrayOf(PropTypes.string),
     buildOptionText: Function,
     showTotal: Function,
     simple: { type: Boolean, default: undefined },


### PR DESCRIPTION
pageSizeOptions 为`number[]`展示会出问题

![image](https://user-images.githubusercontent.com/53564781/232024348-af4a2c94-15a6-4afc-a678-59a451c094a7.png)

为避免这种情况，以及和文档保持一致，修正了ts类型
