### PR TITLE
docs(menu): fix typo

### DIFF
--- a/components/menu/index.en-US.md
+++ b/components/menu/index.en-US.md
@@ -33,10 +33,10 @@ More layouts with navigation: [Layout](/components/layout).
 | items | Menu item content | [ItemType\[\]](#ItemType) | - | 4.20.0 |
 | mode | type of the menu; `vertical`, `horizontal`, and `inline` modes are supported | `vertical` \| `horizontal` \| `inline` | `vertical` |
 | multiple | Allow selection of multiple items | boolean | false |
-| openKeys(v-model) | array with the keys of currently opened sub menus | string\[] |  |
+| openKeys(v-model) | array with the keys of currently opened sub menus | (string \| number)[] |  |
 | overflowedIndicator | Customized the ellipsis icon when menu is collapsed horizontally | slot | `<EllipsisOutlined />` |
 | selectable | allow selecting menu items | boolean | true |
-| selectedKeys(v-model) | array with the keys of currently selected menu items | string\[] |  |
+| selectedKeys(v-model) | array with the keys of currently selected menu items | (string \| number)[] |  |
 | style | style of the root node | object |  |
 | subMenuCloseDelay | delay time to hide submenu when mouse leave, unit: second | number | 0.1 |
 | subMenuOpenDelay | delay time to show submenu when mouse enter, unit: second | number | 0 |
@@ -49,7 +49,7 @@ More layouts with navigation: [Layout](/components/layout).
 | --- | --- | --- |
 | click | callback executed when a menu item is clicked | function({ item, key, keyPath }) |
 | deselect | callback executed when a menu item is deselected, only supported for multiple mode | function({ item, key, selectedKeys }) |
-| openChange | called when open/close sub menu | function(openKeys: string\[]) |
+| openChange | called when open/close sub menu | function(openKeys: (string \| number)[]) |
 | select | callback executed when a menu item is selected | function({ item, key, selectedKeys }) |
 
 ### Menu.Item
@@ -57,7 +57,7 @@ More layouts with navigation: [Layout](/components/layout).
 | Param    | Description                          | Type           | Default value |
 | -------- | ------------------------------------ | -------------- | ------------- |
 | disabled | whether menu item is disabled or not | boolean        | false         |
-| key      | unique id of the menu item           | string         |               |
+| key      | unique id of the menu item           | string \| number         |               |
 | title    | set display title for collapsed item | string \| slot |               |
 
 ### ItemType
@@ -71,7 +71,7 @@ More layouts with navigation: [Layout](/components/layout).
 | danger | Display the danger style | boolean | false |  |
 | disabled | Whether menu item is disabled | boolean | false |  |
 | icon | The icon of the menu item | VueNode \| (item: MenuItemType) => VNode | - |  |
-| key | Unique ID of the menu item | string | - |  |
+| key | Unique ID of the menu item | string \| number | - |  |
 | label | Menu label | VueNode | - |  |
 | title | Set display title for collapsed item | string | - |  |
 
@@ -83,7 +83,7 @@ More layouts with navigation: [Layout](/components/layout).
 | children | Sub-menus or sub-menu items | [ItemType\[\]](#ItemType) | - |  |
 | disabled | Whether sub-menu is disabled | boolean | false |  |
 | icon | Icon of sub menu | VueNode \| (item: SubMenuType) => VueNode | - |  |
-| key | Unique ID of the sub-menu | string | - |  |
+| key | Unique ID of the sub-menu | string \| number | - |  |
 | label | Menu label | VueNode | - |  |
 | popupClassName | Sub-menu class name, not working when `mode="inline"` | string | - |  |
 | popupOffset | Sub-menu offset, not working when `mode="inline"` | \[number, number] | - |  |
@@ -127,7 +127,7 @@ const dividerItem = {
 | --- | --- | --- | --- | --- |
 | disabled | whether sub menu is disabled or not | boolean | false |  |
 | expandIcon | Customized expandIcon | slot | arrow icon | ｜ |
-| key | Unique ID of the sub menu, required | string |  |  |
+| key | Unique ID of the sub menu, required | string \| number |  |  |
 | popupClassName | Sub-menu class name | string |  | 1.5.0 |
 | popupOffset | Sub-menu offset, not working when `mode="inline"` | \[number, number] | - |  |
 | title | title of the sub menu | string\|slot |  |  |

--- a/components/menu/index.zh-CN.md
+++ b/components/menu/index.zh-CN.md
@@ -34,10 +34,10 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*Vn4XSqJFAxcAAA
 | items | 菜单内容 | [ItemType\[\]](#ItemType) | - |  |
 | mode | 菜单类型，现在支持垂直、水平、和内嵌模式三种 | `vertical` \| `horizontal` \| `inline` | `vertical` |
 | multiple | 是否允许多选 | boolean | false |
-| openKeys(v-model) | 当前展开的 SubMenu 菜单项 key 数组 | string\[] |  |
+| openKeys(v-model) | 当前展开的 SubMenu 菜单项 key 数组 | (string \| number)[] |  |
 | overflowedIndicator | 用于自定义 Menu 水平空间不足时的省略收缩的图标 | slot | `<EllipsisOutlined />` |
 | selectable | 是否允许选中 | boolean | true |
-| selectedKeys(v-model) | 当前选中的菜单项 key 数组 | string\[] |  |
+| selectedKeys(v-model) | 当前选中的菜单项 key 数组 | (string \| number)[] |  |
 | subMenuCloseDelay | 用户鼠标离开子菜单后关闭延时，单位：秒 | number | 0.1 |
 | subMenuOpenDelay | 用户鼠标进入子菜单后开启延时，单位：秒 | number | 0 |
 | theme | 主题颜色 | `light` \| `dark` | `light` |
@@ -49,7 +49,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*Vn4XSqJFAxcAAA
 | ---------- | ---------------------------------- | ------------------------------------- |
 | click      | 点击 MenuItem 调用此函数           | function({ item, key, keyPath })      |
 | deselect   | 取消选中时调用，仅在 multiple 生效 | function({ item, key, selectedKeys }) |
-| openChange | SubMenu 展开/关闭的回调            | function(openKeys: string\[])         |
+| openChange | SubMenu 展开/关闭的回调            | function(openKeys: (string \| number)[])         |
 | select     | 被选中时调用                       | function({ item, key, selectedKeys }) |
 
 ### Menu.Item
@@ -58,7 +58,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*Vn4XSqJFAxcAAA
 | -------- | ------------------------ | -------------- | ------ | ----- |
 | disabled | 是否禁用                 | boolean        | false  |       |
 | icon     | 菜单图标                 | slot           |        | 2.8.0 |
-| key      | item 的唯一标志          | string         |        |       |
+| key      | item 的唯一标志          | string \| number         |        |       |
 | title    | 设置收缩时展示的悬浮标题 | string \| slot |        |       |
 
 ### ItemType
@@ -72,7 +72,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*Vn4XSqJFAxcAAA
 | danger   | 展示错误状态样式         | boolean                                | false  |      |
 | disabled | 是否禁用                 | boolean                                | false  |      |
 | icon     | 菜单图标                 | VueNode\|(item: MenuItemType)=>VueNode | -      |      |
-| key      | item 的唯一标志          | string                                 | -      |      |
+| key      | item 的唯一标志          | string \| number                                 | -      |      |
 | label    | 菜单项标题               | VueNode                                | -      |      |
 | title    | 设置收缩时展示的悬浮标题 | string                                 | -      |      |
 
@@ -83,7 +83,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*Vn4XSqJFAxcAAA
 | children | 子菜单的菜单项 | [ItemType\[\]](#ItemType) | - |  |
 | disabled | 是否禁用 | boolean | false |  |
 | icon | 菜单图标 | VueNode\|(item: SubMenuType)=>VueNode | - |  |
-| key | 唯一标志 | string | - |  |
+| key | 唯一标志 | string \| number | - |  |
 | label | 菜单项标题 | VueNode | - |  |
 | popupClassName | 子菜单样式，`mode="inline"` 时无效 | string | - |  |
 | popupOffset | 子菜单偏移量，`mode="inline"` 时无效 | \[number, number] | - |  |
@@ -128,7 +128,7 @@ const dividerItem = {
 | disabled       | 是否禁用                             | boolean           | false    |       |
 | expandIcon     | 自定义 Menu 展开收起图标             | slot              | 箭头图标 |       |
 | icon           | 菜单图标                             | slot              |          | 2.8.0 |
-| key            | 唯一标志, 必填                       | string            |          |       |
+| key            | 唯一标志, 必填                       | string \| number           |          |       |
 | popupClassName | 子菜单样式                           | string            |          | 1.5.0 |
 | popupOffset    | 子菜单偏移量，`mode="inline"` 时无效 | \[number, number] | -        |       |
 | title          | 子菜单项值                           | string\|slot      |          |       |

--- a/components/menu/src/interface.ts
+++ b/components/menu/src/interface.ts
@@ -15,7 +15,7 @@ export interface SubMenuType extends ItemSharedProps {
 
   disabled?: boolean;
 
-  key: string;
+  key: Key;
   theme?: MenuTheme;
   rootClassName?: string;
 


### PR DESCRIPTION
类型文件中字段`key`的类型为`Key`

```ts
// _util/type.ts line 22
export type Key = string | number;
```