### PR TITLE
fix(FloatButton): BackTop attribute invalid

### DIFF
--- a/components/float-button/BackTop.tsx
+++ b/components/float-button/BackTop.tsx
@@ -25,7 +25,6 @@ import { useInjectFloatButtonGroupContext } from './context';
 const BackTop = defineComponent({
   compatConfig: { MODE: 3 },
   name: 'ABackTop',
-  inheritAttrs: false,
   props: initDefaultProps(backTopProps(), {
     visibilityHeight: 400,
     target: () => window,
@@ -126,6 +125,7 @@ const BackTop = defineComponent({
           [`${attrs.class}`]: attrs.class,
           [`${prefixCls.value}-rtl`]: direction.value === 'rtl',
         },
+        type: props.type,
       };
 
       const transitionProps = getTransitionProps('fade');

--- a/components/float-button/BackTop.tsx
+++ b/components/float-button/BackTop.tsx
@@ -25,6 +25,7 @@ import { useInjectFloatButtonGroupContext } from './context';
 const BackTop = defineComponent({
   compatConfig: { MODE: 3 },
   name: 'ABackTop',
+  inheritAttrs: false,
   props: initDefaultProps(backTopProps(), {
     visibilityHeight: 400,
     target: () => window,
@@ -109,23 +110,21 @@ const BackTop = defineComponent({
     });
     const floatButtonGroupContext = useInjectFloatButtonGroupContext();
     return () => {
-      const defaultElement = (
-        <div class={`${prefixCls.value}-content`}>
-          <div class={`${prefixCls.value}-icon`}>
-            <VerticalAlignTopOutlined />
-          </div>
-        </div>
-      );
+      const { description, type, shape, tooltip, badge } = props;
+
       const floatButtonProps = {
         ...attrs,
-        shape: floatButtonGroupContext?.shape.value || props.shape,
+        shape: floatButtonGroupContext?.shape.value || shape,
         onClick: scrollToTop,
         class: {
           [`${prefixCls.value}`]: true,
           [`${attrs.class}`]: attrs.class,
           [`${prefixCls.value}-rtl`]: direction.value === 'rtl',
         },
-        type: props.type,
+        description,
+        type,
+        tooltip,
+        badge,
       };
 
       const transitionProps = getTransitionProps('fade');
@@ -133,8 +132,7 @@ const BackTop = defineComponent({
         <Transition {...transitionProps}>
           <FloatButton v-show={state.visible} {...floatButtonProps} ref={domRef}>
             {{
-              icon: () => <VerticalAlignTopOutlined />,
-              default: () => slots.default?.() || defaultElement,
+              icon: () => slots.default?.() || slots.icon?.() || <VerticalAlignTopOutlined />,
             }}
           </FloatButton>
         </Transition>,

--- a/components/float-button/BackTop.tsx
+++ b/components/float-button/BackTop.tsx
@@ -132,7 +132,7 @@ const BackTop = defineComponent({
         <Transition {...transitionProps}>
           <FloatButton v-show={state.visible} {...floatButtonProps} ref={domRef}>
             {{
-              icon: () => slots.default?.() || slots.icon?.() || <VerticalAlignTopOutlined />,
+              icon: () => slots.icon?.() || <VerticalAlignTopOutlined />,
             }}
           </FloatButton>
         </Transition>,


### PR DESCRIPTION
[#7008 ](https://github.com/vueComponent/ant-design-vue/issues/7008)
![image](https://github.com/vueComponent/ant-design-vue/assets/69418751/69bdcc21-c711-4057-a078-969927f55ee1)
将inheritAttrs删除是因为组件内有消费attrs，type从props中取则是被声明过的props无法从attribute中获取