### PR TITLE
chore: modify the babel configuration

### DIFF
--- a/antd-tools/getBabelCommonConfig.js
+++ b/antd-tools/getBabelCommonConfig.js
@@ -1,4 +1,4 @@
-const { resolve } = require('./utils/projectHelper');
+const { resolve, isThereHaveBrowserslistConfig } = require('./utils/projectHelper');
 
 module.exports = function (modules) {
   const plugins = [
@@ -38,6 +38,11 @@ module.exports = function (modules) {
         resolve('@babel/preset-env'),
         {
           modules,
+          targets: isThereHaveBrowserslistConfig()
+            ? undefined
+            : {
+                browsers: ['last 2 versions', 'Firefox ESR', '> 1%', 'ie >= 11'],
+              },
         },
       ],
     ],

--- a/antd-tools/getBabelCommonConfig.js
+++ b/antd-tools/getBabelCommonConfig.js
@@ -38,9 +38,6 @@ module.exports = function (modules) {
         resolve('@babel/preset-env'),
         {
           modules,
-          targets: {
-            browsers: ['last 2 versions', 'Firefox ESR', '> 1%', 'not ie 11'],
-          },
         },
       ],
     ],


### PR DESCRIPTION
按照文档和这个 babel 配置，[打包后的组件代码](https://www.npmjs.com/package/ant-design-vue?activeTab=code)应该是不需要转 es6 代码的，但是实际上是转换了

![image](https://user-images.githubusercontent.com/29347231/236395256-fb5689dd-e3b3-421a-a988-9b8b302d1ad5.png)


如果不配置 @babel/preset-env 的 targets ，就会使用 package.json 中 browserslist 字段，此时打包后的代码就是正确的（无需转换 es6 的代码）

参考 https://github.com/ant-design/antd-tools/blob/6d4722ad12e46148bbc1b0656072c1c3e4b5cdf8/lib/getBabelCommonConfig.js#L31