### PR TITLE
fix(theme-editor): handleEditConfigChange logic

### DIFF
--- a/site/src/views/theme-editor/index.vue
+++ b/site/src/views/theme-editor/index.vue
@@ -136,14 +136,10 @@ export default defineComponent({
 
     const handleEditConfigChange = (newcontent, _, status) => {
       themeConfigContent.value = newcontent;
-      if (
-        status.contentErrors &&
-        Array.isArray(status.contentErrors.validationErrors) &&
-        status.contentErrors.validationErrors.length === 0
-      ) {
-        editThemeFormatRight.value = true;
-      } else {
+      if (status.contentErrors && status.contentErrors.parseError) {
         editThemeFormatRight.value = false;
+      } else {
+        editThemeFormatRight.value = true;
       }
     };
 


### PR DESCRIPTION
close: #7035 

![image](https://github.com/vueComponent/ant-design-vue/assets/82451257/192f67be-367d-45f9-bce9-4ccd0cef6e94)

控制台输出
- 第一个输出是修改内容但没有出现错误的输出
- 第二个输出是制造了错误的输出

可以发现没有错误的时候 `status.contentErrors` 是 `null`, 出现错误时会有一个 `parseError` 字段。为什么不用 `isRepairable`  的原因是出现两个地方的错误时这个字段的值就会改变，如下图。

![image](https://github.com/vueComponent/ant-design-vue/assets/82451257/315d6d2d-c675-4040-92b0-ebb380c030f4)
