### PR TITLE
fix(Menu.SubMenu): Fixed the issue that animation transitions in SubMenu mode invalidated after setting the prefixCls property globally

### DIFF
--- a/components/menu/src/Menu.tsx
+++ b/components/menu/src/Menu.tsx
@@ -341,7 +341,7 @@ export default defineComponent({
     const rootPrefixCls = computed(() => getPrefixCls());
     const defaultMotions = computed(() => ({
       horizontal: { name: `${rootPrefixCls.value}-slide-up` },
-      inline: collapseMotion,
+      inline: collapseMotion(`${rootPrefixCls.value}-motion-collapse`),
       other: { name: `${rootPrefixCls.value}-zoom-big` },
     }));
 


### PR DESCRIPTION
flx close #7148  close #https://github.com/vueComponent/ant-design-vue/pull/7150