### PR TITLE
feat(date-picker/range-picker): preset value support callback function

### DIFF
--- a/components/date-picker/demo/presetted-ranges.vue
+++ b/components/date-picker/demo/presetted-ranges.vue
@@ -8,11 +8,11 @@ title:
 
 ## zh-CN
 
-可以预设常用的日期范围以提高用户体验。
+可以预设常用的日期范围以提高用户体验。自 `4.1.1` 开始，preset value 支持回调函数返回值方式。
 
 ## en-US
 
-We can set presetted ranges to RangePicker to improve user experience.
+We can set presetted ranges to RangePicker to improve user experience. Since `4.1.1`, preset value supports callback function.
 
 </docs>
 
@@ -24,7 +24,13 @@ We can set presetted ranges to RangePicker to improve user experience.
       style="width: 400px"
       show-time
       format="YYYY/MM/DD HH:mm:ss"
-      :presets="rangePresets"
+      :presets="[
+        {
+          label: 'Now ~ Eod',
+          value: () => [dayjs(), dayjs().endOf('day')], // 5.8.0+ support function
+        },
+        ...rangePresets,
+      ]"
       @change="onRangeChange"
     />
   </a-space>

--- a/components/date-picker/index.en-US.md
+++ b/components/date-picker/index.en-US.md
@@ -96,7 +96,7 @@ The following APIs are shared by DatePicker, RangePicker.
 | placeholder | The placeholder of date input | string \| \[string,string] | - |  |
 | placement | The position where the selection box pops up | `bottomLeft` `bottomRight` `topLeft` `topRight` | bottomLeft | 3.3.0 |
 | popupStyle | To customize the style of the popup calendar | CSSProperties | {} |  |
