### PR TITLE
docs(header): restore button hover style

### DIFF
--- a/site/src/layouts/header/index.less
+++ b/site/src/layouts/header/index.less
@@ -38,7 +38,6 @@
   // Buttons
   .header-button {
     color: var(--text-color);
-    border-color: var(--border-color-base);
   }
 }
 


### PR DESCRIPTION
In the current header component, only the switching version of the button has a highlighting effect on hover, while the other two buttons have no effect. In dark mode, standardizing the hover effect of all buttons can enhance user experience. This pr is to solve the problem of harmonizing the style of buttons under hover.

The expectation is as follows.
<img width="224" alt="image" src="https://github.com/vueComponent/ant-design-vue/assets/71313168/cc1cc936-04d3-471e-9484-8e08bd02189c">
<img width="236" alt="image" src="https://github.com/vueComponent/ant-design-vue/assets/71313168/8a69d6e6-bc7a-4cd9-9883-1f27b8e6d47b">
