### PR TITLE
fix(empty): Fix image slot failure issue

### DIFF
--- a/components/empty/index.tsx
+++ b/components/empty/index.tsx
@@ -36,7 +36,7 @@ const Empty: EmptyType = (props, { slots = {}, attrs }) => {
   const prefixCls = prefixClsRef.value;
 
   const {
-    image = defaultEmptyImg,
+    image = slots.image?.() || defaultEmptyImg,
     description = slots.description?.() || undefined,
     imageStyle,
     class: className = '',


### PR DESCRIPTION
I tried using the image slot of the a-empty component according to the documentation and found that it didn't work, so I modified it