### PR TITLE
fix: table expandColumnTitle slot type declaration

### DIFF
--- a/components/table/Table.tsx
+++ b/components/table/Table.tsx
@@ -653,6 +653,7 @@ const Table = defineComponent({
     footer?: any;
     summary?: any;
     expandedRowRender?: any;
+    expandColumnTitle?: any;
     bodyCell?: {
       text: any;
       value: any;


### PR DESCRIPTION
![image](https://github.com/vueComponent/ant-design-vue/assets/82451257/41b8c0e4-eca4-4653-9db4-07cadc537a1a)
