### PR TITLE
解决Input输入表情时计算错误的问题

### DIFF
--- a/components/input/TextArea.tsx
+++ b/components/input/TextArea.tsx
@@ -12,7 +12,7 @@ import ClearableLabeledInput from './ClearableLabeledInput';
 import ResizableTextArea from './ResizableTextArea';
 import { textAreaProps } from './inputProps';
 import type { InputFocusOptions } from '../vc-input/utils/commonUtils';
-import { fixControlledValue, resolveOnChange, triggerFocus } from '../vc-input/utils/commonUtils';
+import { fixControlledValue, resolveOnChange, triggerFocus, fixEmojiLength, setTriggerValue } from '../vc-input/utils/commonUtils';
 import classNames from '../_util/classNames';
 import { FormItemInputContext, useInjectFormItemContext } from '../form/FormItemContext';
 import type { FocusEventHandler } from '../_util/EventInterface';
@@ -24,30 +24,6 @@ import { getMergedStatus, getStatusClassNames } from '../_util/statusUtils';
 // CSSINJS
 import useStyle from './style';
 import { useInjectDisabled } from '../config-provider/DisabledContext';
-
-function fixEmojiLength(value: string, maxLength: number) {
-  return [...(value || '')].slice(0, maxLength).join('');
-}
-
-function setTriggerValue(
-  isCursorInEnd: boolean,
-  preValue: string,
-  triggerValue: string,
-  maxLength: number,
-) {
-  let newTriggerValue = triggerValue;
-  if (isCursorInEnd) {
-    // 光标在尾部，直接截断
-    newTriggerValue = fixEmojiLength(triggerValue, maxLength);
-  } else if (
-    [...(preValue || '')].length < triggerValue.length &&
-    [...(triggerValue || '')].length > maxLength
-  ) {
-    // 光标在中间，如果最后的值超过最大值，则采用原先的值
-    newTriggerValue = preValue;
-  }
-  return newTriggerValue;
-}
 
 export default defineComponent({
   compatConfig: { MODE: 3 },

--- a/components/vc-input/Input.tsx
+++ b/components/vc-input/Input.tsx
@@ -270,7 +270,7 @@ export default defineComponent({
           prefixCls={prefixCls}
           inputElement={getInputElement()}
           handleReset={handleReset}
-          value={fixControlledValue(stateValue.value)}
+          value={fixControlledValue(mergedValue.value)}
           focused={focused.value}
           triggerFocus={focus}
           suffix={getSuffix()}

--- a/components/vc-input/utils/commonUtils.ts
+++ b/components/vc-input/utils/commonUtils.ts
@@ -102,3 +102,27 @@ export function triggerFocus(
     }
   }
 }
+
+export function fixEmojiLength(value: string, maxLength: number) {
+  return [...(value || '')].slice(0, maxLength).join('');
+}
+
+export function setTriggerValue(
+  isCursorInEnd: boolean,
+  preValue: string,
+  triggerValue: string,
+  maxLength: number,
+) {
+  let newTriggerValue = triggerValue;
+  if (isCursorInEnd) {
+    // 光标在尾部，直接截断
+    newTriggerValue = fixEmojiLength(triggerValue, maxLength);
+  } else if (
+    [...(preValue || '')].length < triggerValue.length &&
+    [...(triggerValue || '')].length > maxLength
+  ) {
+    // 光标在中间，如果最后的值超过最大值，则采用原先的值
+    newTriggerValue = preValue;
+  }
+  return newTriggerValue;
+}


### PR DESCRIPTION
对于textarea来说，一个表情算一个字符。为了让input组件和它保持一致，需要按照textarea的方法，不把maxlength传递下去，在vc-input组件对value长度进行处理