### PR TITLE
docs: github icon support hover tips and optimized the background 

### DIFF
--- a/site/src/layouts/header/Github.vue
+++ b/site/src/layouts/header/Github.vue
@@ -3,20 +3,7 @@
     <template #title>Github</template>
     <span id="github-btn" class="github-btn" :style="githubIconStyles">
       <a class="gh-btn" href="https://github.com/vueComponent/ant-design-vue" target="_blank">
-        <svg
-          viewBox="64 64 896 896"
-          focusable="false"
-          data-icon="github"
-          width="1em"
-          height="1em"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            d="M511.6 76.3C264.3 76.2 64 276.4 64 523.5 64 718.9 189.3 885 363.8 946c23.5 5.9 19.9-10.8 19.9-22.2v-77.5c-135.7 15.9-141.2-73.9-150.3-88.9C215 726 171.5 718 184.5 703c30.9-15.9 62.4 4 98.9 57.9 26.4 39.1 77.9 32.5 104 26 5.7-23.5 17.9-44.5 34.7-60.8-140.6-25.2-199.2-111-199.2-213 0-49.5 16.3-95 48.3-131.7-20.4-60.5 1.9-112.3 4.9-120 58.1-5.2 118.5 41.6 123.2 45.3 33-8.9 70.7-13.6 112.9-13.6 42.4 0 80.2 4.9 113.5 13.9 11.3-8.6 67.3-48.8 121.3-43.9 2.9 7.7 24.7 58.3 5.5 118 32.4 36.8 48.9 82.7 48.9 132.3 0 102.2-59 188.1-200 212.9a127.5 127.5 0 0138.1 91v112.5c.8 9 0 17.9 15 17.9 177.1-59.7 304.6-227 304.6-424.1 0-247.2-200.4-447.3-447.5-447.3z"
-          ></path>
-        </svg>
-        <span class="gh-text">Star</span>
+        <GithubOutlined class="github-icon" />
       </a>
     </span>
   </a-tooltip>
@@ -24,8 +11,11 @@
 
 <script lang="ts">
 import { defineComponent, inject, computed } from 'vue';
-
+import { GithubOutlined } from '@ant-design/icons-vue';
 export default defineComponent({
+  components: {
+    GithubOutlined,
+  },
   setup() {
     const themeMode = inject('themeMode');
     const githubIconStyles = computed(() => {
@@ -53,7 +43,6 @@ export default defineComponent({
 
   .gh-btn {
     color: currentColor;
-    font-size: 1.75em;
     height: auto;
     padding: 6px;
     background: transparent;
@@ -73,6 +62,10 @@ export default defineComponent({
     .gh-text {
       display: none;
     }
+  }
+
+  .github-icon {
+    font-size: 16px;
   }
 
   .gh-count {

--- a/site/src/layouts/header/Github.vue
+++ b/site/src/layouts/header/Github.vue
@@ -65,7 +65,8 @@ export default defineComponent({
   }
 
   .github-icon {
-    font-size: 16px;
+    font-size: 18px;
+    color: var(--text-color);
   }
 
   .gh-count {

--- a/site/src/layouts/header/Github.vue
+++ b/site/src/layouts/header/Github.vue
@@ -1,11 +1,49 @@
 <template>
-  <span id="github-btn" class="github-btn">
-    <a class="gh-btn" href="https://github.com/vueComponent/ant-design-vue" target="_blank">
-      <span class="gh-ico" aria-hidden="true"></span>
-      <span class="gh-text">Star</span>
-    </a>
-  </span>
+  <a-tooltip placement="bottom">
+    <template #title>Github</template>
+    <span id="github-btn" class="github-btn" :style="githubIconStyles">
+      <a class="gh-btn" href="https://github.com/vueComponent/ant-design-vue" target="_blank">
+        <svg
+          viewBox="64 64 896 896"
+          focusable="false"
+          data-icon="github"
+          width="1em"
+          height="1em"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            d="M511.6 76.3C264.3 76.2 64 276.4 64 523.5 64 718.9 189.3 885 363.8 946c23.5 5.9 19.9-10.8 19.9-22.2v-77.5c-135.7 15.9-141.2-73.9-150.3-88.9C215 726 171.5 718 184.5 703c30.9-15.9 62.4 4 98.9 57.9 26.4 39.1 77.9 32.5 104 26 5.7-23.5 17.9-44.5 34.7-60.8-140.6-25.2-199.2-111-199.2-213 0-49.5 16.3-95 48.3-131.7-20.4-60.5 1.9-112.3 4.9-120 58.1-5.2 118.5 41.6 123.2 45.3 33-8.9 70.7-13.6 112.9-13.6 42.4 0 80.2 4.9 113.5 13.9 11.3-8.6 67.3-48.8 121.3-43.9 2.9 7.7 24.7 58.3 5.5 118 32.4 36.8 48.9 82.7 48.9 132.3 0 102.2-59 188.1-200 212.9a127.5 127.5 0 0138.1 91v112.5c.8 9 0 17.9 15 17.9 177.1-59.7 304.6-227 304.6-424.1 0-247.2-200.4-447.3-447.5-447.3z"
+          ></path>
+        </svg>
+        <span class="gh-text">Star</span>
+      </a>
+    </span>
+  </a-tooltip>
 </template>
+
+<script lang="ts">
+import { defineComponent, inject, computed } from 'vue';
+
+export default defineComponent({
+  setup() {
+    const themeMode = inject('themeMode');
+    const githubIconStyles = computed(() => {
+      let iconBackgroundColor = 'rgba(0,0,0,0.06)';
+      if ((themeMode as any).theme.value === 'dark') {
+        iconBackgroundColor = 'rgba(255,255,255,0.12)';
+      }
+      return {
+        '--github-icon-background-color': iconBackgroundColor,
+      };
+    });
+    return {
+      githubIconStyles,
+    };
+  },
+});
+</script>
+
 <style lang="less" scoped>
 @import './Github.less';
 #github-btn {
@@ -14,10 +52,17 @@
   height: auto;
 
   .gh-btn {
+    color: currentColor;
+    font-size: 1.75em;
     height: auto;
-    padding: 1px 4px;
+    padding: 6px;
     background: transparent;
     border: 0;
+    transition: all 0.2s;
+
+    &:hover {
+      background: var(--github-icon-background-color);
+    }
 
     .gh-ico {
       width: 20px;


### PR DESCRIPTION
1. optimized the background color under hover
2. gitHub icon support for tooltip hints
<img width="291" alt="image" src="https://github.com/vueComponent/ant-design-vue/assets/71313168/b25e18f0-9f6a-4ee9-963a-43dd06f16838">
<img width="372" alt="image" src="https://github.com/vueComponent/ant-design-vue/assets/71313168/2f4c68d7-2bc9-465b-9411-48462ecc5173">
