### PR TITLE
fix(component->table->cell):fix the table component rendering when hover

### DIFF
--- a/components/vc-table/Cell/index.tsx
+++ b/components/vc-table/Cell/index.tsx
@@ -104,7 +104,6 @@ export default defineComponent<CellProps>({
     'transformCellText',
   ] as any,
   setup(props, { slots }) {
-
     const hoverRef = ref(null)
     const contextSlots = useInjectSlots();
     const { onHover, startRow, endRow } = useInjectHover();
@@ -121,6 +120,10 @@ export default defineComponent<CellProps>({
         props.additionalProps?.rowSpan ??
         (props.additionalProps?.rowspan as number)
       );
+    });
+    const hovering = eagerComputed(() => {
+      const { index } = props;
+      return inHoverRange(index, rowSpan.value || 1, startRow.value, endRow.value);
     });
     const supportSticky = useInjectSticky();
 
@@ -201,6 +204,7 @@ export default defineComponent<CellProps>({
             renderIndex,
             column: column.__originColumn__,
           });
+
           if (isRenderCell(renderData)) {
             if (process.env.NODE_ENV !== 'production') {
               warning(
@@ -214,6 +218,7 @@ export default defineComponent<CellProps>({
             childNode = renderData;
           }
         }
+
         if (
           !(INTERNAL_COL_DEFINE in column) &&
           cellType === 'body' &&
@@ -274,7 +279,6 @@ export default defineComponent<CellProps>({
       } = cellProps || {};
       const mergedColSpan = (cellColSpan !== undefined ? cellColSpan : colSpan.value) ?? 1;
       const mergedRowSpan = (cellRowSpan !== undefined ? cellRowSpan : rowSpan.value) ?? 1;
-      
       if (mergedColSpan === 0 || mergedRowSpan === 0) {
         return null;
       }
@@ -299,6 +303,7 @@ export default defineComponent<CellProps>({
       if (align) {
         alignStyle.textAlign = align;
       }
+
       // ====================== Render ======================
       let title: string;
       const ellipsisConfig: CellEllipsisType = ellipsis === true ? { showTitle: true } : ellipsis;
@@ -311,10 +316,6 @@ export default defineComponent<CellProps>({
       }
 
       // AddEventListener Hover  
-      const hovering = eagerComputed(() => {
-        const { index } = props;
-        return inHoverRange(index, rowSpan.value || 1, startRow.value, endRow.value);
-      });
       watch([rowSpan,startRow,endRow],()=>{
         hoverRef.value?.setAttribute("class",classNames(
           cellPrefixCls,
@@ -338,7 +339,7 @@ export default defineComponent<CellProps>({
         [`${cellPrefixCls}-fix-sticky`]:
           (isFixLeft || isFixRight) && isSticky && supportSticky.value,
       }
-      
+
       const componentProps = {
         title,
         ...restCellProps,
@@ -357,6 +358,7 @@ export default defineComponent<CellProps>({
         onMouseleave,
         style: [additionalProps.style, alignStyle, fixedStyle, cellStyle],
       };
+
       return (
         <Component {...componentProps} ref={hoverRef}>
           {appendNode}

--- a/components/vc-table/Cell/index.tsx
+++ b/components/vc-table/Cell/index.tsx
@@ -104,7 +104,6 @@ export default defineComponent<CellProps>({
     'transformCellText',
   ] as any,
   setup(props, { slots }) {
-    const hoverRef = ref(null)
     const contextSlots = useInjectSlots();
     const { onHover, startRow, endRow } = useInjectHover();
     const colSpan = computed(() => {
@@ -157,6 +156,29 @@ export default defineComponent<CellProps>({
         return vnode;
       }
     };
+
+    // AddEventListener Hover
+    const hoverRef = ref(null);
+    let componentPropsCommonClassName;
+    let additionalProps;
+    let cellPrefixCls;
+    let cellProps: CellType;
+    let cellClassName;
+    watch([rowSpan, startRow, endRow], () => {
+      hoverRef.value?.setAttribute(
+        'class',
+        classNames(
+          cellPrefixCls,
+          {
+            ...componentPropsCommonClassName,
+            [`${cellPrefixCls}-row-hover`]: !cellProps && hovering.value,
+          },
+          additionalProps.class,
+          cellClassName,
+        ),
+      );
+    });
+
     return () => {
       const {
         prefixCls,
@@ -173,7 +195,6 @@ export default defineComponent<CellProps>({
         firstFixRight,
         lastFixRight,
         appendNode = slots.appendNode?.(),
-        additionalProps = {},
         ellipsis,
         align,
         rowType,
@@ -181,12 +202,10 @@ export default defineComponent<CellProps>({
         column = {},
         cellType,
       } = props;
-      const cellPrefixCls = `${prefixCls}-cell`;
-
+      cellPrefixCls = `${prefixCls}-cell`;
+      additionalProps = props.additionalProps ? props.additionalProps : {};
       // ==================== Child Node ====================
-      let cellProps: CellType;
       let childNode;
-      let componentPropsCommonClassName
       const children = slots.default?.();
       if (validateValue(children) || cellType === 'header') {
         childNode = children;
@@ -274,9 +293,9 @@ export default defineComponent<CellProps>({
         colSpan: cellColSpan,
         rowSpan: cellRowSpan,
         style: cellStyle,
-        class: cellClassName,
         ...restCellProps
       } = cellProps || {};
+      cellClassName = cellProps ? cellProps.class : '';
       const mergedColSpan = (cellColSpan !== undefined ? cellColSpan : colSpan.value) ?? 1;
       const mergedRowSpan = (cellRowSpan !== undefined ? cellRowSpan : rowSpan.value) ?? 1;
       if (mergedColSpan === 0 || mergedRowSpan === 0) {
@@ -315,18 +334,6 @@ export default defineComponent<CellProps>({
         }
       }
 
-      // AddEventListener Hover  
-      watch([rowSpan,startRow,endRow],()=>{
-        hoverRef.value?.setAttribute("class",classNames(
-          cellPrefixCls,
-          {
-            ...componentPropsCommonClassName,
-              [`${cellPrefixCls}-row-hover`]: !cellProps && hovering.value,
-          },
-          additionalProps.class,
-          cellClassName,
-        ))
-      })
       componentPropsCommonClassName = {
         [`${cellPrefixCls}-fix-left`]: isFixLeft && supportSticky.value,
         [`${cellPrefixCls}-fix-left-first`]: firstFixLeft && supportSticky.value,
@@ -338,7 +345,7 @@ export default defineComponent<CellProps>({
         [`${cellPrefixCls}-with-append`]: appendNode,
         [`${cellPrefixCls}-fix-sticky`]:
           (isFixLeft || isFixRight) && isSticky && supportSticky.value,
-      }
+      };
 
       const componentProps = {
         title,


### PR DESCRIPTION
fix the bug  about https://github.com/vueComponent/ant-design-vue/issues/7444
定位问题出现在hovering这个computed变量，里面的依赖关联hover，每一次hover都会导致组件重渲染。