### PR TITLE
fix: empty space-item are not been hidden

### DIFF
--- a/components/space/style/index.tsx
+++ b/components/space/style/index.tsx
@@ -38,7 +38,7 @@ const genSpaceStyle: GenerateStyle<SpaceToken> = token => {
           alignItems: 'baseline',
         },
       },
-      [`${componentCls}-space-item`]: {
+      [`${componentCls}-item`]: {
         '&:empty': {
           display: 'none',
         },


### PR DESCRIPTION
Expect: The css selector does match '.ant-space-item:empty'.
Actual: It's '.ant-space-space-item:empty'

This PR fixes this issue.