### PR TITLE
docs(Modal):fix full-screen modal on the presentation documentation has no effect🥠

### DIFF
--- a/components/modal/demo/fullscreen.vue
+++ b/components/modal/demo/fullscreen.vue
@@ -45,7 +45,7 @@ const handleOk = (e: MouseEvent) => {
   open.value = false;
 };
 </script>
-<style lang="less" scoped>
+<style lang="less">
 .full-modal {
   .ant-modal {
     max-width: 100%;


### PR DESCRIPTION
### Version
4.0.1

### Bug描述
在官网关于`Modal`组件全屏的演示文档中，发现无法全屏显示Modal，如下图所示
![28892b6934562304d8e34c7eeb77c42](https://github.com/vueComponent/ant-design-vue/assets/32154293/eda80a19-8e85-4b05-91ec-cdcbce37d8b3)
