### PR TITLE
fix: rangePick onOk can't close the panel

### DIFF
--- a/components/vc-picker/utils/getRanges.tsx
+++ b/components/vc-picker/utils/getRanges.tsx
@@ -40,7 +40,13 @@ export default function getRanges({
 
     okNode = needConfirmButton && (
       <li class={`${prefixCls}-ok`}>
-        <Button disabled={okDisabled} onClick={onOk}>
+        <Button
+          disabled={okDisabled}
+          onClick={e => {
+            e.stopPropagation();
+            onOk && onOk();
+          }}
+        >
           {locale.ok}
         </Button>
       </li>


### PR DESCRIPTION
fix: #6911 ，正常情况已在 #6994 中解决。
fix: 另一种情况，当RangePick中同时存在getPopupContainer和showTime的时候还是会存在此问题。