### PR TITLE
fix(Select): dropdown rendering blank

### DIFF
--- a/components/vc-virtual-list/List.tsx
+++ b/components/vc-virtual-list/List.tsx
@@ -195,7 +195,8 @@ const List = defineComponent({
       });
     });
     onUpdated(() => {
-      nextTick(() => {
+      // for: wait for dropdown render slot finished
+      setTimeout(() => {
         offsetHeight.value = fillerInnerRef.value?.offsetHeight || 0;
       });
     });


### PR DESCRIPTION
resolve #7539

背景：
使用`dropdownRender`对`ASelect`进行自定义扩展，在`ASelect`有焦点的情况下且滚动条滚动超过一页时，点击下拉会出现选项空白，完整讨论见 [Issue](https://github.com/vueComponent/ant-design-vue/issues/7539)，[官方文档](https://www.antdv.com/components/select-cn#components-select-demo-custom-dropdown-menu)可复现。

操作步骤：
1.  添加多个Item，直到数据超过一页
2. 将滚动条滚动到最底部，点击页面除 Select 框以外的位置失焦
3. 再次点击 Select 框，此时出现选项空白😱
![2024-08-19-171117_out](https://github.com/user-attachments/assets/858340e8-a187-4129-a185-d3e081f5df20)


对比流程：
`ASelect`不聚焦时，点击下拉框，会触发`onContainerFocus`等方法，在`onContainerFocus`方法中用`setTimeout`延迟修改`mockFocused`，`mockFocused`变化会引起`List`的`onUpdated`的执行，此时列表已渲染完成，`offsetHeight`能被正确赋值，触发了 `watcher`，更新`state.scrollTop`，进而更新到`calRes.offset`中。

而`ASelect`聚焦时，点击下拉框，不会触发`onContainerFocus`方法，导致`offsetHeight`未能正确赋值，进而`calRes.offset`未能正确计算，导致`List`未能正确滚动到历史停留位置，出现选项空白。
