### PR TITLE
fix(table): fix the size of the footer when size and scroll coexist (#6634)

### DIFF
--- a/components/table/style/size.less
+++ b/components/table/style/size.less
@@ -14,6 +14,7 @@
       > .@{table-prefix-cls}-body > table,
       > .@{table-prefix-cls}-scroll > .@{table-prefix-cls}-header > table,
       > .@{table-prefix-cls}-scroll > .@{table-prefix-cls}-body > table,
+      > .@{table-prefix-cls}-scroll > .@{table-prefix-cls}-footer > table,
       > .@{table-prefix-cls}-fixed-left > .@{table-prefix-cls}-header > table,
       > .@{table-prefix-cls}-fixed-right > .@{table-prefix-cls}-header > table,
       > .@{table-prefix-cls}-fixed-left


### PR DESCRIPTION
修复了问题：[#6634 ](https://github.com/vueComponent/ant-design-vue/issues/6634)