### PR TITLE
fix(locales): Update ja_JP.ts

### DIFF
--- a/components/date-picker/locale/ja_JP.ts
+++ b/components/date-picker/locale/ja_JP.ts
@@ -6,7 +6,15 @@ import type { PickerLocale } from '../generatePicker';
 const locale: PickerLocale = {
   lang: {
     placeholder: '日付を選択',
+    yearPlaceholder: '年を選択',
+    quarterPlaceholder: '四半期を選択',
+    monthPlaceholder: '月を選択',
+    weekPlaceholder: '週を選択',
     rangePlaceholder: ['開始日付', '終了日付'],
+    rangeYearPlaceholder: ['開始年', '終了年'],
+    rangeMonthPlaceholder: ['開始月', '終了月'],
+    rangeQuarterPlaceholder: ['開始四半期', '終了四半期'],
+    rangeWeekPlaceholder: ['開始週', '終了週'],
     ...CalendarLocale,
   },
   timePickerLocale: {


### PR DESCRIPTION
Using the `< a-range-picker > `component of the Japanese internationalization configuration, when the `picker` attribute is set to `month`, the `placeholder` still displays "日付を選択 (select date)", which is not in line with expectations.
Although you can modify `placeholder` manually for the time being, you hope to solve this problem fundamentally.
Look at the source code and find that the relevant configuration is missing in the Japanese internationalization configuration. Therefore, it is supplemented and perfected in this pr.

使用日语国际化配置的 `<a-range-picker>` 组件，`picker` 属性设置为 `month` 时，`placeholder` 仍然显示 "日付を選択(选择日期)" 这不符合预期。

虽然可以暂时手动修改 `placeholder` ，但希望从根本解决此问题。

查看源代码发现日语国际化配置中缺少相关配置。故在此 pr 中补充完善。