### PR TITLE
docs: banner adjust light and dark mode

### DIFF
--- a/site/src/layouts/header/index.vue
+++ b/site/src/layouts/header/index.vue
@@ -191,16 +191,13 @@ export default defineComponent({
   z-index: 100;
   padding: 16px;
   line-height: 28px;
-  color: #8590a6;
   text-align: center;
-  background-color: #141414;
 }
 .alert-banner {
-  color: #fff;
   padding: 5px;
 }
 .alert-banner a {
-  color: #fff;
+  color: inherit;
   text-decoration: underline;
 }
 .alert-banner .close-icon {


### PR DESCRIPTION
![image](https://github.com/vueComponent/ant-design-vue/assets/82451257/a96c9790-1dff-460b-9ea7-b05800aa21be)
顶部这个横幅的 background 和 text color，没有适配明暗模式