### PR TITLE
fix: fixed error with no expected value in `expandColumnTitle` slot

### DIFF
--- a/components/_util/__mocks__/RenderSlot.tsx
+++ b/components/_util/__mocks__/RenderSlot.tsx
@@ -1,0 +1,11 @@
+import { defineComponent } from 'vue';
+import { customRenderSlot } from '../vnode';
+
+export default defineComponent({
+  name: 'RenderSlot',
+  setup(_props, { slots }) {
+    return () => {
+      return customRenderSlot(slots, 'default', {}, () => ['default value']);
+    };
+  },
+});

--- a/components/_util/__tests__/vNode.test.js
+++ b/components/_util/__tests__/vNode.test.js
@@ -1,0 +1,26 @@
+import RenderSlot from '../__mocks__/RenderSlot';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+
+describe('render slot content', () => {
+  it('renders slot content', () => {
+    const wrapper = mount(RenderSlot, {
+      slots: {
+        default: () => 'This is slot content',
+      },
+    });
+
+    expect(wrapper.html()).toContain('This is slot content');
+  });
+
+  it('render default value when slot is fragment', async () => {
+    const wrapper = mount(RenderSlot, {
+      slots: {
+        default: () => <></>,
+      },
+    });
+
+    await nextTick();
+    expect(wrapper.html()).toContain('default value');
+  });
+});

--- a/components/_util/vnode.ts
+++ b/components/_util/vnode.ts
@@ -56,8 +56,8 @@ export function triggerVNodeUpdate(vm: VNode, attrs: Record<string, any>, dom: a
   VueRender(cloneVNode(vm, { ...attrs }), dom);
 }
 
