### PR TITLE
fix: Resolve the #7344 issue about the  transitions in vue3.4

### DIFF
--- a/components/_util/transition.tsx
+++ b/components/_util/transition.tsx
@@ -30,8 +30,8 @@ export const getTransitionProps = (transitionName: string, opt: TransitionProps 
         enterFromClass: `${transitionName}-enter ${transitionName}-enter-prepare ${transitionName}-enter-start`,
         enterActiveClass: `${transitionName}-enter ${transitionName}-enter-prepare`,
         enterToClass: `${transitionName}-enter ${transitionName}-enter-active`,
-        leaveFromClass: ` ${transitionName}-leave`,
-        leaveActiveClass: `${transitionName}-leave ${transitionName}-leave-active`,
+        leaveFromClass: `${transitionName}-leave ${transitionName}-leave-prepare ${transitionName}-leave-start`,
+        leaveActiveClass: `${transitionName}-leave ${transitionName}-leave-prepare`,
         leaveToClass: `${transitionName}-leave ${transitionName}-leave-active`,
         ...opt,
       }


### PR DESCRIPTION
解决 https://github.com/vueComponent/ant-design-vue/issues/7344 中的问题，问题定位在 transition 的 leave 。改了之后在 vue3.4的版本 dropdown组件和 popconfirm 组件的能够正常使用