### PR TITLE
fix(grid): add missing space-evenly alignment for grid-row

### DIFF
--- a/components/grid/style/index.ts
+++ b/components/grid/style/index.ts
@@ -50,6 +50,10 @@ const genGridRowStyle: GenerateStyle<GridRowToken> = (token): CSSObject => {
         justifyContent: 'space-around',
       },
 
+      '&-space-evenly ': {
+        justifyContent: 'space-evenly',
+      },
+
       // Align at the top
       '&-top': {
         alignItems: 'flex-start',


### PR DESCRIPTION
close #7564 
fix issue with space-evenly not working

