### PR TITLE
component(message): fix message offset error

### DIFF
--- a/components/message/style/index.ts
+++ b/components/message/style/index.ts
@@ -71,6 +71,8 @@ const genMessageStyle: GenerateStyle<MessageToken> = token => {
         ...resetComponent(token),
         position: 'fixed',
         top: marginXS,
+        left: '50%',
+        transform: 'translateX(-50%)',
         width: '100%',
         pointerEvents: 'none',
         zIndex: zIndexPopup,


### PR DESCRIPTION
Setting flex in the body property affects the fixed layout offset of the message.

Therefore the properties of the message's fixed layout are enhanced (e.g. `left` `transform`)

this is a mini reproduction [codeSandbox](https://codesandbox.io/s/vigorous-water-vw4qsq?file=/src/App.vue)

close #7065 