### PR TITLE
docs(notification): Fix hooks description in demo

### DIFF
--- a/components/notification/demo/hook.vue
+++ b/components/notification/demo/hook.vue
@@ -8,7 +8,7 @@ title:
 
 ## zh-CN
 
-通过 `notification.useNotification` 创建支持读取 context 的 `contextHolder`。请注意，我们推荐通过顶层注册的方式代替 `message` 静态方法，因为静态方法无法消费上下文，因而 ConfigProvider 的数据也不会生效。
+通过 `notification.useNotification` 创建支持读取 context 的 `contextHolder`。请注意，我们推荐通过顶层注册的方式代替 `notification` 静态方法，因为静态方法无法消费上下文，因而 ConfigProvider 的数据也不会生效。
 
 ## en-US
 


### PR DESCRIPTION
中文文档里 Notification Hooks 调用描述中的变量名称有误，英文文档则正常。