-const ensureValidVNode = (slot: VNodeArrayChildren) => {
-  return slot.some(child => {
+const ensureValidVNode = (slot: VNodeArrayChildren | null) => {
+  return (slot || []).some(child => {
     if (!isVNode(child)) return true;
     if (child.type === Comment) return false;
     if (child.type === Fragment && !ensureValidVNode(child.children as VNodeArrayChildren))
@@ -74,7 +74,7 @@ export function customRenderSlot(
   props: Record<string, unknown>,
   fallback?: () => VNodeArrayChildren,
 ) {
-  const slot = slots[name]?.(props) || [];
+  const slot = slots[name]?.(props);
   if (ensureValidVNode(slot)) {
     return slot;
   }

--- a/components/_util/vnode.ts
+++ b/components/_util/vnode.ts
@@ -1,6 +1,6 @@
 import { filterEmpty } from './props-util';
-import type { VNode, VNodeProps } from 'vue';
-import { cloneVNode, isVNode, render as VueRender } from 'vue';
+import type { Slots, VNode, VNodeArrayChildren, VNodeProps } from 'vue';
+import { cloneVNode, isVNode, Comment, Fragment, render as VueRender } from 'vue';
 import warning from './warning';
 import type { RefObject } from './createRef';
 type NodeProps = Record<string, any> &
@@ -54,4 +54,30 @@ export function deepCloneElement<T, U>(
 
 export function triggerVNodeUpdate(vm: VNode, attrs: Record<string, any>, dom: any) {
   VueRender(cloneVNode(vm, { ...attrs }), dom);
+}
+
+export function customRenderSlot(
+  slots: Slots,
+  name: string,
+  props: Record<string, unknown>,
+  fallback?: () => VNodeArrayChildren,
+) {
+  const slot = slots[name]?.(props) || [];
+
+  const ensureValidVNode = (slot: VNodeArrayChildren) => {
+    return slot.some(child => {
+      if (!isVNode(child)) return true;
+      if (child.type === Comment) return false;
+      if (child.type === Fragment && !ensureValidVNode(child.children as VNodeArrayChildren))
+        return false;
+      return true;
+    })
+      ? slot
+      : null;
+  };
+
+  if (ensureValidVNode(slot)) {
+    return slot;
+  }
+  return fallback?.();
 }

--- a/components/_util/vnode.ts
+++ b/components/_util/vnode.ts
@@ -56,6 +56,18 @@ export function triggerVNodeUpdate(vm: VNode, attrs: Record<string, any>, dom: a
   VueRender(cloneVNode(vm, { ...attrs }), dom);
 }
 
+const ensureValidVNode = (slot: VNodeArrayChildren) => {
+  return slot.some(child => {
+    if (!isVNode(child)) return true;
+    if (child.type === Comment) return false;
+    if (child.type === Fragment && !ensureValidVNode(child.children as VNodeArrayChildren))
+      return false;
+    return true;
+  })
+    ? slot
+    : null;
+};
+
 export function customRenderSlot(
   slots: Slots,
   name: string,
@@ -63,19 +75,6 @@ export function customRenderSlot(
   fallback?: () => VNodeArrayChildren,
 ) {
   const slot = slots[name]?.(props) || [];
-
-  const ensureValidVNode = (slot: VNodeArrayChildren) => {
-    return slot.some(child => {
-      if (!isVNode(child)) return true;
-      if (child.type === Comment) return false;
-      if (child.type === Fragment && !ensureValidVNode(child.children as VNodeArrayChildren))
-        return false;
-      return true;
-    })
-      ? slot
-      : null;
-  };
-
   if (ensureValidVNode(slot)) {
     return slot;
   }

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -11,6 +11,7 @@ import useStyle from './style';
 import Skeleton from '../skeleton';
 import type { CustomSlotsType } from '../_util/type';
 import { customRenderSlot } from '../_util/vnode';
+
 export interface CardTabListType {
   key: string;
   tab: any;

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -1,5 +1,5 @@
 import type { VNodeTypes, PropType, VNode, ExtractPropTypes, CSSProperties } from 'vue';
-import { isVNode, defineComponent, renderSlot } from 'vue';
+import { isVNode, defineComponent } from 'vue';
 import Tabs from '../tabs';
 import PropTypes from '../_util/vue-types';
 import { flattenChildren, isEmptyElement, filterEmptyWithUndefined } from '../_util/props-util';
@@ -10,6 +10,7 @@ import devWarning from '../vc-util/devWarning';
 import useStyle from './style';
 import Skeleton from '../skeleton';
 import type { CustomSlotsType } from '../_util/type';
+import { customRenderSlot } from '../_util/vnode';
 export interface CardTabListType {
   key: string;
   tab: any;
@@ -152,7 +153,7 @@ const Card = defineComponent({
                 `tabList slots is deprecated, Please use \`customTab\` instead.`,
               );
               let tab = temp !== undefined ? temp : slots[name] ? slots[name](item) : null;
-              tab = renderSlot(slots, 'customTab', item as any, () => [tab]);
+              tab = customRenderSlot(slots, 'customTab', item as any, () => [tab]);
               return <TabPane tab={tab} key={item.key} disabled={item.disabled} />;
             })}
           </Tabs>

--- a/components/vc-table/Cell/index.tsx
+++ b/components/vc-table/Cell/index.tsx
@@ -1,7 +1,7 @@
 import classNames from '../../_util/classNames';
 import { filterEmpty, flattenChildren, isValidElement } from '../../_util/props-util';
 import type { CSSProperties, VNodeArrayChildren } from 'vue';
-import { Text, computed, defineComponent, isVNode, renderSlot } from 'vue';
+import { Text, computed, defineComponent, isVNode } from 'vue';
 
 import type {
   DataIndex,
@@ -23,6 +23,7 @@ import { useInjectSticky } from '../context/StickyContext';
 import { warning } from '../../vc-util/warning';
 import type { MouseEventHandler } from '../../_util/EventInterface';
 import eagerComputed from '../../_util/eagerComputed';
+import { customRenderSlot } from 'ant-design-vue/es/_util/vnode';
 
 /** Check if cell is in hover range */
 function inHoverRange(cellStartRow: number, cellRowSpan: number, startRow: number, endRow: number) {
@@ -223,7 +224,7 @@ export default defineComponent<CellProps>({
           contextSlots.value.bodyCell &&
           !column.slots?.customRender
         ) {
-          const child = renderSlot(
+          const child = customRenderSlot(
             contextSlots.value,
             'bodyCell',
             {

--- a/components/vc-table/hooks/useColumns.tsx
+++ b/components/vc-table/hooks/useColumns.tsx
@@ -179,9 +179,7 @@ function useColumns<RecordType>(
           class: `${prefixCls.value}-expand-icon-col`,
           columnType: 'EXPAND_COLUMN',
         },
-        title: contextSlots.value.expandColumnTitle
-          ? renderSlot(contextSlots.value, 'expandColumnTitle', {}, () => [''])
-          : null,
+        title: contextSlots.value.expandColumnTitle?.(),
         fixed: fixedColumn,
         class: `${prefixCls.value}-row-expand-icon-cell`,
         width: expandColumnWidth.value,

--- a/components/vc-table/hooks/useColumns.tsx
+++ b/components/vc-table/hooks/useColumns.tsx
@@ -14,7 +14,7 @@ import type {
 import { INTERNAL_COL_DEFINE } from '../utils/legacyUtil';
 import { EXPAND_COLUMN } from '../constant';
 import { useInjectSlots } from '../../table/context';
-import { customRenderSlot } from 'ant-design-vue/es/_util/vnode';
+import { customRenderSlot } from '../../_util/vnode';
 
 function flatColumns<RecordType>(columns: ColumnsType<RecordType>): ColumnType<RecordType>[] {
   return columns.reduce((list, column) => {

--- a/components/vc-table/hooks/useColumns.tsx
+++ b/components/vc-table/hooks/useColumns.tsx
@@ -14,6 +14,7 @@ import type {
 import { INTERNAL_COL_DEFINE } from '../utils/legacyUtil';
 import { EXPAND_COLUMN } from '../constant';
 import { useInjectSlots } from '../../table/context';
+import { customRenderSlot } from 'ant-design-vue/es/_util/vnode';
 
 function flatColumns<RecordType>(columns: ColumnsType<RecordType>): ColumnType<RecordType>[] {
   return columns.reduce((list, column) => {
@@ -179,7 +180,7 @@ function useColumns<RecordType>(
           class: `${prefixCls.value}-expand-icon-col`,
           columnType: 'EXPAND_COLUMN',
         },
-        title: contextSlots.value.expandColumnTitle?.() || '',
+        title: customRenderSlot(contextSlots.value, 'expandColumnTitle', {}, () => ['']),
         fixed: fixedColumn,
         class: `${prefixCls.value}-row-expand-icon-cell`,
         width: expandColumnWidth.value,

--- a/components/vc-table/hooks/useColumns.tsx
+++ b/components/vc-table/hooks/useColumns.tsx
@@ -179,7 +179,9 @@ function useColumns<RecordType>(
           class: `${prefixCls.value}-expand-icon-col`,
           columnType: 'EXPAND_COLUMN',
         },
-        title: renderSlot(contextSlots.value, 'expandColumnTitle', {}, () => ['']),
+        title: contextSlots.value?.expandColumnTitle
+          ? renderSlot(contextSlots.value, 'expandColumnTitle', {}, () => [''])
+          : null,
         fixed: fixedColumn,
         class: `${prefixCls.value}-row-expand-icon-cell`,
         width: expandColumnWidth.value,

--- a/components/vc-table/hooks/useColumns.tsx
+++ b/components/vc-table/hooks/useColumns.tsx
@@ -1,6 +1,6 @@
 import { warning } from '../../vc-util/warning';
 import type { ComputedRef, Ref } from 'vue';
-import { renderSlot, computed, watchEffect } from 'vue';
+import { computed, watchEffect } from 'vue';
 import type {
   ColumnsType,
   ColumnType,
@@ -179,7 +179,7 @@ function useColumns<RecordType>(
           class: `${prefixCls.value}-expand-icon-col`,
           columnType: 'EXPAND_COLUMN',
         },
-        title: contextSlots.value.expandColumnTitle?.(),
+        title: contextSlots.value.expandColumnTitle?.() || '',
         fixed: fixedColumn,
         class: `${prefixCls.value}-row-expand-icon-cell`,
         width: expandColumnWidth.value,

--- a/components/vc-table/hooks/useColumns.tsx
+++ b/components/vc-table/hooks/useColumns.tsx
@@ -179,7 +179,7 @@ function useColumns<RecordType>(
           class: `${prefixCls.value}-expand-icon-col`,
           columnType: 'EXPAND_COLUMN',
         },
-        title: contextSlots.value?.expandColumnTitle
+        title: contextSlots.value.expandColumnTitle
           ? renderSlot(contextSlots.value, 'expandColumnTitle', {}, () => [''])
           : null,
         fixed: fixedColumn,


### PR DESCRIPTION
replace vue's private `renderSlot` method with the `customRenderSlot` method.

what `customRenderSlot` does is enhance the way `jsx` is rendered, so that if there is only a `Comment` or `Fragment` in the `slot`, the default content is rendered, in line with what is expected from `template` rendering.

close #7260