### PR TITLE
docs(calendar): optimize calendar docs note layout

### DIFF
--- a/components/calendar/index.en-US.md
+++ b/components/calendar/index.en-US.md
@@ -16,9 +16,11 @@ When data is in the form of dates, such as schedules, timetables, prices calenda
 
 **Note:** Part of the Calendar's locale is read from `value`. So, please set the locale of `dayjs` correctly.
 
-```html
-// The default locale is en-US, if you want to use other locale, just set locale in entry file
-globally. // import dayjs from 'dayjs'; // import 'dayjs/locale/zh-cn'; // dayjs.locale('zh-cn');
+```jsx
+// The default locale is en-US, if you want to use other locale, just set locale in entry file globally.
+// import dayjs from 'dayjs';
+// import 'dayjs/locale/zh-cn';
+// dayjs.locale('zh-cn');
 
 <a-calendar v-model:value @panelChange="onPanelChange" @select="onSelect"></a-calendar>
 ```

--- a/components/calendar/index.zh-CN.md
+++ b/components/calendar/index.zh-CN.md
@@ -17,9 +17,11 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*-p-wQLik200AAA
 
 **注意：**Calendar 部分 locale 是从 value 中读取，所以请先正确设置 dayjs 的 locale。
 
-```html
-// 默认语言为 en-US，所以如果需要使用其他语言，推荐在入口文件全局设置 locale // import dayjs from
-'dayjs'; // import 'dayjs/locale/zh-cn'; // dayjs.locale('zh-cn');
+```jsx
+// 默认语言为 en-US，所以如果需要使用其他语言，推荐在入口文件全局设置 locale
+// import dayjs from 'dayjs';
+// import 'dayjs/locale/zh-cn';
+// dayjs.locale('zh-cn');
 
 <a-calendar v-model:value="value" @panelChange="onPanelChange" @select="onSelect"></a-calendar>
 ```


### PR DESCRIPTION
Optimizing the layout of `note` in `calendar` component documents.

<img width="886" alt="image" src="https://github.com/vueComponent/ant-design-vue/assets/71313168/5c7ec5a5-b23e-4b9c-88b7-8356c1f7e217">
