### PR TITLE
fix: 修复宽度超出100%时不能随侧边栏一块滚动

### DIFF
--- a/components/layout/style/index.ts
+++ b/components/layout/style/index.ts
@@ -124,7 +124,7 @@ const genLayoutStyle: GenerateStyle<LayoutToken, CSSObject> = token => {
         },
 
         '&-trigger': {
-          position: 'fixed',
+          position: 'sticky',
           bottom: 0,
           zIndex: 1,
           height: layoutTriggerHeight,


### PR DESCRIPTION
宽度超出100%时出现横向滚动，应该在横向滚动的时候随着侧边栏一块，而不是脱离侧边栏