### PR TITLE
docs: update dynamic form item demo

### DIFF
--- a/components/form/demo/dynamic-form-item.vue
+++ b/components/form/demo/dynamic-form-item.vue
@@ -41,7 +41,6 @@ Add or remove form items dynamically.
       <MinusCircleOutlined
         v-if="dynamicValidateForm.domains.length > 1"
         class="dynamic-delete-button"
-        :disabled="dynamicValidateForm.domains.length === 1"
         @click="removeDomain(domain)"
       />
     </a-form-item>


### PR DESCRIPTION
![image](https://github.com/vueComponent/ant-design-vue/assets/82451257/b26e10b8-04e5-400e-a5b0-e5f1982aad0c)

并且这个判断有逻辑问题，当 `dynamicValidateForm.domains.length`  不为 1 的时候都被带上了 `disabled` 属性，并且 `disabled` 没有任何作用，依然可以点击。

> There is a logic issue here. When dynamicValidateForm.domains.length is not equal to 1, the component receives the disabled property. Furthermore, the disable property seems to serve no purpose, as you can also trigger a click event.