### PR TITLE
feat: 组件 transfer 新增 targetOrder 属性,设置右侧列表元素的排序策略,不设置保持原有功能,添加到顶部,可设置…

### DIFF
--- a/components/transfer/index.en-US.md
+++ b/components/transfer/index.en-US.md
@@ -38,6 +38,7 @@ One or more elements can be selected from either column, one click on the proper
 | showSelectAll | Show select all checkbox on the header | boolean | true |  |
 | status | Set validation status | 'error' \| 'warning' | - | 3.3.0 |
 | targetKeys(v-model) | A set of keys of elements that are listed on the right column. | string\[] | \[] |  |
+| targetOrder | order strategy for elements in the target list. If set to push, the newly added elements will be pushed to the bottom. If set to unshift, the newly added elements will be inserted on the top, defualt on the top | 'unshift' \| 'push' | - | 4.2.2 |
 | titles | A set of titles that are sorted from left to right. | string\[] | - |  |
 
 ### events

--- a/components/transfer/index.tsx
+++ b/components/transfer/index.tsx
@@ -106,6 +106,8 @@ export const transferProps = () => ({
   oneWay: booleanType(),
   pagination: someType<PaginationType>([Object, Boolean]),
   status: stringType<InputStatus>(),
+  // 右侧目标添加顺序 unshift | push，默认unshift添加到顶部，push则追加到尾部
+  targetOrder: stringType<'unshift' | 'push'>(),
   onChange:
     functionType<
       (targetKeys: string[], direction: TransferDirection, moveKeys: string[]) => void
@@ -177,7 +179,7 @@ const Transfer = defineComponent({
     };
 
     const moveTo = (direction: TransferDirection) => {
-      const { targetKeys = [], dataSource = [] } = props;
+      const { targetKeys = [], targetOrder, dataSource = [] } = props;
       const moveKeys = direction === 'right' ? sourceSelectedKeys.value : targetSelectedKeys.value;
       const dataSourceDisabledKeysMap = groupDisabledKeysMap(dataSource);
       // filter the disabled options
@@ -187,7 +189,9 @@ const Transfer = defineComponent({
       // move items to target box
       const newTargetKeys =
         direction === 'right'
-          ? newMoveKeys.concat(targetKeys)
+          ? targetOrder === 'push'
+            ? targetKeys.concat(newMoveKeys)
+            : newMoveKeys.concat(targetKeys)
           : targetKeys.filter(targetKey => !newMoveKeysMap.has(targetKey));
 
       // empty checked keys

--- a/components/transfer/index.zh-CN.md
+++ b/components/transfer/index.zh-CN.md
@@ -39,6 +39,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*yv12S4sSRAEAAA
 | showSelectAll | 是否展示全选勾选框 | boolean | true |  |
 | status | 设置校验状态 | 'error' \| 'warning' | - | 3.3.0 |
 | targetKeys(v-model) | 显示在右侧框数据的 key 集合 | string\[] | \[] |  |
+| targetOrder | 右侧列表元素的排序策略：若为 push，则新加入的元素排在最后；若为 unshift，则新加入的元素排在最前，默认 排在最前 | 'unshift' \| 'push' | - | 4.2.2 |
 | titles | 标题集合，顺序从左至右 | string\[] | \['', ''] |  |
 
 ### 事件


### PR DESCRIPTION
…为push,新添加项则在最后

当前：从左侧添加到右侧，新添加元素在顶部，缺点比较单一，弱需要添加到底部，则不支持；
修改后：增加 `targetOrder` 属性，定义 右侧列表元素的排序策略；

issues：https://github.com/vueComponent/ant-design-vue/issues/2626 有提到类似问题，但一直没解决，本次解决此issues；



