### PR TITLE
fix(PresetPanel): preset panel stopPropagation

### DIFF
--- a/components/vc-picker/PresetPanel.tsx
+++ b/components/vc-picker/PresetPanel.tsx
@@ -22,7 +22,8 @@ export default defineComponent({
             {props.presets.map(({ label, value }, index) => (
               <li
                 key={index}
-                onClick={() => {
+                onClick={e => {
+                  e.stopPropagation();
                   props.onClick(value);
                 }}
                 onMouseenter={() => {


### PR DESCRIPTION
### 这个变动的性质是

- [x] 日常 bug 修复

### 需求背景

> RangePicker在getPopupContainer设置为`(el) => el.parentNode`时，点击preset时会触发两次onOpenChange，第一次为preset panel，open为false，第二次为事件冒泡到onPickerClick，open为true 

> 复现地址 https://stackblitz.com/edit/vitejs-vite-kjllhh?file=src%2Fcomponents%2FHelloWorld.vue 点击RangePicker，选择PresetPanel中的一个preset，日期选择面板消失后又出现

### 实现方案和 API（非新功能可选）

> PresetPanel的onClick阻止事件冒泡