### PR TITLE
fix[Carousel]: Fixed the current value returned by beforeChange props is incorrect

### DIFF
--- a/components/vc-slick/inner-slider.jsx
+++ b/components/vc-slick/inner-slider.jsx
@@ -372,7 +372,7 @@ export default {
       }
     },
     slideHandler(index, dontAnimate = false) {
-      const { asNavFor, currentSlide, beforeChange, speed, afterChange } = this.$props;
+      const { asNavFor, beforeChange, speed, afterChange } = this.$props;
       const { state, nextState } = slideHandler({
         index,
         ...this.$props,
@@ -381,7 +381,7 @@ export default {
         useCSS: this.useCSS && !dontAnimate,
       });
       if (!state) return;
-      beforeChange && beforeChange(currentSlide, state.currentSlide);
+      beforeChange && beforeChange(this.currentSlide, state.currentSlide);
       const slidesToLoad = state.lazyLoadedList.filter(
         value => this.lazyLoadedList.indexOf(value) < 0,
       );
@@ -390,7 +390,7 @@ export default {
       }
       if (!this.$props.waitForAnimate && this.animationEndCallback) {
         clearTimeout(this.animationEndCallback);
-        afterChange && afterChange(currentSlide);
+        afterChange && afterChange(this.currentSlide);
         delete this.animationEndCallback;
       }
       this.setState(state, () => {


### PR DESCRIPTION
### 版本
Antd vue  4.1.2

### 问题描述
引入走马灯组件，使用 **beforeChange** 属性，发现返回的 **current** 的值始终为 **undefined**

### 复现链接
https://codesandbox.io/p/sandbox/ji-ben-ant-design-vue-4-1-2-forked-pdrlxc?file=%2Fsrc%2Fdemo.vue%3A11%2C53

![50f2bdf2f21a72f522b552188583a68](https://github.com/vueComponent/ant-design-vue/assets/32154293/5e746e1e-9cdf-47f2-b363-2f6ef2d35e25)



