### PR TITLE
docs: prev and next buttons only show cn title

### DIFF
--- a/site/src/layouts/PrevAndNext.vue
+++ b/site/src/layouts/PrevAndNext.vue
@@ -21,8 +21,8 @@
           ></path>
         </svg>
       </span>
-      <span>{{ prev.title }}</span>
-      <span v-if="isZhCN" class="chinese">{{ prev.subtitle }}</span>
+      <span v-if="isZhCN" class="chinese">{{ prev.subtitle || prev.title }}</span>
+      <span v-else>{{ prev.enTitle || prev.title }}</span>
     </router-link>
     <router-link
       v-if="next"
@@ -30,8 +30,8 @@
       class="next-page"
       :to="getLocalizedPathname(next.path, isZhCN)"
     >
-      <span>{{ next.title }}</span>
-      <span v-if="isZhCN" class="chinese">{{ next.subtitle }}</span>
+      <span v-if="isZhCN" class="chinese">{{ next.subtitle || next.title }}</span>
+      <span v-else>{{ next.enTitle || next.title }}</span>
       <span role="img" aria-label="right" class="anticon anticon-right footer-nav-icon-after">
         <svg
           viewBox="64 64 896 896"
@@ -65,4 +65,3 @@ export default defineComponent({
   },
 });
 </script>
-<style lang="less" scoped></style>


### PR DESCRIPTION

![image](https://github.com/vueComponent/ant-design-vue/assets/82451257/3db20f4e-6fbb-4818-ab97-dc9fcf8f11cc)

![1690877543302](https://github.com/vueComponent/ant-design-vue/assets/82451257/c15fa93b-fcd3-484a-9252-c63e859a5b5f)

页面位于 docs 这个界面时，属性里面没有 subtitle，只有 enTitle 和 title。位于 componenets 界面时，属性里面又没有 enTitle，只有 subtitle 和 title。

| 界面 |  中文标题属性 |  英文标题属性 |
|  ----  | ----  | ----  |
| docs  | title | enTitle |
| componenets  | subtitle | title |