### PR TITLE
fix: TimePicker Panel use moment.clone

### DIFF
--- a/components/vc-time-picker/Panel.jsx
+++ b/components/vc-time-picker/Panel.jsx
@@ -27,7 +27,7 @@ function toNearestValidTime(time, hourOptions, minuteOptions, secondOptions) {
   const second = secondOptions
     .slice()
     .sort((a, b) => Math.abs(time.second() - a) - Math.abs(time.second() - b))[0];
-  return moment(`${hour}:${minute}:${second}`, 'HH:mm:ss');
+  return time.clone().hour(hour).minute(minute).second(second).startOf('second');
 }
 
 const Panel = {


### PR DESCRIPTION
moment(xxx, 'HH:mm:ss') use Date() to access default year month date, which cause bug when timezone setted
https://github.com/moment/moment/pull/6169