### PR TITLE
fix(_utils): Compatible with Vue3.4.0's computed breaking changes.

### DIFF
--- a/components/_util/eagerComputed.ts
+++ b/components/_util/eagerComputed.ts
@@ -1,16 +1,25 @@
-import { watchEffect, shallowRef } from 'vue';
+import compareVersions from 'compare-versions';
+import { watchEffect, shallowRef, computed, version } from 'vue';
 import type { ComputedRef } from 'vue';
 export declare type ComputedGetter<T> = (...args: any[]) => T;
-export default function eagerComputed<T>(fn: ComputedGetter<T>) {
-  const result = shallowRef<T>();
-  watchEffect(
-    () => {
-      result.value = fn();
-    },
-    {
-      flush: 'sync', // needed so updates are immediate.
-    },
-  );
 
-  return result as any as ComputedRef<T>;
-}
+const breakingChangeVersion = '3.4.0';
+const needEager = compareVersions(version, breakingChangeVersion) < 0;
+
+const eagerComputed = needEager
+  ? function <T>(fn: ComputedGetter<T>) {
+      const result = shallowRef<T>();
+      watchEffect(
+        () => {
+          result.value = fn();
+        },
+        {
+          flush: 'sync', // needed so updates are immediate.
+        },
+      );
+
+      return result as any as ComputedRef<T>;
+    }
+  : computed;
+
+export default eagerComputed;


### PR DESCRIPTION
close #7592 

Starting from Vue 3.4.0, we no longer need eagerComputed because the reactivity system in Vue 3.4.0 optimizes the computed function's execution. Although, the error will not occur above 3.5.0, we still no longer need eagerComputed.