### PR TITLE
fix(vue): fixed modal component failed to trigger update in vue@3.4.x

### DIFF
--- a/components/_util/vnode.ts
+++ b/components/_util/vnode.ts
@@ -51,3 +51,8 @@ export function deepCloneElement<T, U>(
     return cloned;
   }
 }
+
+export function triggerVNodeUpdate(instance: VNode) {
+  instance.component.effect.dirty = true;
+  instance.component.update();
+}

--- a/components/_util/vnode.ts
+++ b/components/_util/vnode.ts
@@ -1,6 +1,6 @@
 import { filterEmpty } from './props-util';
 import type { VNode, VNodeProps } from 'vue';
-import { cloneVNode, isVNode } from 'vue';
+import { cloneVNode, isVNode, render as VueRender } from 'vue';
 import warning from './warning';
 import type { RefObject } from './createRef';
 type NodeProps = Record<string, any> &
@@ -52,7 +52,6 @@ export function deepCloneElement<T, U>(
   }
 }
 
-export function triggerVNodeUpdate(instance: VNode) {
-  instance.component.effect.dirty = true;
-  instance.component.update();
+export function triggerVNodeUpdate(vm: VNode, attrs: Record<string, any>, dom: any) {
+  VueRender(cloneVNode(vm, { ...attrs }), dom);
 }

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -3,6 +3,7 @@ import ConfirmDialog from './ConfirmDialog';
 import type { ModalFuncProps } from './Modal';
 import ConfigProvider, { globalConfigForApi } from '../config-provider';
 import omit from '../_util/omit';
+import { triggerVNodeUpdate } from '../_util/vnode';
 
 import { getConfirmLocale } from './locale';
 import destroyFns from './destroyFns';
@@ -71,7 +72,7 @@ const confirm = (config: ModalFuncProps) => {
     }
     if (confirmDialogInstance) {
       Object.assign(confirmDialogInstance.component.props, currentConfig);
-      confirmDialogInstance.component.update();
+      triggerVNodeUpdate(confirmDialogInstance);
     }
   }
 

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -71,8 +71,7 @@ const confirm = (config: ModalFuncProps) => {
       };
     }
     if (confirmDialogInstance) {
-      Object.assign(confirmDialogInstance.component.props, currentConfig);
-      triggerVNodeUpdate(confirmDialogInstance);
+      triggerVNodeUpdate(confirmDialogInstance, currentConfig, container);
     }
   }
 


### PR DESCRIPTION
In vue 3.4.x, the execution logic of the `update` function has been changed so that calling `update` directly does not update the component.

In this case, the logic for updating the component should be abstracted into a function (e.g. `triggerVNodeUpdate`), and any subsequent manual calls to `update` should be replaced with `triggerVNodeUpdate(instance)`.

close #7239 