### PR TITLE
fix(table): Supplement FilterDropdown type

### DIFF
--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -29,8 +29,8 @@ import devWarning from '../../../vc-util/devWarning';
 import isEqual from '../../../vc-util/isEqual';
 
 interface FilterResetProps {
-  confirm?: Boolean;
-  closeDropdown?: Boolean;
+  confirm?: boolean;
+  closeDropdown?: boolean;
 }
 
 const { SubMenu, Item: MenuItem } = Menu;

--- a/components/table/hooks/useFilter/FilterDropdown.tsx
+++ b/components/table/hooks/useFilter/FilterDropdown.tsx
@@ -28,7 +28,7 @@ import type { CheckboxChangeEvent } from '../../../checkbox/interface';
 import devWarning from '../../../vc-util/devWarning';
 import isEqual from '../../../vc-util/isEqual';
 
-interface FilterRestProps {
+interface FilterResetProps {
   confirm?: Boolean;
   closeDropdown?: Boolean;
 }
@@ -279,7 +279,7 @@ export default defineComponent<FilterDropdownProps<any>>({
     };
 
     const onReset = (
-      { confirm, closeDropdown }: FilterRestProps = { confirm: false, closeDropdown: false },
+      { confirm, closeDropdown }: FilterResetProps = { confirm: false, closeDropdown: false },
     ) => {
       if (confirm) {
         internalTriggerFilter([]);

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -269,8 +269,8 @@ interface FilterConfirmProps {
 }
 
 interface FilterResetProps {
-  confirm?: Boolean;
-  closeDropdown?: Boolean;
+  confirm?: boolean;
+  closeDropdown?: boolean;
 }
 ```
 

--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -258,10 +258,19 @@ interface FilterDropdownProps {
   setSelectedKeys: (selectedKeys: Key[]) => void;
   selectedKeys: Key[];
   confirm: (param?: FilterConfirmProps) => void;
-  clearFilters?: () => void;
+  clearFilters?: (param?: FilterResetProps) => void;
   filters?: ColumnFilterItem[];
   visible: boolean;
   column: ColumnType;
+}
+
+interface FilterConfirmProps {
+  closeDropdown: boolean;
+}
+
+interface FilterResetProps {
+  confirm?: Boolean;
+  closeDropdown?: Boolean;
 }
 ```
 

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -263,10 +263,19 @@ interface FilterDropdownProps {
   setSelectedKeys: (selectedKeys: Key[]) => void;
   selectedKeys: Key[];
   confirm: (param?: FilterConfirmProps) => void;
-  clearFilters?: () => void;
+  clearFilters?: (param?: FilterResetProps) => void;
   filters?: ColumnFilterItem[];
   visible: boolean;
   column: ColumnType;
+}
+
+interface FilterConfirmProps {
+  closeDropdown: boolean;
+}
+
+interface FilterResetProps {
+  confirm?: Boolean;
+  closeDropdown?: Boolean;
 }
 ```
 

--- a/components/table/index.zh-CN.md
+++ b/components/table/index.zh-CN.md
@@ -274,8 +274,8 @@ interface FilterConfirmProps {
 }
 
 interface FilterResetProps {
-  confirm?: Boolean;
-  closeDropdown?: Boolean;
+  confirm?: boolean;
+  closeDropdown?: boolean;
 }
 ```
 

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -79,8 +79,8 @@ export interface FilterConfirmProps {
   closeDropdown: boolean;
 }
 export interface FilterResetProps {
-  confirm?: Boolean;
-  closeDropdown?: Boolean;
+  confirm?: boolean;
+  closeDropdown?: boolean;
 }
 
 export interface FilterDropdownProps<RecordType> {

--- a/components/table/interface.tsx
+++ b/components/table/interface.tsx
@@ -78,13 +78,17 @@ export type FilterSearchType<RecordType = Record<string, any>> =
 export interface FilterConfirmProps {
   closeDropdown: boolean;
 }
+export interface FilterResetProps {
+  confirm?: Boolean;
+  closeDropdown?: Boolean;
+}
 
 export interface FilterDropdownProps<RecordType> {
   prefixCls: string;
   setSelectedKeys: (selectedKeys: Key[]) => void;
   selectedKeys: Key[];
   confirm: (param?: FilterConfirmProps) => void;
-  clearFilters?: () => void;
+  clearFilters?: (param?: FilterResetProps) => void;
   filters?: ColumnFilterItem[];
   /** Only close filterDropdown */
   close: () => void;


### PR DESCRIPTION
### 改动

1. 修正 `FilterDropdown.tsx` 里的拼写错误 🐶
2. 补全 `components/table/interface.tsx` 中 `FilterDropdownProps` 的 `clearFilters` 属性类型及对应文档
