### PR TITLE
fix(vc-image): remove repeat listener

### DIFF
--- a/components/vc-image/src/Image.tsx
+++ b/components/vc-image/src/Image.tsx
@@ -97,9 +97,6 @@ const ImageInternal = defineComponent({
       onChange: onPreviewVisibleChange,
     });
 
-    watch(isShowPreview, (val, preVal) => {
-      onPreviewVisibleChange(val, preVal);
-    });
     const status = ref<ImageStatus>(isCustomPlaceholder.value ? 'loading' : 'normal');
     watch(
       () => props.src,


### PR DESCRIPTION
close: #6944 

```diff
const [isShowPreview, setShowPreview] = useMergedState(!!previewVisible.value, {
  value: previewVisible,
  onChange: onPreviewVisibleChange,
});

- watch(isShowPreview, (val, preVal) => {
-  onPreviewVisibleChange(val, preVal);
- });
```
`useMergedState` 这个方法里面传递了 `onChange` 属性，所以就没有必要再监听 `isShowPreview` 的变化了