### PR TITLE
fix(Input): autoSize not work when change value in onMounted

### DIFF
--- a/components/input/ResizableTextArea.tsx
+++ b/components/input/ResizableTextArea.tsx
@@ -77,7 +77,7 @@ const ResizableTextArea = defineComponent({
           startResize();
         }
       },
-      { immediate: true, flush: 'post' },
+      { immediate: true },
     );
     const autoSizeStyle = ref<CSSProperties>();
     watch(


### PR DESCRIPTION
最小复现代码：
```vue
<template>
  <a-textarea v-model:value="inputValue" placeholder="Basic usage" auto-size />
</template>

<script lang="ts" setup>
  import { ref, onMounted } from 'vue';
  const inputValue = ref();

  onMounted(() => {
    inputValue.value = 'autoSize will not work';
  });
</script>
```