### PR TITLE
fix(date-picker): 修复在macbook的chrome浏览器使用display: inline-flex导致的问题

### DIFF
--- a/components/date-picker/style/index.less
+++ b/components/date-picker/style/index.less
@@ -162,7 +162,7 @@
   // ======================== Range =========================
   &-range {
     position: relative;
-    display: inline-flex;
+    display: flex;
 
     // Clear
     .@{picker-prefix-cls}-clear {


### PR DESCRIPTION
> 首先，感谢你的贡献！ 😄
> 
> 新特性请提交至 feature 分支，其余可提交至 master 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~
> 
> [[English Template / 英文模板](?expand=1)]
> 
> ### 这个变动的性质是
> * [ ]  新特性提交
> * [x]  日常 bug 修复
> * [ ]  站点、文档改进
> * [ ]  组件样式改进
> * [ ]  TypeScript 定义更新
> * [ ]  重构
> * [ ]  代码风格优化
> * [ ]  分支合并
> * [ ]  其他改动（是关于什么的改动？）
> 
> ### 需求背景
> > 1. 描述相关需求的来源。
> >    macbook chrome浏览器下浏览器与window chrome浏览器下图标位置有区别，需要实现在浏览器宽度变长时图标位置依旧在末尾
> > 2. 要解决的问题。
> >   .ant-picker-range下的display: inline-flex;修改为display: flex;
> > 3. 相关的 issue 讨论链接。
> >  
> 
> ### 实现方案和 API（非新功能可选）
> > 1. 基本的解决思路和其他可选方案。
> >    .ant-picker-range下的display: inline-flex;修改为display: flex;
> > 2. 列出最终的 API 实现和用法。
> 
> 
> > 3. 涉及 UI/交互变动需要有截图或 GIF。
> ![image](https://github.com/vueComponent/ant-design-vue/assets/107539476/65d5069f-2196-4597-b7bd-dac90839cf1e)
> ### 对用户的影响和可能的风险（非新功能可选）
> > 1. 这个改动对用户端是否有影响？影响的方面有哪些？
> >    无
> > 2. 是否有可能隐含的 break change 和其他风险？
> >    无
> 
> ### Changelog 描述（非新功能可选）
> > 1. 英文描述
> >    date-picker using display: inline-flex in macbook chrome causes problems
> > 2. 中文描述（可选）
> >    date-picker在macbook的chrome浏览器使用display: inline-flex导致的问题 
> 
> ### 请求合并前的自查清单
> * [x]  文档已补充或无须补充
> * [x]  代码演示已提供或无须提供
> * [x]  TypeScript 定义已补充或无须补充
> * [x]  Changelog 已提供或无须提供
> 
> ### 后续计划（非新功能可选）
> > 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。

