### PR TITLE
fix: duplicate identifier 'AStyleProvider'

### DIFF
--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -266,8 +266,6 @@ declare module 'vue' {
     ABackTop: typeof import('ant-design-vue')['BackTop'];
 
     AWatermark: typeof import('ant-design-vue')['Watermark'];
-
-    AStyleProvider: typeof import('ant-design-vue')['StyleProvider'];
   }
 }
 export {};


### PR DESCRIPTION
`AStyleProvider` has defined:
https://github.com/vueComponent/ant-design-vue/blob/3c5fb845428ddaa587e539e5dfbdb815a61b8dca/typings/global.d.ts#L64C70-L64C70