### PR TITLE
fix: remove /* #__PURE__*/ comments

### DIFF
--- a/components/_util/hooks/_vueuse/_configurable.ts
+++ b/components/_util/hooks/_vueuse/_configurable.ts
@@ -28,7 +28,7 @@ export interface ConfigurableLocation {
   location?: Location;
 }
 
-export const defaultWindow = /* #__PURE__ */ isClient ? window : undefined;
-export const defaultDocument = /* #__PURE__ */ isClient ? window.document : undefined;
-export const defaultNavigator = /* #__PURE__ */ isClient ? window.navigator : undefined;
-export const defaultLocation = /* #__PURE__ */ isClient ? window.location : undefined;
+export const defaultWindow =  isClient ? window : undefined;
+export const defaultDocument =  isClient ? window.document : undefined;
+export const defaultNavigator =  isClient ? window.navigator : undefined;
+export const defaultLocation =  isClient ? window.location : undefined;

--- a/components/_util/hooks/_vueuse/is.ts
+++ b/components/_util/hooks/_vueuse/is.ts
@@ -21,7 +21,7 @@ export const rand = (min: number, max: number) => {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 };
 export const isIOS =
-  /* #__PURE__ */ isClient &&
+   isClient &&
   window?.navigator?.userAgent &&
   /iP(ad|hone|od)/.test(window.navigator.userAgent);
 export const hasOwn = <T extends object, K extends keyof T>(val: T, key: K): key is K =>


### PR DESCRIPTION
### 这个变动的性质是
- [x] 日常 bug 修复

### 需求背景
使用 Vite 5 打包时出现 Warning 提示 `/* #__PURE__*/` comment 被移除
相关文件 `components/_util/hooks/_vueuse/_configurable.ts`, `components/_util/hooks/_vueuse/is.ts`

相关 Issues: 
1. #7132
2. https://github.com/vitejs/vite/issues/15100#issuecomment-1835657597 

### 实现方案和 API

移除 `/* #__PURE__*/` 

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
