### PR TITLE
fix: fetchCode get blocks in specific order

### DIFF
--- a/plugin/md/markdownToVue.ts
+++ b/plugin/md/markdownToVue.ts
@@ -139,13 +139,13 @@ import ColorChunk from '@/components/ColorChunk';
 import TokenTable from '@/components/TokenTable';
 import ComponentTokenTable from '@/components/ComponentTokenTable';
 
-export default { 
+export default {
     components: {
         ColorChunk,
-        TokenTable, 
+        TokenTable,
         ComponentTokenTable
-    }, 
-    pageData: ${JSON.stringify(pageData)} 
+    },
+    pageData: ${JSON.stringify(pageData)}
 }
 </script>
 ${fetchCode(content, 'style')}

--- a/plugin/md/utils/fetchCode.ts
+++ b/plugin/md/utils/fetchCode.ts
@@ -13,18 +13,6 @@ const reObj = {
 };
 
 export default function fetchCode(src: string, type: string): string {
-  if (type === 'template') {
-    //     const $ = cheerio.load(src, {
-    //       decodeEntities: false,
-    //       xmlMode: false,
-    //       recognizeSelfClosing: true,
-    //       _useHtmlParser2: true,
-    //     });
-    //     return `<template>
-    //   ${$(type).html().trim()}
-    // </template>`;
-    src = src.split('<script')[0];
-  }
   const matches = src.match(reObj[type]);
   return matches ? matches[0] : '';
 }


### PR DESCRIPTION
`fetchCode` 只能按照下面的顺序才能正确渲染内容

```vue
<template>...</template>
<script>...</script> 
```
而这样会出现内容为空的情况
```vue
<script>...</script> 
<template>...</template>
```