### PR TITLE
fix: dealing with switching topics modal, notification, message does not take effect close #6512

### DIFF
--- a/components/theme/internal.ts
+++ b/components/theme/internal.ts
@@ -21,7 +21,7 @@ import statisticToken, { merge as mergeToken, statistic } from './util/statistic
 import type { VueNode } from '../_util/type';
 import { objectType } from '../_util/type';
 import type { ComputedRef, InjectionKey, Ref } from 'vue';
-import { defineComponent, provide, computed, inject } from 'vue';
+import { defineComponent, provide, computed, inject, watchEffect, ref } from 'vue';
 import { toReactive } from '../_util/toReactive';
 
 const defaultTheme = createTheme(defaultDerivative);
@@ -63,12 +63,17 @@ export interface DesignTokenContext {
 //defaultConfig
 const DesignTokenContextKey: InjectionKey<DesignTokenContext> = Symbol('DesignTokenContext');
 
+export const globalDesignTokenApi = ref<DesignTokenContext>();
+
 export const useDesignTokenProvider = (value: DesignTokenContext) => {
   provide(DesignTokenContextKey, value);
+  watchEffect(() => {
+    globalDesignTokenApi.value = value;
+  });
 };
 
 export const useDesignTokenInject = () => {
-  return inject(DesignTokenContextKey, defaultConfig);
+  return inject(DesignTokenContextKey, globalDesignTokenApi.value ?? defaultConfig);
 };
 export const DesignTokenProvider = defineComponent({
   props: {
@@ -87,7 +92,10 @@ export function useToken(): [
   ComputedRef<GlobalToken>,
   ComputedRef<string>,
 ] {
-  const designTokenContext = inject(DesignTokenContextKey, defaultConfig);
+  const designTokenContext = inject<DesignTokenContext>(
+    DesignTokenContextKey,
+    globalDesignTokenApi.value || defaultConfig,
+  );
 
   const salt = computed(() => `${version}-${designTokenContext.hashed || ''}`);
 

--- a/components/theme/internal.ts
+++ b/components/theme/internal.ts
@@ -73,7 +73,7 @@ export const useDesignTokenProvider = (value: DesignTokenContext) => {
 };
 
 export const useDesignTokenInject = () => {
-  return inject(DesignTokenContextKey, globalDesignTokenApi.value ?? defaultConfig);
+  return inject(DesignTokenContextKey, globalDesignTokenApi.value || defaultConfig);
 };
 export const DesignTokenProvider = defineComponent({
   props: {


### PR DESCRIPTION
处理切换主题的时候，暗黑主题不生效的问题 #6512 ，目前查看遇到的问题是`internal`下的`useToken`无法响应token，嵌套的`DesignTokenContext`拿到的是空，就导致了无法触发响应。
目前我用的解决方案是通过全局的属性进行桥接，不知道还有没有好一些的方案实现。