### PR TITLE
feat: prop type of select should contain Boolean

### DIFF
--- a/components/select/index.tsx
+++ b/components/select/index.tsx
@@ -36,10 +36,10 @@ export const selectProps = () => ({
     'backfill',
   ]),
   value: {
-    type: [Array, Object, String, Number] as PropType<SelectValue>,
+    type: [Array, Object, String, Number, Boolean] as PropType<SelectValue>,
   },
   defaultValue: {
-    type: [Array, Object, String, Number] as PropType<SelectValue>,
+    type: [Array, Object, String, Number, Boolean] as PropType<SelectValue>,
   },
   notFoundContent: PropTypes.any,
   suffixIcon: PropTypes.any,


### PR DESCRIPTION
for boolean choices from backend, it's very common that `true` or `false` should be vaue type of select props