### PR TITLE
fix: withModifiers cannot be used with the capture modifier

### DIFF
--- a/components/vc-trigger/Popup/PopupInner.tsx
+++ b/components/vc-trigger/Popup/PopupInner.tsx
@@ -204,7 +204,7 @@ export default defineComponent({
                         class={mergedClassName}
                         onMouseenter={onMouseenter}
                         onMouseleave={onMouseleave}
-                        onMousedown={withModifiers(onMousedown, ['capture'])}
+                        onMousedownCapture={onMousedown}
                         {...{
                           [supportsPassive ? 'onTouchstartPassive' : 'onTouchstart']: withModifiers(
                             onTouchstart,


### PR DESCRIPTION
[vuejs/core #11226](https://github.com/vuejs/core/issues/11226)

withModifiers cannot use the `capture`, `once`, or `passive` modifiers, so event capturing will not work here. Change to onMousedownCapture for event capturing.
