### PR TITLE
fix dayjs is not excluded in dist

### DIFF
--- a/webpack.build.conf.js
+++ b/webpack.build.conf.js
@@ -14,14 +14,15 @@ function addLocales(webpackConfig) {
 }
 
 function externalDayjs(config) {
-  config.externals.dayjs = {
+  config.externals.push({
     dayjs: {
       root: 'dayjs',
       commonjs2: 'dayjs',
       commonjs: 'dayjs',
       amd: 'dayjs',
+      module: 'dayjs',
     },
-  };
+  });
   config.externals.push(function ({ _context, request }, callback) {
     if (/^dayjs\/plugin\//.test(request)) {
       const name = request.replace(/\//g, '_');
@@ -30,6 +31,7 @@ function externalDayjs(config) {
         commonjs2: name,
         commonjs: name,
         amd: name,
+        module: name,
       });
     }
     callback();


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### Changelog description (Optional if not new feature)
![1689996342446](https://github.com/vueComponent/ant-design-vue/assets/20181287/61d619bd-05d5-40ef-bb39-ae644f336faa)
1. 修复dayjs没有成功使用externals排除，导致dayjs在使用cdn方式加载时，日期时间组件的国际化受影响

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
