### PR TITLE
fix(Button):the wave animation bug of loading state switching🌊

### DIFF
--- a/components/_util/wave/index.tsx
+++ b/components/_util/wave/index.tsx
@@ -45,15 +45,14 @@ export default defineComponent({
     onMounted(() => {
       watch(
         () => props.disabled,
-        () => {
+        (newV, oldV) => {
           clear();
           nextTick(() => {
             const node = findDOMNode(instance);
 
-            if (!node || node.nodeType !== 1 || props.disabled) {
+            if (!node || node.nodeType !== 1 || props.disabled || (!newV && oldV)) {
               return;
             }
-
             // Click handler
             const onClick = (e: MouseEvent) => {
               // Fix radio button click twice


### PR DESCRIPTION
### Antd Vue Version

4.0.1

### BUG描述

修复按钮loading状态切换的动画bug。当按钮多次切换到loading状态之后，点击按钮，会发现按钮的波浪动画颜色很深（其实是建立了多个wave的动画元素）

![ded22ef92fd1ddbc447999503cf65d1](https://github.com/vueComponent/ant-design-vue/assets/32154293/0646ebf9-c7b0-4bee-8eab-d87a417d0b8d)
![d4eb4b46d817318ea60ef883bc2ee4f](https://github.com/vueComponent/ant-design-vue/assets/32154293/679dcaea-568e-4466-9426-8aaf2da79573)

### 复现链接

https://codesandbox.io/s/antd-vue-4-0-button-wave-bug-cftvrz?file=/src/demo.vue

### 复现步骤

```vue
<script setup>
import {ref} from "vue"
const isLoading = ref(false);
const clickBtn = ()=>{
  isLoading.value = true;
  setTimeout(() => {
    isLoading.value = false;
  }, 3000);
}    
</script>

<template>
  <a-space>
      <a-button :loading="isLoading">Antd Vue1</a-button>
      <a-button>Antd Vue2</a-button>
      <a-button :disabled="isLoading" @click="clickBtn">click!click!</a-button>
    </a-space>
</template>
```

1. 打开复现链接或者采用上面的代码（下面将会以上面的代码作为描述的前提）
2. 在打开的链接页面，点击最后一个按钮`click!click!`，等待模拟异步请求完成，loading状态切换为false。
3. 重复2步骤多次
4. 点击第一个按钮`Antd Vue1`,会发现波浪动画的颜色很深，而第二个按钮不会。

### 代码改动说明
![da249d5f561b187530464396fa1edf2](https://github.com/vueComponent/ant-design-vue/assets/32154293/5f025181-43b1-4587-beea-0e85e14bc4cb)

改动的代码文件是`ant-design-vue\components\_util\wave\index.tsx`

增加了`(!newV && oldV)`的判断条件。

原本出现这个bug是因为当loading状态切换为true的时候（`props.disabled`也为true），会触发`watch`，由于在`nextTick`中判断了`props.disabled`，所以不会新建`wave`动画元素，但是当异步请求结束，loading状态变为false，此时也会触发`watch`，但是在`nextTick`中没有拦截这种情况，就导致了会新建一个`wave`动画元素。多次反复之后就会新建多个`wave`动画元素。

所以我判断了如果loading状态从true变为false的时候，不会新建`wave`动画元素。

### 其它问题

从正常状态切换loading状态的时候，在loading状态时点击还存在wave动画，这是否符合最初的设计？

因为我看到官网上的例子，如果一开始就是loading状态，点击的时候不会有wave动画。

在此PR中没有涉及这个问题的更改。