### PR TITLE
fix: select选择器组件，value为空字符串''时,展示占位符 and style: 搜索框在屏幕放大时，输入框和右侧的搜索按钮底部不对齐

### DIFF
--- a/components/input/style/mixin.less
+++ b/components/input/style/mixin.less
@@ -169,6 +169,7 @@
     width: 100%;
     margin-bottom: 0;
     text-align: inherit;
+    height: 32px;
 
     &:focus {
       z-index: 1; // Fix https://gw.alipayobjects.com/zos/rmsportal/DHNpoqfMXSfrSnlZvhsJ.png
@@ -182,6 +183,9 @@
         z-index: 0;
       }
     }
+  }
+  .@{inputClass}-lg{
+    height:40px;
   }
 
   &-addon {

--- a/components/vc-select/Select.tsx
+++ b/components/vc-select/Select.tsx
@@ -278,7 +278,7 @@ export default defineComponent({
       if (!props.mode && mergedValues.value.length === 1) {
         const firstValue = mergedValues.value[0];
         if (
-          firstValue.value === null &&
+          (firstValue.value === null || firstValue.value === '')
           (firstValue.label === null || firstValue.label === undefined)
         ) {
           return [];


### PR DESCRIPTION
 #6533  select选择器组件，value为空字符串''时,展示占位符  #6436 搜索框在屏幕放大时，输入框和右侧的搜索按钮底部不对齐