### PR TITLE
fix(vc-input): emoji length should be 1

### DIFF
--- a/components/vc-input/Input.tsx
+++ b/components/vc-input/Input.tsx
@@ -36,7 +36,12 @@ export default defineComponent({
     watch(
       () => props.value,
       () => {
-        stateValue.value = props.value;
+        const value = [...fixControlledValue(props.value)];
+        if (value.length > props.maxlength) {
+          stateValue.value = value.slice(0, props.maxlength).join('');
+        } else {
+          stateValue.value = props.value;
+        }
       },
     );
     watch(
@@ -103,7 +108,8 @@ export default defineComponent({
       // https://github.com/vueComponent/ant-design-vue/issues/2203
       if ((((e as any).isComposing || composing) && props.lazy) || stateValue.value === value)
         return;
-      const newVal = e.target.value;
+
+      const newVal = value;
       resolveOnChange(inputRef.value, e, triggerChange);
       setValue(newVal);
     };
@@ -200,7 +206,7 @@ export default defineComponent({
       if (!inputProps.autofocus) {
         delete inputProps.autofocus;
       }
-      const inputNode = <input {...omit(inputProps, ['size'])} />;
+      const inputNode = <input {...omit(inputProps, ['size'])} maxlength={undefined} />;
       return withDirectives(inputNode as VNode, [[antInputDirective]]);
     };
     const getSuffix = () => {


### PR DESCRIPTION
fix: #6794 

The original design of `a-input` was to limit the length of `a-input` through the maxlength attribute of input, but this is inconsistent with the behavior of `a-textarea` (the length of emoji calculated in `a-input` is 2, and in `a-textarea` it is 1), so I personally think it is better to use truncation.

> 原先组件的设计是通过 input 的 maxlength 属性限制 a-input 输入的长度，但是这样和 a-textarea 的行为表现不一致（emoji 在 a-input 计算出来的 length 为 2，在 a-textarea 中为 1）

After:
![image](https://github.com/vueComponent/ant-design-vue/assets/82451257/cd39f0cf-8ea6-40f1-a0ee-f74a800c9d2d)
