### PR TITLE
fix: default value for direction in configProvider

### DIFF
--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -88,6 +88,7 @@ export const configProviderProps = () => ({
   componentDisabled: { type: Boolean, default: undefined },
   direction: {
     type: String as PropType<'ltr' | 'rtl'>,
+    default: 'ltr',
   },
   space: objectType<{ size?: SizeType | number }>(),
   virtual: { type: Boolean, default: undefined },

--- a/components/config-provider/context.ts
+++ b/components/config-provider/context.ts
@@ -156,6 +156,7 @@ export const defaultConfigProvider: ConfigProviderInnerProps = {
   },
   iconPrefixCls: computed(() => defaultIconPrefixCls),
   getPopupContainer: computed(() => () => document.body),
+  direction: computed(() => 'ltr'),
 };
 
 export const useConfigContextInject = () => {


### PR DESCRIPTION
fix: #6886 第二个示例

<img width="45%" src="https://github.com/vueComponent/ant-design-vue/assets/82451257/361449fb-8b0f-42ce-aac9-b2bd0c37407c" />
<img width="45%" src="https://github.com/vueComponent/ant-design-vue/assets/82451257/928a32f8-45b5-4218-a653-45f258147edd" />

经过排查，发现 direction.value 是 undefined
