### PR TITLE
feat(Input): Add v-model:value.trim support to input component

### DIFF
--- a/components/_util/BaseInput.tsx
+++ b/components/_util/BaseInput.tsx
@@ -35,6 +35,7 @@ const BaseInput = defineComponent({
     size: PropTypes.string,
     style: PropTypes.oneOfType([String, Object]),
     class: PropTypes.string,
+    valueModifiers: PropTypes.object,
   },
   emits: [
     'change',
@@ -86,6 +87,9 @@ const BaseInput = defineComponent({
     };
 
     const handleBlur = (e: Event) => {
+      if (props?.valueModifiers?.trim) {
+        (e.target as HTMLInputElement).value = (e.target as HTMLInputElement).value.trim();
+      }
       emit('blur', e);
     };
     const handleFocus = (e: Event) => {

--- a/components/vc-input/BaseInput.tsx
+++ b/components/vc-input/BaseInput.tsx
@@ -72,10 +72,12 @@ export default defineComponent({
         affixWrapperClassName,
         wrapperClassName,
         groupClassName,
+        valueModifiers,
       } = props;
       let element = cloneElement(inputElement, {
         value,
         hidden,
+        valueModifiers,
       });
       // ================== Prefix & Suffix ================== //
       if (hasPrefixSuffix({ prefix, suffix, allowClear })) {

--- a/components/vc-input/Input.tsx
+++ b/components/vc-input/Input.tsx
@@ -231,7 +231,7 @@ export default defineComponent({
       }
     });
     return () => {
-      const { prefixCls, disabled, ...rest } = props;
+      const { prefixCls, disabled, valueModifiers, ...rest } = props;
       return (
         <BaseInput
           {...rest}
@@ -245,6 +245,7 @@ export default defineComponent({
           triggerFocus={focus}
           suffix={getSuffix()}
           disabled={disabled}
+          valueModifiers={valueModifiers}
           v-slots={slots}
         />
       );

--- a/components/vc-input/inputProps.ts
+++ b/components/vc-input/inputProps.ts
@@ -46,6 +46,7 @@ export const baseInputProps = () => {
     readonly: { type: Boolean, default: undefined },
     handleReset: Function as PropType<MouseEventHandler>,
     hidden: { type: Boolean, default: undefined },
+    valueModifiers: { type: Object, default: undefined },
   };
 };
 export const inputProps = () => ({


### PR DESCRIPTION
close #7658 

让组件a-input支持 v-model:value.trim 的写法。

判断valueModifiers的属性查看是否有trim属性，如果有表示该组件要使用 v-model:value.trim功能，去除输入框文字两侧的空格