### PR TITLE
fix: dataRange active-bar

### DIFF
--- a/components/vc-picker/RangePicker.tsx
+++ b/components/vc-picker/RangePicker.tsx
@@ -418,8 +418,8 @@ function RangerPicker<DateType>() {
         ],
         () => {
           arrowLeft.value = 0;
-          if (mergedOpen.value && mergedActivePickerIndex.value) {
-            if (startInputDivRef.value && separatorRef.value && panelDivRef.value) {
+          if (mergedActivePickerIndex.value) {
+            if (startInputDivRef.value && separatorRef.value) {
               arrowLeft.value = startInputDivWidth.value + separatorWidth.value;
               if (
                 panelDivWidth.value &&


### PR DESCRIPTION
当我配置 open为false时，聚焦结束时间框时， 发现active状态仍是开始框， 而光标已经移入结束框， 如图（可能光标截取不到）：
<img width="579" alt="image" src="https://github.com/vueComponent/ant-design-vue/assets/91053541/17a03f25-729a-4660-8f03-38b44fa0ad56">

我认为active应聚焦在结束时间框下， 所以对代码做了些改动。