### PR TITLE
fix: replace push with concat

### DIFF
--- a/components/_util/props-util/index.ts
+++ b/components/_util/props-util/index.ts
@@ -49,15 +49,15 @@ const hasProp = (instance: any, prop: string) => {
 export const skipFlattenKey = Symbol('skipFlatten');
 const flattenChildren = (children = [], filterEmpty = true) => {
   const temp = Array.isArray(children) ? children : [children];
-  const res = [];
+  let res = [];
   temp.forEach(child => {
     if (Array.isArray(child)) {
-      res.push(...flattenChildren(child, filterEmpty));
+      res = res.concat(flattenChildren(child, filterEmpty));
     } else if (child && child.type === Fragment) {
       if (child.key === skipFlattenKey) {
         res.push(child);
       } else {
-        res.push(...flattenChildren(child.children, filterEmpty));
+        res = res.concat(flattenChildren(child.children, filterEmpty));
       }
     } else if (child && isVNode(child)) {
       if (filterEmpty && !isEmptyElement(child)) {


### PR DESCRIPTION
resolve #7634 

using the extension operator (...) When using the extension operator (...), the element is stored in stack memory.

related: https://stackoverflow.com/questions/61740599/rangeerror-maximum-call-stack-size-exceeded-with-array-push