### PR TITLE
fix(segmented): title property in segmented component slot not effective

### DIFF
--- a/components/segmented/style/index.ts
+++ b/components/segmented/style/index.ts
@@ -99,6 +99,7 @@ const genSegmentedStyle: GenerateStyle<SegmentedToken> = (token: SegmentedToken)
           insetInlineStart: 0,
           borderRadius: 'inherit',
           transition: `background-color ${token.motionDurationMid}`,
+          pointerEvents: 'none',
         },
 
         [`&:hover:not(${componentCls}-item-selected):not(${componentCls}-item-disabled)`]: {


### PR DESCRIPTION
当我给插槽里的标签添加title属性时，鼠标放上去是没有效果的，因为被:after伪类样式挡住了