### PR TITLE
docs: match dependencies in package.json instead of simply setting 'l…

### DIFF
--- a/site/src/utils/generateOnlineDemo.ts
+++ b/site/src/utils/generateOnlineDemo.ts
@@ -43,10 +43,11 @@ app.use(Antd).mount('#app');
 `;
 
 function getDeps(code: string) {
+  const deps = Object.assign({}, packageInfo.dependencies, packageInfo.devDependencies);
   return (code.match(/from '([^']+)';\n/g) || [])
     .map(v => v.slice(6, v.length - 3))
     .reduce((prevV, dep) => {
-      prevV[dep] = 'latest';
+      prevV[dep] = deps[dep] || 'latest';
       return prevV;
     }, {});
 }


### PR DESCRIPTION
When generating codesandbox 'parameters', match the dependencies in package.json instead of simply setting them to 'latest'