### PR TITLE
fix(text-area): fix a textarea with an autosize cursor jump to the end when typing korean

### DIFF
--- a/components/input/ResizableTextArea.tsx
+++ b/components/input/ResizableTextArea.tsx
@@ -110,13 +110,7 @@ const ResizableTextArea = defineComponent({
       const cls = classNames(prefixCls, attrs.class, {
         [`${prefixCls}-disabled`]: disabled,
       });
-      const style = [
-        attrs.style,
-        textareaStyles.value,
-        resizeStatus.value === RESIZE_STATUS_RESIZING
-          ? { overflowX: 'hidden', overflowY: 'hidden' }
-          : null,
-      ];
+      const style = [attrs.style, textareaStyles.value];
       const textareaProps: any = {
         ...otherProps,
         ...attrs,


### PR DESCRIPTION
## Background

When using `textarea` with `autoSize` attribute and type Korean in a middle of the `textarea`, the cursor will move to the end.

### How to reproduce 
1. Open [textarea](https://antdv.com/components/input#components-input-demo-autosize-textarea)
2. Type a random message
3. Move cursor to a middle of the the `textarea` and switch to Korean keyboard (in a video is 2-set)
4. Press `a` to type `ㅁ` multiple time.

https://github.com/vueComponent/ant-design-vue/assets/30238194/6478d3fb-89b1-4d4e-8e57-6b9da5aaaa8f

## Fix

As mention in this [issue](https://github.com/vueComponent/ant-design-vue/issues/5922#issuecomment-1264668492), remove this css will fix the problem. The styling was added in version 1.5.0 ([PR](https://github.com/vueComponent/ant-design-vue/pull/1853/commits/356e60a12cba5b2e06b870e1a4b66609f7b24022#diff-160dbc70a94a1553592776d87a39b1d98adcddec7c2d0a2773d55d83c7ed6138), [file](https://github.com/vueComponent/ant-design-vue/blob/356e60a12cba5b2e06b870e1a4b66609f7b24022/components/input/ResizableTextArea.jsx#L92))



https://github.com/vueComponent/ant-design-vue/assets/30238194/7f18d954-59ae-47f8-9bbf-3a9d0fdcb0e5


## Related
https://github.com/vueComponent/ant-design-vue/issues/5922