### PR TITLE
fix(TreeSelect): fixed the problem that the onChange hook will be triggered when value doesn't change (#6776)

### DIFF
--- a/components/tree-select/index.tsx
+++ b/components/tree-select/index.tsx
@@ -206,9 +206,11 @@ const TreeSelect = defineComponent({
     });
 
     const handleChange: TreeSelectProps['onChange'] = (...args: any[]) => {
-      emit('update:value', args[0]);
-      emit('change', ...args);
-      formItemContext.onFieldChange();
+      if (args[0] !== args[2].preValue[0]?.value) {
+        emit('update:value', args[0]);
+        emit('change', ...args);
+        formItemContext.onFieldChange();
+      }
     };
     const handleTreeExpand: TreeSelectProps['onTreeExpand'] = (keys: Key[]) => {
       emit('update:treeExpandedKeys', keys);


### PR DESCRIPTION
### 这个变动的性质是

- [x] 日常 bug 修复

### 需求背景

> 1. TreeSelect组件在选择同一值后依然触发onChange事件问题
> 2.  #6776

### 实现方案和 API（非新功能可选）

> 1. 增加preValue判断，若值相同则不触发onChange事件

### 对用户的影响和可能的风险（非新功能可选）

> 无影响，无风险

### Changelog 描述（非新功能可选）

> 1. Fixed the problem that the onChange hook will be triggered when value doesn't change.
> 2. 修复了值不变时change事件仍被触发的问题

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。