### PR TITLE
【docs】：Code example 'setup' is missing

### DIFF
--- a/plugin/md/markdownToVue.ts
+++ b/plugin/md/markdownToVue.ts
@@ -134,18 +134,18 @@ async function genDocCode(content: string, pageData: PageData) {
   return `
 <template><article class="markdown">${pageData.html}</article></template>
 
-<script>
+<script setup>
 import ColorChunk from '@/components/ColorChunk';
 import TokenTable from '@/components/TokenTable';
 import ComponentTokenTable from '@/components/ComponentTokenTable';
 
-export default { 
+export default {
     components: {
         ColorChunk,
-        TokenTable, 
+        TokenTable,
         ComponentTokenTable
-    }, 
-    pageData: ${JSON.stringify(pageData)} 
+    },
+    pageData: ${JSON.stringify(pageData)}
 }
 </script>
 ${fetchCode(content, 'style')}

--- a/plugin/md/markdownToVue.ts
+++ b/plugin/md/markdownToVue.ts
@@ -86,7 +86,7 @@ ${vueCode?.trim()}
   const scriptContent = fetchCode(vueCode, 'scriptContent');
   let jsCode = (await tsToJs(scriptContent))?.trim();
   jsCode = jsCode
-    ? `<script>
+    ? `<script setup>
 ${jsCode}
 </script>`
     : '';
@@ -134,7 +134,7 @@ async function genDocCode(content: string, pageData: PageData) {
   return `
 <template><article class="markdown">${pageData.html}</article></template>
 
-<script setup>
+<script>
 import ColorChunk from '@/components/ColorChunk';
 import TokenTable from '@/components/TokenTable';
 import ComponentTokenTable from '@/components/ComponentTokenTable';


### PR DESCRIPTION
Modify the official website code example, switch TS to JS, the top of the example should be '<script setup>'
### issue
![image](https://github.com/vueComponent/ant-design-vue/assets/30883395/8062ade1-b216-49e3-b89c-a55d4694154d)
![image](https://github.com/vueComponent/ant-design-vue/assets/30883395/f61308a8-72de-4bf1-87de-5003e07e4d32)

### After restoration
![image](https://github.com/vueComponent/ant-design-vue/assets/30883395/f09fd5c4-6ca2-4be7-9922-80094fa6497a)

