### PR TITLE
docs(site): Remove the reference to the App component in the migration document

### DIFF
--- a/site/src/vueDocs/migration-v4.en-US.md
+++ b/site/src/vueDocs/migration-v4.en-US.md
@@ -18,7 +18,6 @@ This document will help you upgrade from ant-design-vue `3.x` version to ant-des
 - Remove less, adopt CSS-in-JS, for better support of dynamic themes.
   - All less files are removed, and less variables are no longer exported.
   - Css files are no longer included in package. Since CSS-in-JS supports importing on demand, the original `ant-design-vue/dist/antd.css` has also been abandoned. If you need to reset some basic styles, please import `ant-design-vue/dist/reset.css`.
-  - If you need to reset the style of the component, but you don't want to introduce `ant-design-vue/dist/reset.css` to pollute the global style, You can try using the [App](/components/app) in the outermost layer to solve the problem that native elements do not have antd specification style.
 - Remove css variables and dynamic theme built on top of them.
 - LocaleProvider has been deprecated in 3.x (use `<ConfigProvider locale />` instead), we removed the related folder `ant-design-vue/es/locale-provider` and `ant-design-vue/lib/locale-provider` in 4.x.
 - Replace built-in Moment.js with Dayjs. For more: [Use custom date library](/docs/vue/use-custom-date-library/).

--- a/site/src/vueDocs/migration-v4.zh-CN.md
+++ b/site/src/vueDocs/migration-v4.zh-CN.md
@@ -19,7 +19,6 @@
 - 弃用 less，采用 CSS-in-JS，更好地支持动态主题。
   - 所有 less 文件全部移除，less 变量不再支持透出。
   - 产物中不再包含 css 文件。由于 CSS-in-JS 支持按需引入，原本的 `ant-design-vue/dist/antd.css` 也已经移除，如果需要重置一些基本样式请引入 `ant-design-vue/dist/reset.css`。
-  - 如果需要组件重置样式，又不想引入 `ant-design-vue/dist/reset.css` 从而导致污染全局样式的话，可以尝试在应用最外层使用[App 组件](/components/app-cn)，解决原生元素没有 ant-design-vue 规范样式的问题。
 - 移除 css variables 以及在此之上构筑的动态主题方案。
 - LocaleProvider 在 3.x 中已经废弃（使用 `<ConfigProvider locale />` 替代），我们在 4.x 里彻底移除了相关目录 `ant-design-vue/es/locale-provider`、`ant-design-vue/lib/locale-provider`。
 - 不再支持 `babel-plugin-import`，CSS-in-JS 本身具有按需加载的能力，不再需要插件支持。


### PR DESCRIPTION
组件库当中没有有 App 组件，这一行会误导用户