### PR TITLE
Make all components be available in theme editor

### DIFF
--- a/components/tooltip/style/index.ts
+++ b/components/tooltip/style/index.ts
@@ -134,14 +134,14 @@ export default (prefixCls: Ref<string>, injectStyle: Ref<boolean>): UseComponent
         return [];
       }
 
-      const { borderRadius, colorTextLightSolid, colorBgDefault, borderRadiusOuter } = token;
+      const { borderRadius, colorTextLightSolid, colorBgSpotlight, borderRadiusOuter } = token;
 
       const TooltipToken = mergeToken<TooltipToken>(token, {
         // default variables
         tooltipMaxWidth: 250,
         tooltipColor: colorTextLightSolid,
         tooltipBorderRadius: borderRadius,
-        tooltipBg: colorBgDefault,
+        tooltipBg: colorBgSpotlight,
         tooltipRadiusOuter: borderRadiusOuter > 4 ? 4 : borderRadiusOuter,
       });
 

--- a/site/src/components/antdv-token-previewer/ThemeEditor.tsx
+++ b/site/src/components/antdv-token-previewer/ThemeEditor.tsx
@@ -61,12 +61,13 @@ const ThemeEditor = defineComponent({
 
     const aliasOpen = ref<boolean>(false);
 
-    const { theme, infoFollowPrimary, onInfoFollowPrimaryChange, updateRef } = useControlledTheme({
-      theme: customTheme,
-      defaultTheme,
-      onChange: props.onThemeChange,
-      darkAlgorithm,
-    });
+    const { theme, infoFollowPrimary, onInfoFollowPrimaryChange, updateRef, compiledTokens } =
+      useControlledTheme({
+        theme: customTheme,
+        defaultTheme,
+        onChange: props.onThemeChange,
+        darkAlgorithm,
+      });
 
     const handleTokenSelect: TokenPanelProProps['onTokenSelect'] = (token, type) => {
       const tokens = typeof token === 'string' ? (token ? [token] : []) : token;
@@ -118,7 +119,8 @@ const ThemeEditor = defineComponent({
     });
 
     const relatedComponents = computed(() => {
-      return computedSelectedTokens.value ? getRelatedComponents(computedSelectedTokens.value) : [];
+      const compiledTokenNames = Object.keys(compiledTokens.value);
+      return computedSelectedTokens.value ? getRelatedComponents(compiledTokenNames) : [];
     });
 
     expose({

--- a/site/src/components/antdv-token-previewer/hooks/useControlledTheme.tsx
+++ b/site/src/components/antdv-token-previewer/hooks/useControlledTheme.tsx
@@ -1,14 +1,15 @@
 import type { DerivativeFunc } from 'ant-design-vue/es/_util/cssinjs';
 import { theme as antTheme } from 'ant-design-vue';
 import type { ThemeConfig } from 'ant-design-vue/es/config-provider/context';
-import type { Ref } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
 import { watchEffect, ref, computed } from 'vue';
 import type { MutableTheme, Theme } from '../interface';
 import deepUpdateObj from '../utils/deepUpdateObj';
 import getDesignToken from '../utils/getDesignToken';
 import getValueByPath from '../utils/getValueByPath';
+import type { MapToken } from 'ant-design-vue/es/theme/interface';
 
-const { darkAlgorithm: defaultDark, compactAlgorithm, defaultAlgorithm } = antTheme;
+const { darkAlgorithm: defaultDark, compactAlgorithm, defaultAlgorithm, defaultSeed } = antTheme;
 
 export type ThemeCode = 'light' | 'dark' | 'compact';
 export const themeMap: Record<ThemeCode, DerivativeFunc<any, any>> = {
@@ -29,6 +30,7 @@ export type UseControlledTheme = (options: {
   infoFollowPrimary: Ref<boolean>;
   onInfoFollowPrimaryChange: (value: boolean) => void;
   updateRef: () => void;
+  compiledTokens: ComputedRef<MapToken>;
 };
 
 const useControlledTheme: UseControlledTheme = ({ theme: customTheme, defaultTheme, onChange }) => {
@@ -79,6 +81,11 @@ const useControlledTheme: UseControlledTheme = ({ theme: customTheme, defaultThe
     }
   };
 
+  const compiledTokens = computed(() => {
+    const token = Object.assign(defaultSeed, customTheme.value.config.token);
+    return defaultAlgorithm(token);
+  });
+
   return {
     theme: computed(() => ({
       ...theme.value,
@@ -92,6 +99,7 @@ const useControlledTheme: UseControlledTheme = ({ theme: customTheme, defaultThe
       themeRef.value = theme.value;
       forceUpdate();
     },
+    compiledTokens,
   };
 };
 


### PR DESCRIPTION
1. Ensure all components are visible in the Theme Editor by considering the use alias tokens to fetch related components.
2. Correct the usage of the tooltip alias token to set it as the background color. According to Ant Design v5, the appropriate choice is **colorBgSpotlight**.
<img width="429" alt="image" src="https://github.com/vueComponent/ant-design-vue/assets/50825440/90ba07cf-e6cf-42fe-97c9-53c1eb8c61b2">
