### PR TITLE
fix(AutoComplete): #7380 and #7276

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -172,7 +172,7 @@ export default defineComponent({
     const handleChange = (e: Event) => {
       const { composing } = e.target as any;
       let triggerValue = (e.target as any).value;
-      compositing.value = !!((e as any).isComposing || composing);
+      compositing.value = !!((e as any).isComposing && composing);
       if ((compositing.value && props.lazy) || stateValue.value === triggerValue) return;
 
       if (hasMaxLength.value) {

--- a/components/vc-input/Input.tsx
+++ b/components/vc-input/Input.tsx
@@ -93,8 +93,7 @@ export default defineComponent({
     const handleChange = (e: ChangeEvent) => {
       const { value, composing } = e.target as any;
       // https://github.com/vueComponent/ant-design-vue/issues/2203
-      if ((((e as any).isComposing || composing) && props.lazy) || stateValue.value === value)
-        return;
+      if (((e as any).isComposing && composing && props.lazy) || stateValue.value === value) return;
       const newVal = e.target.value;
       resolveOnChange(inputRef.value, e, triggerChange);
       setValue(newVal);


### PR DESCRIPTION
修复#7380 和 #7276 问题

复现步骤（必要条件：AutoComplete的默认插槽为InputSearch或TextArea组件时才会出现）：

## 问题

问题1:
1. 首先输入中文
2. 点击输入框，中文自动消失

问题2:
1. 首先输入中文，输入完毕后删除所有中文字符
2. 再输入英文时无法正常输入

问题3:
1. 首先输入英文，输入完毕后删除所有英文字符
2. 再输入中文时，随便点击键盘中任意按键，中文消失

## 原因

在初次输入中文时，`isCompositing`状态与手动设置的`e.target.composing`标志不同步。
