### PR TITLE
fix: 避免在焦点元素或其祖先元素上使用 aria-hidden;

### DIFF
--- a/components/vc-dialog/Dialog.jsx
+++ b/components/vc-dialog/Dialog.jsx
@@ -282,7 +282,7 @@ export default {
           forceRender={forceRender}
           onMousedown={this.onDialogMouseDown}
         >
-          <div tabIndex={0} ref="sentinelStart" style={sentinelStyle} aria-hidden="true" />
+          <div tabIndex={0} ref="sentinelStart" style={sentinelStyle} />
           <div class={`${prefixCls}-content`}>
             {closer}
             {header}
@@ -291,7 +291,7 @@ export default {
             </div>
             {footer}
           </div>
-          <div tabIndex={0} ref="sentinelEnd" style={sentinelStyle} aria-hidden="true" />
+          <div tabIndex={0} ref="sentinelEnd" style={sentinelStyle} />
         </LazyRenderBox>
       );
       const dialogTransitionProps = getTransitionProps(transitionName, {

--- a/components/vc-tabs/src/TabPane.jsx
+++ b/components/vc-tabs/src/TabPane.jsx
@@ -43,7 +43,7 @@ export default {
       panelSentinelEnd = <Sentinel setRef={setPanelSentinelEnd} nextElement={sentinelEnd} />;
     }
     return (
-      <div class={cls} role="tabpanel" aria-hidden={active ? 'false' : 'true'}>
+      <div class={cls} role="tabpanel">
         {panelSentinelStart}
         {shouldRender ? children : placeholder}
         {panelSentinelEnd}


### PR DESCRIPTION
### 用于修复较新版本的 Chrome 浏览器对在焦点元素上使用 aria-hidden 的报错
<img width="794" alt="image" src="https://github.com/user-attachments/assets/9b5bb068-ce5f-4769-ae02-fa79a7d1ad62">
目前在这个 issue 中有人提到 https://github.com/vueComponent/ant-design-vue/issues/7749
在评论区中有人提到可以使用
````
.ant-modal div[aria-hidden="true"] {
display: none !important;
}
````

来临时规避，但是我们项目中实际使用的话在某些场景 tab 展示会有异常
参考 antd for react 的处理方式：
https://github.com/ant-design/ant-design/issues/50170#issuecomment-2263385601
https://github.com/react-component/dialog/commit/df21b0ebcc103bebf081242452a91d7524769b1e
把相关使用到 aria-hidden 的地方给删除了