### PR TITLE
fix(message): getContainer prop doesn't work

### DIFF
--- a/components/_util/Portal.tsx
+++ b/components/_util/Portal.tsx
@@ -1,5 +1,13 @@
 import PropTypes from './vue-types';
-import { defineComponent, nextTick, onBeforeMount, onUpdated, Teleport, watch } from 'vue';
+import {
+  defineComponent,
+  nextTick,
+  onBeforeMount,
+  onMounted,
+  onUpdated,
+  Teleport,
+  watch,
+} from 'vue';
 import { useInjectPortal } from '../vc-trigger/context';
 
 export default defineComponent({
@@ -17,6 +25,8 @@ export default defineComponent({
     const { shouldRender } = useInjectPortal();
     onBeforeMount(() => {
       isSSR = false;
+    });
+    onMounted(() => {
       if (shouldRender.value) {
         container = props.getContainer();
       }

--- a/components/config-provider/hooks/useConfigInject.ts
+++ b/components/config-provider/hooks/useConfigInject.ts
@@ -24,7 +24,7 @@ export default (name: string, props: Record<any, any>) => {
     () => props.getTargetContainer ?? configProvider.getTargetContainer?.value,
   );
   const getPopupContainer = computed(
-    () => props.getPopupContainer ?? configProvider.getPopupContainer?.value,
+    () => props.getContainer ?? props.getPopupContainer ?? configProvider.getPopupContainer?.value,
   );
 
   const dropdownMatchSelectWidth = computed<boolean | number>(


### PR DESCRIPTION
close: #6937 

1. In the `useConfigInject.ts` file, add `props.getContainer` to the return value of `getPopupContainer` so that we can correctly assign `getPopupContainer` in `useMessage.tsx`.

> 在  `useConfigInject.ts` 文件中将 `props.getContainer` 添加到 `getPopupContainer` 的返回中，这样我们才能正确的在 `useMessage.tsx` 中给 `getPopupContainer` 正确赋值

```diff
// useConfigInject.ts
const getPopupContainer = computed(
- () => props.getPopupContainer ?? configProvider.getPopupContainer?.value,
+ () => props.getContainer ?? props.getPopupContainer ?? configProvider.getPopupContainer?.value,
);

// useMessage.tsx
const { getPrefixCls, getPopupContainer } = useConfigInject('message', props);
```
2. Attempting to access the DOM elements of the page within the `onBeforeMount` lifecycle hook returns null. Therefore, this method should be called within the `onMounted` lifecycle hook.

> 在 `onBeforeMount` 生命周期函数中去获取页面的 DOM 元素，会得到 null，所以应该在 `onMounted` 生命周期中调用该方法


After: 
![image](https://github.com/vueComponent/ant-design-vue/assets/82451257/91abeba8-bf1f-43db-bae1-e9d43a2da860)
