### PR TITLE
fix(tabs):  the dropdown menu opened automatically in Customized trigger of new tab

### DIFF
--- a/components/tabs/src/TabNavList/OperationNode.tsx
+++ b/components/tabs/src/TabNavList/OperationNode.tsx
@@ -121,6 +121,14 @@ export default defineComponent({
       }
     });
 
+    watch(
+      () => props.tabs.length,
+      val => {
+        if(!val) {
+          setOpen(false);
+        }
+    });
+    
     return () => {
       const {
         prefixCls,
@@ -146,7 +154,6 @@ export default defineComponent({
       if (!tabs.length) {
         moreStyle.visibility = 'hidden';
         moreStyle.order = 1;
-        setOpen(false);
       }
 
       const overlayClassName = classNames({

--- a/components/tabs/src/TabNavList/OperationNode.tsx
+++ b/components/tabs/src/TabNavList/OperationNode.tsx
@@ -146,6 +146,7 @@ export default defineComponent({
       if (!tabs.length) {
         moreStyle.visibility = 'hidden';
         moreStyle.order = 1;
+        setOpen(false);
       }
 
       const overlayClassName = classNames({


### PR DESCRIPTION
fix issue [#6653](https://github.com/vueComponent/ant-design-vue/issues/6653)

**bug复现步骤**

1.打开 antdv 官网。定位到标签页。找到“自定义新增页签触发器”的示例。
2.一直点击“ADD”新增标签页，直到出现"..."。
3.点击“...”打开标签页弹窗，点击标签页的“X”关掉弹窗中所有的标签页，直到弹窗自动关闭。
4.再次添加几个新的标签页，这时标签页弹窗会自动打开。

**原因**

第3步，关掉所有的标签页，直到弹窗自动关闭后，控制Dropdown的visible还是true，没有重置为false