### PR TITLE
docs: fix drawer-handler's background in dark mode

### DIFF
--- a/site/src/theme/static/dark.less
+++ b/site/src/theme/static/dark.less
@@ -366,4 +366,8 @@
       color: rgba(255, 255, 255, 0.65);
     }
   }
+
+  .drawer-handle {
+    background: #1d1d1d;
+  }
 }


### PR DESCRIPTION
ref: #6744