### PR TITLE
fix(table): table select style(#6721)

### DIFF
--- a/components/table/style/index.ts
+++ b/components/table/style/index.ts
@@ -271,13 +271,13 @@ const genTableStyle: GenerateStyle<TableToken, CSSObject> = token => {
               borderTopColor: 'transparent',
 
               '&:first-child': {
-                borderStartStartRadius: tableRadius,
-                borderEndStartRadius: tableRadius,
+                borderStartStartRadius: 0,
+                borderEndStartRadius: 0,
               },
 
               '&:last-child': {
-                borderStartEndRadius: tableRadius,
-                borderEndEndRadius: tableRadius,
+                borderStartEndRadius: 0,
+                borderEndEndRadius: 0,
               },
             },
           },


### PR DESCRIPTION
When using default tableradius or self configured tableradius in the token, do not affect the background tableradius of continuous tick options

Synchronize ant design 5.0 https://ant.design/components/table-cn