### PR TITLE
fix: remove duplicate style variable

### DIFF
--- a/site/src/hooks/useSiteToken.ts
+++ b/site/src/hooks/useSiteToken.ts
@@ -42,7 +42,6 @@ const useSiteToken = () => {
       :root {
         --header-height: ${tokenValue.headerHeight}px;
         --menu-item-border: ${tokenValue.menuItemBorder}px;
-        --mobile-max-width: ${tokenValue.mobileMaxWidth}px;
 
         --primary-color: ${tokenValue.colorPrimary};
         --component-background: ${tokenValue.colorBgContainer};


### PR DESCRIPTION
I found that there are two duplicate variable declarations `--mobile-max-width`.