### PR TITLE
Fix Upload component event

### DIFF
--- a/components/vc-upload/AjaxUploader.tsx
+++ b/components/vc-upload/AjaxUploader.tsx
@@ -302,6 +302,7 @@ export default defineComponent({
             type="file"
             ref={fileInput}
             onClick={e => e.stopPropagation()} // https://github.com/ant-design/ant-design/issues/19948
+            onCancel={e => e.stopPropagation()}
             key={uid.value}
             style={{ display: 'none' }}
             accept={accept}


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch. Pull request will be merged after one of collaborators approve. Please makes sure that these form are filled before submitting your pull request, thank you!

[[中文版模板 / Chinese template](https://github.com/vueComponent/ant-design-vue/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md)]

### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### Changelog description (Optional if not new feature)

1. 修复 `<input type="file"/>`  在chrome117版本下，cancel事件冒泡 被外层 onCancel监听捕获的问题

上传组件弹出的文件选择框，点击取消后会一直冒泡传递到最外层。。这时候如果有个组件刚好写了onCancel就会被执行

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Additional Plan? (Optional if not new feature)

> If this PR related with other PR or following info. You can type here.
