### PR TITLE
docs: correct simple copy-paste error

### DIFF
--- a/components/list/demo/loadmore.vue
+++ b/components/list/demo/loadmore.vue
@@ -12,7 +12,7 @@ title:
 
 ## en-US
 
-Load more list with `loadMore` property.
+Load more list with `loadMore` slot.
 
 </docs>
 


### PR DESCRIPTION
Corrects a single word which is probably taken from the React version.