### PR TITLE
perf: `borderRadius Token` Compatible with `string`

### DIFF
--- a/components/_util/cssinjs/util.ts
+++ b/components/_util/cssinjs/util.ts
@@ -116,3 +116,10 @@ export function supportLogicProps(): boolean {
 
   return canLogic!;
 }
+
+export function removeUnit(num: string | number): number {
+  if (typeof num === 'number') {
+    return num;
+  }
+  return Number(num.replace('px', ''));
+}

--- a/components/theme/themes/shared/genRadius.ts
+++ b/components/theme/themes/shared/genRadius.ts
@@ -1,3 +1,4 @@
+import { removeUnit } from '../../../_util/cssinjs/util';
 import type { MapToken } from '../../interface';
 
 const genRadius = (
@@ -6,6 +7,8 @@ const genRadius = (
   MapToken,
   'borderRadiusXS' | 'borderRadiusSM' | 'borderRadiusLG' | 'borderRadius' | 'borderRadiusOuter'
 > => {
+  radiusBase = removeUnit(radiusBase);
+
   let radiusLG = radiusBase;
   let radiusSM = radiusBase;
   let radiusXS = radiusBase;

--- a/components/theme/util/alias.ts
+++ b/components/theme/util/alias.ts
@@ -2,6 +2,7 @@ import { TinyColor } from '@ctrl/tinycolor';
 import type { AliasToken, MapToken, OverrideToken, SeedToken } from '../interface';
 import getAlphaColor from './getAlphaColor';
 import seedToken from '../themes/seed';
+import { removeUnit } from '../../_util/cssinjs/util';
 
 /** Raw merge of `@ant-design/cssinjs` token. Which need additional process */
 type RawMergedToken = MapToken & OverrideToken & { override: Partial<AliasToken> };
@@ -84,10 +85,10 @@ export default function formatToken(derivativeToken: RawMergedToken): AliasToken
     controlOutline: getAlphaColor(mergedToken.colorPrimaryBg, mergedToken.colorBgContainer),
 
     lineType: mergedToken.lineType,
-    borderRadius: mergedToken.borderRadius,
-    borderRadiusXS: mergedToken.borderRadiusXS,
-    borderRadiusSM: mergedToken.borderRadiusSM,
-    borderRadiusLG: mergedToken.borderRadiusLG,
+    borderRadius: removeUnit(mergedToken.borderRadius),
+    borderRadiusXS: removeUnit(mergedToken.borderRadiusXS),
+    borderRadiusSM: removeUnit(mergedToken.borderRadiusSM),
+    borderRadiusLG: removeUnit(mergedToken.borderRadiusLG),
 
     fontWeightStrong: 600,
 


### PR DESCRIPTION
resolve #7684 

Since too many people still pass in the `string` type when configuring a token, this can cause errors in the `MapToken` result.