### PR TITLE
docs: add Vite and Rsbuild to getting started

### DIFF
--- a/site/src/vueDocs/getting-started.en-US.md
+++ b/site/src/vueDocs/getting-started.en-US.md
@@ -12,27 +12,37 @@ The following CodeSandbox demo is the simplest use case, and it's also a good ha
 
 ## Import ant-design-vue
 
-### 1. Installation
+### 1. Create a New Project
 
-[vue-cli](https://github.com/vuejs/vue-cli)
+If you need to create a new project, you can use [Vite](https://github.com/vitejs/vite), [Rsbuild](https://github.com/web-infra-dev/rsbuild), or [Vue CLI](https://github.com/vuejs/vue-cli).
+
+Please initialize the project using the command line:
+
+- Vite:
+
+```bash
+$ npm create vite@latest
+```
+
+- Rsbuild:
+
+```bash
+$ npm create rsbuild@latest
+```
+
+- Vue CLI:
 
 ```bash
 $ npm install -g @vue/cli
 # OR
 $ yarn global add @vue/cli
-```
 
-### 2. Create a New Project
-
-A new project can be created using CLI tools.
-
-```bash
 $ vue create antd-demo
 ```
 
-And, setup your vue project configuration.
+> Vue CLI is no longer maintained, so it is not recommended to use.
 
-### 3. Use antd's Components
+### 2. Use antd's Components
 
 #### Install
 
@@ -95,7 +105,7 @@ In this way, component sub-components, such as Button and ButtonGroup, need to b
 </script>
 ```
 
-### 4. Component list
+### 3. Component list
 
 [Component list](https://github.com/vueComponent/ant-design-vue/blob/main/components/components.ts)
 

--- a/site/src/vueDocs/getting-started.zh-CN.md
+++ b/site/src/vueDocs/getting-started.zh-CN.md
@@ -12,29 +12,39 @@ Ant Design Vue 致力于提供给程序员**愉悦**的开发体验。
 
 ## 引入 ant-design-vue
 
-### 1. 安装脚手架工具
+### 1. 新建项目
 
-[vue-cli](https://github.com/vuejs/vue-cli)
+如果你需要新建一个项目，可以使用 [Vite](https://github.com/vitejs/vite)、[Rsbuild](https://github.com/web-infra-dev/rsbuild) 或 [Vue CLI](https://github.com/vuejs/vue-cli)。
+
+请使用命令行来初始化项目：
+
+- Vite:
+
+```bash
+$ npm create vite@latest
+```
+
+- Rsbuild:
+
+```bash
+$ npm create rsbuild@latest
+```
+
+- Vue CLI:
 
 ```bash
 $ npm install -g @vue/cli
 # OR
 $ yarn global add @vue/cli
-```
 
-### 2. 创建一个项目
-
-使用命令行进行初始化。
-
-```bash
 $ vue create antd-demo
 ```
 
-并配置项目。
+> Vue CLI 已经停止迭代，因此不推荐使用。
 
 若安装缓慢报错，可尝试用 `cnpm` 或别的镜像源自行安装：`rm -rf node_modules && cnpm install`。
 
-### 3. 使用组件
+### 2. 使用组件
 
 #### 安装
 


### PR DESCRIPTION
Add Vite and Rsbuild to the Getting Started guide 😄

The current Getting Started guide only contains Vue CLI, and Vue CLI is no longer maintained. So it would be better if we could recommend some modern tools like Vite and Rsbuild to users.