### PR TITLE
:memo: 修改手动上传示例代码

### DIFF
--- a/components/upload/demo/upload-manually.vue
+++ b/components/upload/demo/upload-manually.vue
@@ -57,7 +57,7 @@ export default defineComponent({
     };
 
     const beforeUpload: UploadProps['beforeUpload'] = file => {
-      fileList.value = [...fileList.value, file];
+      fileList.value = [...(fileList.value || []), file];
       return false;
     };
 


### PR DESCRIPTION
示例代码在运行时,ts类型报错.原因是试图在可能为 undefined 的对象上使用扩展运算符.

![image](https://github.com/vueComponent/ant-design-vue/assets/25839948/907a7890-5243-408c-bad9-0e57b9d3cad9)
![image](https://github.com/vueComponent/ant-design-vue/assets/25839948/431f3294-0e7f-4fb4-b638-431db6580ded)
