### PR TITLE
fix(BaseInput): replace deprecated syntax

### DIFF
--- a/components/_util/BaseInput.tsx
+++ b/components/_util/BaseInput.tsx
@@ -72,8 +72,10 @@ const BaseInput = defineComponent({
       isComposing.value = false;
       (e.target as any).composing = false;
       emit('compositionend', e);
-      const event = document.createEvent('HTMLEvents');
-      event.initEvent('input', true, true);
+      const event = new Event('input', {
+        bubbles: true,
+        cancelable: true,
+      });
       e.target.dispatchEvent(event);
       handleChange(e);
     };


### PR DESCRIPTION
BaseInput中使用的 `createEvent()` 和 `Event.initEvent()` 已经不再推荐使用，根据mdn中的推荐改为了 `event constructors` 的写法

参考：
https://developer.mozilla.org/en-US/docs/Web/API/Document/createEvent