### PR TITLE
fix(RangePicker): syntax errors

### DIFF
--- a/components/vc-picker/RangePicker.tsx
+++ b/components/vc-picker/RangePicker.tsx
@@ -315,7 +315,7 @@ function RangerPicker<DateType>() {
 
           // Fill disabled unit
           for (let i = 0; i < 2; i += 1) {
-            if (mergedDisabled[i] && !getValue(postValues, i) && !getValue(props.allowEmpty, i)) {
+            if (mergedDisabled.value[i] && !getValue(postValues, i) && !getValue(props.allowEmpty, i)) {
               postValues = updateValues(postValues, props.generateConfig.getNow(), i);
             }
           }


### PR DESCRIPTION
计算属性 `mergedDisabled` 使用 `.value` 获取值