### PR TITLE
feat: add keyboardPrediction prop

### DIFF
--- a/components/_util/BaseInput.tsx
+++ b/components/_util/BaseInput.tsx
@@ -35,6 +35,7 @@ const BaseInput = defineComponent({
     size: PropTypes.string,
     style: PropTypes.oneOfType([String, Object]),
     class: PropTypes.string,
+    keyboardPrediction: PropTypes.bool,
   },
   emits: [
     'change',
@@ -64,13 +65,17 @@ const BaseInput = defineComponent({
       emit('change', e);
     };
     const onCompositionstart = (e: CompositionEvent) => {
-      isComposing.value = true;
-      (e.target as any).composing = true;
+      if (props.keyboardPrediction) {
+        isComposing.value = true;
+        (e.target as any).composing = true;
+      }
       emit('compositionstart', e);
     };
     const onCompositionend = (e: CompositionEvent) => {
-      isComposing.value = false;
-      (e.target as any).composing = false;
+      if (props.keyboardPrediction) {
+        isComposing.value = false;
+        (e.target as any).composing = false;
+      }
       emit('compositionend', e);
       const event = document.createEvent('HTMLEvents');
       event.initEvent('input', true, true);

--- a/components/input/index.en-US.md
+++ b/components/input/index.en-US.md
@@ -54,6 +54,7 @@ A basic widget for getting the user input is a text field. Keyboard and mouse ca
 | defaultValue | The initial input content | string |  |  |  |
 | showCount | Whether show text count | boolean | false |  |  |
 | value(v-model) | The input content value | string |  |  |  |
+| keyboardPrediction | Supports predictive keyboards or complex input methods such as Chinese | boolean | false | 4.2.4 |
 
 ### TextArea Events
 

--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -55,6 +55,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*sBqqTatJ-AkAAA
 | defaultValue | 输入框默认内容 | string |  |  |  |
 | showCount | 是否展示字数 | boolean | false |  |  |
 | value(v-model) | 输入框内容 | string |  |  |  |
+| keyboardPrediction | 支持预测键盘或复杂输入法（如中文） | boolean | false | 4.2.4 |
 
 ### TextArea 事件
 

--- a/components/input/inputProps.ts
+++ b/components/input/inputProps.ts
@@ -33,6 +33,7 @@ const textAreaProps = () => ({
   onCompositionstart: eventType<CompositionEventHandler>(),
   onCompositionend: eventType<CompositionEventHandler>(),
   valueModifiers: Object,
+  keyboardPrediction: { type: Boolean, default: undefined },
 });
 
 export { textAreaProps };

--- a/components/mentions/index.en-US.md
+++ b/components/mentions/index.en-US.md
@@ -16,7 +16,7 @@ When you need to mention someone or something.
 
 ### Mention
 
-| Property | Description | Type | Default |
+| Property | Description | Type | Default | Version |
 | --- | --- | --- | --- | --- |
 | autofocus | Auto get focus when component mounted | boolean | `false` |
 | defaultValue | Default value | string |  |
@@ -31,6 +31,7 @@ When you need to mention someone or something.
 | value(v-model) | Set value of mentions | string |  |
 | options | Option Configuration | [Options](#option) | \[] | 4.0 |
 | option | custom option label | v-slot:option="option" | - | 4.0 |
+| keyboardPrediction | Supports predictive keyboards or complex input methods such as Chinese | boolean | false | 4.2.4 |
 
 ### Events
 

--- a/components/mentions/index.zh-CN.md
+++ b/components/mentions/index.zh-CN.md
@@ -17,7 +17,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*pxR2S53P_xoAAA
 
 ### Mentions
 
-| 参数 | 说明 | 类型 | 默认值 |
+| 参数 | 说明 | 类型 | 默认值 | 版本 |
 | --- | --- | --- | --- | --- |
 | autofocus | 自动获得焦点 | boolean | `false` |
 | defaultValue | 默认值 | string |  |
@@ -32,6 +32,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*pxR2S53P_xoAAA
 | value(v-model) | 设置值 | string |  |
 | options | 选项配置 | [Options](#option) | \[] | 4.0 |
 | option | 通过 option 插槽，自定义节点 | v-slot:option="option" | - | 4.0 |
+| keyboardPrediction | 支持预测键盘或复杂输入法（如中文） | boolean | false | 4.2.4 |
 
 ### 事件
 

--- a/components/pagination/index.en-US.md
+++ b/components/pagination/index.en-US.md
@@ -39,6 +39,7 @@ A long list can be divided into several pages using `Pagination`, and only one p
 | simple | whether to use simple mode | boolean | - |  |
 | size | specify the size of `Pagination`, can be set to `small` | string | "" |  |
 | total | total number of data items | number | 0 |  |
+| keyboardPrediction | Supports predictive keyboards or complex input methods such as Chinese | boolean | false | 4.2.4 |
 
 ### events
 

--- a/components/pagination/index.zh-CN.md
+++ b/components/pagination/index.zh-CN.md
@@ -33,6 +33,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*WM86SrBC8TsAAA
 | simple | 当添加该属性时，显示为简单分页 | boolean | - |  |
 | size | 当为「small」时，是小尺寸分页 | string | "" |  |
 | total | 数据总数 | number | 0 |  |
+| keyboardPrediction | 支持预测键盘或复杂输入法（如中文） | boolean | false | 4.2.4 |
 
 ### 事件
 

--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -70,6 +70,7 @@ Select component to select value from options.
 | tokenSeparators | Separator used to tokenize, only applies when `mode="tags"` | string\[] | - |  |
 | value(v-model) | Current selected option. | string\|number\|string\[]\|number\[] | - |  |
 | virtual | Disable virtual scroll when set to false | boolean | true | 3.0 |
+| keyboardPrediction | Supports predictive keyboards or complex input methods such as Chinese | boolean | false | 4.2.4 |
 
 > Note, if you find that the drop-down menu scrolls with the page, or you need to trigger Select in other popup layers, please try to use `getPopupContainer={triggerNode => triggerNode.parentElement}` to fix the drop-down popup rendering node in the parent element of the trigger .
 

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -70,6 +70,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*5oPiTqPxGAUAAA
 | tokenSeparators | 自动分词的分隔符，仅在 `mode="tags"` 时生效 | string\[] | - |  |
 | value(v-model) | 指定当前选中的条目 | string\|string\[]\|number\|number\[] | - |  |
 | virtual | 设置 false 时关闭虚拟滚动 | boolean | true | 3.0 |
+| keyboardPrediction | 支持预测键盘或复杂输入法（如中文） | boolean | false | 4.2.4 |
 
 > 注意，如果发现下拉菜单跟随页面滚动，或者需要在其他弹层中触发 Select，请尝试使用 `getPopupContainer={triggerNode => triggerNode.parentNode}` 将下拉弹层渲染节点固定在触发器的父元素中。
 

--- a/components/vc-input/inputProps.ts
+++ b/components/vc-input/inputProps.ts
@@ -101,6 +101,7 @@ export const inputProps = () => ({
   valueModifiers: Object,
   hidden: { type: Boolean, default: undefined },
   status: String as PropType<InputStatus>,
+  keyboardPrediction: { type: Boolean, default: undefined },
 });
 export type InputProps = Partial<ExtractPropTypes<ReturnType<typeof inputProps>>>;
 

--- a/components/vc-mentions/src/mentionsProps.ts
+++ b/components/vc-mentions/src/mentionsProps.ts
@@ -33,6 +33,7 @@ export const mentionsProps = {
   loading: { type: Boolean, default: undefined },
   rows: [Number, String],
   direction: { type: String as PropType<Direction> },
+  keyboardPrediction: { type: Boolean, default: undefined },
 };
 
 export const vcMentionsProps = {

--- a/components/vc-pagination/Options.tsx
+++ b/components/vc-pagination/Options.tsx
@@ -19,6 +19,7 @@ export default defineComponent({
     rootPrefixCls: String,
     selectPrefixCls: String,
     goButton: PropTypes.any,
+    keyboardPrediction: { type: Boolean, default: undefined },
   },
   setup(props) {
     const goInputText = ref('');
@@ -91,6 +92,7 @@ export default defineComponent({
         selectPrefixCls,
         pageSize,
         disabled,
+        keyboardPrediction,
       } = props;
       const prefixCls = `${rootPrefixCls}-options`;
       let changeSelect = null;
@@ -155,6 +157,7 @@ export default defineComponent({
               onChange={handleChange}
               onKeyup={go}
               onBlur={handleBlur}
+              keyboardPrediction={keyboardPrediction}
             ></BaseInput>
             {locale.page}
             {gotoButton}

--- a/components/vc-pagination/Pagination.tsx
+++ b/components/vc-pagination/Pagination.tsx
@@ -58,6 +58,7 @@ export default defineComponent({
     jumpPrevIcon: PropTypes.any,
     jumpNextIcon: PropTypes.any,
     totalBoundaryShowSizeChanger: PropTypes.number.def(50),
+    keyboardPrediction: { type: Boolean, default: undefined },
   },
   data() {
     const props = this.$props;
@@ -350,6 +351,7 @@ export default defineComponent({
       selectComponentClass,
       selectPrefixCls,
       pageSizeOptions,
+      keyboardPrediction,
     } = this.$props;
     const { stateCurrent, statePageSize } = this;
     const { class: className, ...restAttrs } = splitAttrs(this.$attrs).extraAttrs;
@@ -431,6 +433,7 @@ export default defineComponent({
               onInput={this.handleKeyUp}
               onChange={this.handleKeyUp}
               size="3"
+              keyboardPrediction={keyboardPrediction}
             ></BaseInput>
             <span class={`${prefixCls}-slash`}>／</span>
             {allPages}

--- a/components/vc-select/BaseSelect.tsx
+++ b/components/vc-select/BaseSelect.tsx
@@ -235,6 +235,7 @@ export const baseSelectPropsWithoutPrivate = () => {
     onMouseenter: Function as PropType<(e: MouseEvent) => void>,
     onMouseleave: Function as PropType<(e: MouseEvent) => void>,
     onClick: Function as PropType<(e: MouseEvent) => void>,
+    keyboardPrediction: { type: Boolean, default: undefined },
   };
 };
 const baseSelectProps = () => {

--- a/components/vc-select/Selector/Input.tsx
+++ b/components/vc-select/Selector/Input.tsx
@@ -36,6 +36,7 @@ export const inputProps = {
   onCompositionend: { type: Function as PropType<CompositionEventHandler> },
   onFocus: { type: Function as PropType<FocusEventHandler> },
   onBlur: { type: Function as PropType<FocusEventHandler> },
+  keyboardPrediction: { type: Boolean, default: undefined },
 };
 
 export type InputProps = Partial<ExtractPropTypes<typeof inputProps>>;
@@ -71,6 +72,7 @@ const Input = defineComponent({
         open,
         inputRef,
         attrs,
+        keyboardPrediction,
       } = props;
 
       let inputNode: any = inputElement || <BaseInput></BaseInput>;
@@ -97,6 +99,7 @@ const Input = defineComponent({
             disabled,
             tabindex,
             lazy: false,
+            keyboardPrediction,
             autocomplete: autocomplete || 'off',
             autofocus,
             class: classNames(`${prefixCls}-selection-search-input`, inputNode?.props?.class),

--- a/components/vc-select/Selector/MultipleSelector.tsx
+++ b/components/vc-select/Selector/MultipleSelector.tsx
@@ -67,6 +67,7 @@ const props = {
   onInputMouseDown: Function,
   onInputCompositionStart: Function,
   onInputCompositionEnd: Function,
+  keyboardPrediction: { type: Boolean, default: undefined },
 };
 
 const onPreventMouseDown = (event: MouseEvent) => {
@@ -234,6 +235,7 @@ const SelectSelector = defineComponent<SelectorProps>({
         onInputMouseDown,
         onInputCompositionStart,
         onInputCompositionEnd,
+        keyboardPrediction,
       } = props;
       // >>> Input Node
       const inputNode = (
@@ -264,6 +266,7 @@ const SelectSelector = defineComponent<SelectorProps>({
             attrs={pickAttrs(props, true)}
             onFocus={() => (focused.value = true)}
             onBlur={() => (focused.value = false)}
+            keyboardPrediction={keyboardPrediction}
           />
 
           {/* Measure Node */}

--- a/components/vc-select/Selector/SingleSelector.tsx
+++ b/components/vc-select/Selector/SingleSelector.tsx
@@ -38,6 +38,7 @@ const props = {
   onInputMouseDown: Function,
   onInputCompositionStart: Function,
   onInputCompositionEnd: Function,
+  keyboardPrediction: { type: Boolean, default: undefined },
 };
 const SingleSelector = defineComponent<SelectorProps>({
   name: 'SingleSelector',
@@ -117,6 +118,7 @@ const SingleSelector = defineComponent<SelectorProps>({
         onInputPaste,
         onInputCompositionStart,
         onInputCompositionEnd,
+        keyboardPrediction,
       } = props;
       const item = values[0];
       let titleNode = null;
@@ -163,6 +165,7 @@ const SingleSelector = defineComponent<SelectorProps>({
               onCompositionend={onInputCompositionEnd}
               tabindex={tabindex}
               attrs={pickAttrs(props, true)}
+              keyboardPrediction={keyboardPrediction}
             />
           </span>
 

--- a/components/vc-select/Selector/index.tsx
+++ b/components/vc-select/Selector/index.tsx
@@ -66,6 +66,8 @@ export interface SelectorProps {
    * This may be removed after React provides replacement of `findDOMNode`
    */
   domRef: () => HTMLDivElement;
+
+  keyboardPrediction: boolean;
 }
 export interface RefSelectorProps {
   focus: () => void;
@@ -121,6 +123,7 @@ const Selector = defineComponent<SelectorProps>({
      * This may be removed after React provides replacement of `findDOMNode`
      */
     domRef: Function,
+    keyboardPrediction: { type: Boolean, default: undefined },
   } as any,
   setup(props, { expose }) {
     const inputRef = createRef();

--- a/components/vc-select/Selector/interface.ts
+++ b/components/vc-select/Selector/interface.ts
@@ -25,4 +25,5 @@ export interface InnerSelectorProps {
   onInputPaste: EventHandler;
   onInputCompositionStart: EventHandler;
   onInputCompositionEnd: EventHandler;
+  keyboardPrediction: boolean;
 }


### PR DESCRIPTION
add keyboardPrediction prop to restored previous behavior when users search, similar to earlier versions.

This PR will add the option to support features related to composition events without breaking the old behavior.
The new change in version 4.2.* prevented the current behavior of inputs from being completely broken, causing nearly all of our apps to break upon upgrade.

https://github.com/vueComponent/ant-design-vue/assets/8065692/1ae29ade-e6fc-4e1a-8c03-970bb3f204da

