### PR TITLE
fix(Select): update select component convert2LabelValues fn

### DIFF
--- a/components/vc-select/Select.tsx
+++ b/components/vc-select/Select.tsx
@@ -207,6 +207,9 @@ export default defineComponent({
     // ========================= Wrap Value =========================
     const convert2LabelValues = (draftValues: DraftValueType) => {
       // Convert to array
+      if (multiple.value) {
+        draftValues = Array.isArray(draftValues) ? draftValues : [];
+      }
       const valueList = toArray(draftValues);
 
       // Convert to labelInValue type


### PR DESCRIPTION
解决select 多选状态下null和空字符串展示空tag的问题