### PR TITLE
fix(auto-complete): error when nest input-number

### DIFF
--- a/components/vc-select/Selector/index.tsx
+++ b/components/vc-select/Selector/index.tsx
@@ -180,10 +180,13 @@ const Selector = defineComponent<SelectorProps>({
       }
     };
 
-    const onInputChange = (event: { target: { value: any } }) => {
-      let {
-        target: { value },
-      } = event;
+    const onInputChange = (e: Event | string) => {
+      let value;
+      if (typeof e === 'string') {
+        value = e;
+      } else {
+        value = (e.target as HTMLInputElement).value;
+      }
 
       // Pasted text should replace back to origin content
       if (props.tokenWithEnter && pastedText && /[\r\n]/.test(pastedText)) {


### PR DESCRIPTION
fix: #6685 

![image](https://github.com/vueComponent/ant-design-vue/assets/82451257/a4dc4c24-bf35-4593-ae58-ab7de66934d2)

![image](https://github.com/vueComponent/ant-design-vue/assets/82451257/fa053e96-b4b8-491f-9016-104f29325266)


在这个方法中，输入时可以看到传入的不是一个 event 事件，而是一个 string 类型的值，所以解析不到 value 导致控制台报 `Uncaught TypeError: Cannot read properties of undefined (reading 'value')` 的错误。