### PR TITLE
fix(FloatButton): type error

### DIFF
--- a/components/float-button/interface.ts
+++ b/components/float-button/interface.ts
@@ -20,7 +20,7 @@ export const floatButtonProps = () => {
     shape: stringType<FloatButtonShape>('circle'),
     tooltip: PropTypes.any,
     href: String,
-    target: stringType<'_self' | '_blank' | '_parent' | '_top'>(),
+    target: String,
     badge: objectType<FloatButtonBadgeProps>(),
     onClick: functionType<MouseEventHandler>(),
   };


### PR DESCRIPTION
按照文档所述这里的 `target` 相当于 `a` 标签的 `target`。
那么 `_self`、`_blank`、`_parent`、`_top` 只是有特殊含义的关键字，并不能完全囊括 `target` 可以输入的内容，我们还可以传入 `framename` 用来在指定的 `<iframe>` 上打开URL链接