### PR TITLE
fix(ImageGroup):fix open imagegroup without animation 🍅

### DIFF
--- a/components/image/PreviewGroup.tsx
+++ b/components/image/PreviewGroup.tsx
@@ -12,6 +12,7 @@ import CloseOutlined from '@ant-design/icons-vue/CloseOutlined';
 import LeftOutlined from '@ant-design/icons-vue/LeftOutlined';
 import RightOutlined from '@ant-design/icons-vue/RightOutlined';
 import SwapOutlined from '@ant-design/icons-vue/SwapOutlined';
+import { getTransitionName } from '../_util/transition';
 import useStyle from './style';
 import { anyType } from '../_util/type';
 
@@ -38,7 +39,7 @@ const InternalPreviewGroup = defineComponent({
   inheritAttrs: false,
   props: previewGroupProps(),
   setup(props, { attrs, slots }) {
-    const { prefixCls } = useConfigInject('image', props);
+    const { prefixCls, rootPrefixCls } = useConfigInject('image', props);
     const previewPrefixCls = computed(() => `${prefixCls.value}-preview`);
     const [wrapSSR, hashId] = useStyle(prefixCls);
     const mergedPreview = computed(() => {
@@ -51,6 +52,12 @@ const InternalPreviewGroup = defineComponent({
       return {
         ..._preview,
         rootClassName: hashId.value,
+        transitionName: getTransitionName(rootPrefixCls.value, 'zoom', _preview.transitionName),
+        maskTransitionName: getTransitionName(
+          rootPrefixCls.value,
+          'fade',
+          _preview.maskTransitionName,
+        ),
       };
     });
     return () => {


### PR DESCRIPTION
### Antd Version

4.0.1

### Bug详情

`<ImageGroup/>`图片预览打开时候没有过渡动画

### 复现链接

[ImageGroup without animation - CodeSandbox](https://codesandbox.io/s/imagegroup-without-animation-rc7mpp?file=/src/demo.vue)

### 复现步骤

1. 点击上述链接或者官网查看Image组件的文档
2. 点击ImageGroup的多个图片预览，没有过渡动画