### PR TITLE
fix: 表格单元格宽度精度

### DIFF
--- a/components/vc-resize-observer/index.tsx
+++ b/components/vc-resize-observer/index.tsx
@@ -29,6 +29,8 @@ export default defineComponent({
         size: {
           width: number;
           height: number;
+          originWidth: number;
+          originHeight: number;
           offsetWidth: number;
           offsetHeight: number;
         },
@@ -84,6 +86,8 @@ export default defineComponent({
           Promise.resolve().then(() => {
             onResize(
               {
+                originWidth: width,
+                originHeight: height,
                 ...size,
                 offsetWidth,
                 offsetHeight,

--- a/components/vc-table/Body/MeasureCell.tsx
+++ b/components/vc-table/Body/MeasureCell.tsx
@@ -14,14 +14,14 @@ export default defineComponent<MeasureCellProps>({
     const tdRef = ref<HTMLTableCellElement>();
     onMounted(() => {
       if (tdRef.value) {
-        emit('columnResize', props.columnKey, tdRef.value.offsetWidth);
+        emit('columnResize', props.columnKey, tdRef.value.getBoundingClientRect().width);
       }
     });
     return () => {
       return (
         <VCResizeObserver
-          onResize={({ offsetWidth }) => {
-            emit('columnResize', props.columnKey, offsetWidth);
+          onResize={({ originWidth }) => {
+            emit('columnResize', props.columnKey, originWidth);
           }}
         >
           <td ref={tdRef} style={{ padding: 0, border: 0, height: 0 }}>


### PR DESCRIPTION
表格列多的情况下，悬浮的标题栏会因为获取的单元格宽度精度失真，而逐渐无法对齐