-| presets | The preset ranges for quick selection | { label: slot, value: [dayjs](https://day.js.org/) }[] | - | 4.0 |
+| presets | The preset ranges for quick selection, Since `4.1.1`, preset value supports callback function. | { label: slot, value: [dayjs](https://day.js.org/) \| (() => [dayjs](https://day.js.org/))}[] | - | 4.0 |
 | prevIcon | The custom prev icon | slot | - | 3.0 |
 | size | To determine the size of the input box, the height of `large` and `small`, are 40px and 24px respectively, while default size is 32px | `large` \| `middle` \| `small` | - |  |
 | status | Set validation status | 'error' \| 'warning' | - | 3.3.0 |
@@ -175,7 +175,7 @@ The following APIs are shared by DatePicker, RangePicker.
 | disabled | If disable start or end | \[boolean, boolean] | - |  |
 | disabledTime | To specify the time that cannot be selected | function(date: dayjs, partial: `start` \| `end`) | - |  |
 | format | To set the date format, refer to [dayjs](https://day.js.org/) | [formatType](#formattype) | `YYYY-MM-DD HH:mm:ss` |  |
-| presets | The preset ranges for quick selection | { label: slot, value: [dayjs](https://day.js.org/)\[] }[] | - | 4.0 |
+| presets | The preset ranges for quick selection, Since `4.1.1`, preset value supports callback function. | { label: slot, value: [dayjs](https://day.js.org/) \| (() => [dayjs](https://day.js.org/))[]}[] | - | 4.0 |
 | ranges | The preseted ranges for quick selection | { \[range: string]: [dayjs](https://day.js.org/)\[] } \| { \[range: string]: () => [dayjs](https://day.js.org/)\[] } | - |  |
 | renderExtraFooter | Render extra footer in panel | v-slot:renderExtraFooter="mode" | - |  |
 | separator | Set separator between inputs | string \| v-slot:separator | `<SwapRightOutlined />` |  |

--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -98,7 +98,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*3OpRQKcygo8AAA
 | placement | 选择框弹出的位置 | `bottomLeft` `bottomRight` `topLeft` `topRight` | bottomLeft | 3.3.0 |
 | popupStyle | 额外的弹出日历样式 | CSSProperties | {} |  |
 | prevIcon | 自定义上一个图标 | slot | - | 3.0 |
-| presets | 预设时间范围快捷选择 | { label: slot, value: [dayjs](https://day.js.org/) }[] | - | 4.0 |
+| presets | 预设时间范围快捷选择, 自 `4.1.1` 起 value 支持函数返回值 | { label: slot, value: [dayjs](https://day.js.org/) \| (() => [dayjs](https://day.js.org/))}[] | - | 4.0 |
 | size | 输入框大小，`large` 高度为 40px，`small` 为 24px，默认是 32px | `large` \| `middle` \| `small` | - |  |
 | status | 设置校验状态 | 'error' \| 'warning' | - | 3.3.0 |
 | suffixIcon | 自定义的选择框后缀图标 | v-slot:suffixIcon | - |  |
@@ -176,7 +176,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*3OpRQKcygo8AAA
 | disabled | 禁用起始项 | \[boolean, boolean] | - |  |
 | disabledTime | 不可选择的时间 | function(date: dayjs, partial: `start` \| `end`) | - |  |
 | format | 展示的日期格式 | [formatType](#formattype) | `YYYY-MM-DD HH:mm:ss` |  |
-| presets | 预设时间范围快捷选择 | { label: slot, value: [dayjs](https://day.js.org/)\[] }[] | - | 4.0 |
+| presets | 预设时间范围快捷选择, 自 `4.1.1` 起 value 支持函数返回值 | { label: slot, value: [dayjs](https://day.js.org/) \| (() => [dayjs](https://day.js.org/))[]}[] | - | 4.0 |
 | ranges | 预设时间范围快捷选择 | { \[range: string]: [dayjs](https://day.js.org/)\[] } \| { \[range: string]: () => [dayjs](https://day.js.org/)\[] } | - |  |
 | renderExtraFooter | 在面板中添加额外的页脚 | v-slot:renderExtraFooter="mode" | - |  |
 | separator | 设置分隔符 | string \| v-slot:separator | `<SwapRightOutlined />` |  |

--- a/components/vc-picker/Picker.tsx
+++ b/components/vc-picker/Picker.tsx
@@ -270,8 +270,11 @@ function Picker<DateType>() {
       });
 
       // ============================ Trigger ============================
-      const triggerChange = (newValue: DateType | null) => {
+      const triggerChange = (newValue: DateType | (() => DateType) | null) => {
         const { onChange, generateConfig, locale } = props;
+        if (typeof newValue === 'function') {
+          newValue = (newValue as () => DateType)();
+        }
         setSelectedValue(newValue);
         setInnerValue(newValue);
 

--- a/components/vc-picker/RangePicker.tsx
+++ b/components/vc-picker/RangePicker.tsx
@@ -489,8 +489,12 @@ function RangerPicker<DateType>() {
         }, 0);
       }
 
-      function triggerChange(newValue: RangeValue<DateType>, sourceIndex: 0 | 1) {
-        let values = newValue;
+      function triggerChange(
+        newValue: RangeValue<DateType> | (() => RangeValue<DateType>),
+        sourceIndex: 0 | 1,
+      ) {
+        const isFunction = typeof newValue === 'function';
+        let values = isFunction ? newValue() : newValue;
         let startValue = getValue(values, 0);
         let endValue = getValue(values, 1);
         const {

--- a/components/vc-picker/interface.ts
+++ b/components/vc-picker/interface.ts
@@ -94,6 +94,7 @@ export type DisabledTime<DateType> = (date: DateType | null) => DisabledTimes;
 export type OnPanelChange<DateType> = (value: DateType, mode: PanelMode) => void;
 
 export type EventValue<DateType> = DateType | null;
+
 export type RangeValue<DateType> = [EventValue<DateType>, EventValue<DateType>] | null;
 
 export type Components = {
@@ -111,5 +112,5 @@ export type CustomFormat<DateType> = (value: DateType) => string;
 
 export interface PresetDate<T> {
   label: VueNode;
-  value: T;
+  value: T | (() => T);
 }


### PR DESCRIPTION
allow presets to use current time as of user clicking the option

ant-design5.8.0版本更新时支持了 https://github.com/ant-design/ant-design/pull/43476