### PR TITLE
chore: fix typo in en docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ English | [简体中文](./README-zh_CN.md)
 
 ## Using npm or yarn
 
-**We recommend using npm or yarn to install**，it not only makes development easier，but also allow you to take advantage of the rich ecosystem of Javascript packages and tooling.
+**We recommend using npm or yarn to install**, it not only makes development easier, but also allow you to take advantage of the rich ecosystem of Javascript packages and tooling.
 
 ```bash
 $ npm install ant-design-vue --save
@@ -49,7 +49,7 @@ $ npm install ant-design-vue --save
 $ yarn add ant-design-vue
 ```
 
-If you are in a bad network environment，you can try other registries and tools like [cnpm](https://github.com/cnpm/cnpm).
+If you are in a bad network environment, you can try other registries and tools like [cnpm](https://github.com/cnpm/cnpm).
 
 ## Links
 

--- a/components/calendar/index.en-US.md
+++ b/components/calendar/index.en-US.md
@@ -38,7 +38,7 @@ customize the progress dot by setting a scoped slot
 | monthFullCellRender | Customize the display of the month cell by setting a scoped slot, the returned content will override the cell | v-slot:monthFullCellRender="{current: dayjs}" | - |  |
 | validRange | to set valid range | \[[dayjs](https://day.js.org/), [dayjs](https://day.js.org/)] | - |  |
 | value(v-model) | The current selected date | [dayjs](https://day.js.org/) | current date |  |
-| valueFormat | optional, format of binding value. If not specified, the binding value will be a Date object | string，[date formats](https://day.js.org/docs/en/display/format) | - |  |
+| valueFormat | optional, format of binding value. If not specified, the binding value will be a Date object | string, [date formats](https://day.js.org/docs/en/display/format) | - |  |
 
 ### events
 

--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -45,7 +45,7 @@ Cascade selection box.
 | placeholder | input placeholder | string | 'Please select' |  |
 | placement | Use preset popup align config from builtinPlacements | `bottomLeft` \| `bottomRight` \| `topLeft` \| `topRight` | `bottomLeft` | 3.0 |
 | removeIcon | The custom remove icon | slot | - | 3.2 |
-| searchValue | Set search value，Need work with `showSearch` | string | - | 3.0 |
+| searchValue | Set search value, Need work with `showSearch` | string | - | 3.0 |
 | showSearch | Whether show search input in single mode. | boolean \| [object](#showsearch) | false |  |
 | size | input size | `large` \| `default` \| `small` | `default` |  |
 | status | Set validation status | 'error' \| 'warning' | - | 3.3.0 |

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -103,7 +103,7 @@ The following APIs are shared by DatePicker, RangePicker.
 | suffixIcon | The custom suffix icon | v-slot:suffixIcon | - |  |
 | superNextIcon | The custom super next icon | slot | - | 3.0 |
 | superPrevIcon | The custom super prev icon | slot | - | 3.0 |
-| valueFormat | optional, format of binding value. If not specified, the binding value will be a Date object | string，[date formats](https://day.js.org/docs/en/display/format) | - |  |
+| valueFormat | optional, format of binding value. If not specified, the binding value will be a Date object | string, [date formats](https://day.js.org/docs/en/display/format) | - |  |
 
 ### Common Events
 

--- a/components/slider/index.en-US.md
+++ b/components/slider/index.en-US.md
@@ -20,7 +20,7 @@ To input a value in a range.
 | disabled | If true, the slider will not be intractable. | boolean | false |  |
 | dots | Whether the thumb can drag over tick only. | boolean | false |  |
 | handleStyle | The style of slider handle | CSSProperties | - |  |
-| included | Make effect when `marks` not null，`true` means containment and `false` means coordinative | boolean | true |  |
+| included | Make effect when `marks` not null, `true` means containment and `false` means coordinative | boolean | true |  |
 | mark | Custom tick mark of Slider, | v-slot:mark | { point: number, label: any } | 3.0 |
 | marks | Tick mark of Slider, type of key must be `number`, and must in closed interval \[min, max], each mark can declare its own style. | object | { number: string\|VNode } or { number: { style: object, label: string\|VNode } } or { number: () => VNode } |  |
 | max | The maximum value the slider can slide to | number | 100 |  |

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -75,7 +75,7 @@ Specify `dataSource` of Table as an array of data.
 | childrenColumnName | The column contains children to display | string | `children` |  |
 | columns | Columns of table [config](#column) | array | - |  |
 | components | Override default table elements | object | - |  |
-| customFilterDropdown | Customized filter overlay，need set `column.customFilterDropdown` | v-slot:customFilterDropdown="[FilterDropdownProps](#filterdropdownprops)" | - | 3.0 |
+| customFilterDropdown | Customized filter overlay, need set `column.customFilterDropdown` | v-slot:customFilterDropdown="[FilterDropdownProps](#filterdropdownprops)" | - | 3.0 |
 | customFilterIcon | Customized filter icon | v-slot:customFilterIcon="{filtered, column}" | - | 3.0 |
 | customHeaderRow | Set props on per header row | Function(columns, index) | - |  |
 | customRow | Set props on per row | Function(record, index) | - |  |
@@ -154,7 +154,7 @@ One of the Table `columns` prop for describing the table's columns, Column has t
 | align | specify how content is aligned | 'left' \| 'right' \| 'center' | 'left' |  |
 | colSpan | Span of this column's title | number |  |  |
 | customCell | Set props on per cell | Function(record, rowIndex, column) | - | column add from 3.0 |
-| customFilterDropdown | use v-slot:customFilterDropdown，Priority is lower than filterDropdown | boolean | false | 3.0 |
+| customFilterDropdown | use v-slot:customFilterDropdown, Priority is lower than filterDropdown | boolean | false | 3.0 |
 | customHeaderCell | Set props on per header cell | Function(column) | - |  |
 | customRender | Renderer of the table cell. The return value should be a VNode | Function({text, record, index}) {} | - |  |
 | dataIndex | Display field of the data record, support nest path by string array | string \| string\[] | - |  |

--- a/components/tabs/index.en-US.md
+++ b/components/tabs/index.en-US.md
@@ -62,7 +62,7 @@ Ant Design has 3 types of Tabs for different situations.
 
 ### Tabs.TabPane Slots
 
-| 插槽名称  | 说明                                            | 参数 |
-| --------- | ----------------------------------------------- | ---- |
-| closeIcon | 自定义关闭图标，`在 type="editable-card"`时有效 | -    |
-| tab       | Show text in TabPane's head                     | -    |
+| Slot Name | Description                                                   | Arguments |
+| --------- | ------------------------------------------------------------- | --------- |
+| closeIcon | Customize close icon, Only works while `type="editable-card"` | -         |
+| tab       | Show text in TabPane's head                                   | -         |

--- a/components/time-picker/index.en-US.md
+++ b/components/time-picker/index.en-US.md
@@ -40,7 +40,7 @@ By clicking the input box, you can select a time from a popup panel.
 | suffixIcon | The custom suffix icon | v-slot:suffixIcon | - |  |
 | use12Hours | Display as 12 hours format, with default format `h:mm:ss a` | boolean | false |  |
 | value(v-model) | To set time | [dayjs](https://day.js.org/) | - |  |
-| valueFormat | optional, format of binding value. If not specified, the binding value will be a Date object | string，[date formats](https://day.js.org/docs/en/display/format) | - |  |
+| valueFormat | optional, format of binding value. If not specified, the binding value will be a Date object | string, [date formats](https://day.js.org/docs/en/display/format) | - |  |
 
 #### DisabledTime
 

--- a/site/src/vueDocs/compatible-style.en-US.md
+++ b/site/src/vueDocs/compatible-style.en-US.md
@@ -10,7 +10,7 @@ Ant Design Vue supports the last 2 versions of modern browsers. If you need to b
 Ant Design Vue default using CSS-in-JS with `:where` Selector to reduce priority to avoid user additional adjust style cost when updating. If you want to support old browser (or some other CSS framework selector priority conflict like TailwindCSS), you can use `StyleProvider` to adjust this behavior :
 
 ```html
-// `hashPriority` 默认为 `low`，配置为 `high` 后， // 会移除 `:where` 选择器封装
+// Config `hashPriority` to `high` instead of default `low`, which will remove `:where` wrapper
 <template>
   <a-style-provider hash-priority="high">
     <MyApp />
@@ -31,14 +31,14 @@ Note:
 
 1、After turning off the `:where` downgrade, you may need to manually adjust the priority of some styles.
 
-2、hashPriority not support change，you can reload for new value.
+2、hashPriority not support change, you can reload for new value.
 
 ### CSS Logical Properties
 
 To unify LTR and RTL styles, Ant Design Vue uses CSS logical properties. For example, the original `margin-left` is replaced by `margin-inline-start`, so that it is the starting position spacing under both LTR and RTL. If you need to be compatible with older browsers, you can configure `transformers` through the `StyleProvider` of `@ant-design/cssinjs`:
 
 ```html
-// `transformers` 提供预处理功能将样式进行转换
+// `transformers` provides a way to transform CSS properties
 <template>
   <a-style-provider :transformers="[legacyLogicalPropertiesTransformer]">
     <MyApp />

--- a/site/src/vueDocs/introduce.en-US.md
+++ b/site/src/vueDocs/introduce.en-US.md
@@ -46,7 +46,7 @@ You can subscribe to this feed for new version notifications: <https://github.co
 
 ### Using npm or yarn
 
-**We recommend using npm or yarn to install**，it not only makes development easier，but also allow you to take advantage of the rich ecosystem of Javascript packages and tooling.
+**We recommend using npm or yarn to install**, it not only makes development easier, but also allow you to take advantage of the rich ecosystem of Javascript packages and tooling.
 
 ```bash
 $ npm install ant-design-vue@4.x --save
@@ -56,7 +56,7 @@ $ npm install ant-design-vue@4.x --save
 $ yarn add ant-design-vue@4.x
 ```
 
-If you are in a bad network environment，you can try other registries and tools like [cnpm](https://github.com/cnpm/cnpm).
+If you are in a bad network environment, you can try other registries and tools like [cnpm](https://github.com/cnpm/cnpm).
 
 ### Import in Browser
 


### PR DESCRIPTION
一些中英文逗号，以及 .en-US.md 文件中直接使用了中文，没有翻译的问题