### PR TITLE
fix[date-picker]: fixed focus of picker panel

### DIFF
--- a/components/vc-picker/Picker.tsx
+++ b/components/vc-picker/Picker.tsx
@@ -507,13 +507,7 @@ function Picker<DateType>() {
         }
 
         const panel = (
-          <div
-            class={`${prefixCls}-panel-container`}
-            ref={panelDivRef}
-            onMousedown={e => {
-              e.preventDefault();
-            }}
-          >
+          <div class={`${prefixCls}-panel-container`} ref={panelDivRef}>
             {panelNode}
           </div>
         );

--- a/components/vc-picker/RangePicker.tsx
+++ b/components/vc-picker/RangePicker.tsx
@@ -1135,9 +1135,6 @@ function RangerPicker<DateType>() {
               class={`${prefixCls}-panel-container`}
               style={{ marginLeft: `${panelLeft.value}px` }}
               ref={panelDivRef}
-              onMousedown={e => {
-                e.preventDefault();
-              }}
             >
               {mergedNodes}
             </div>

--- a/components/vc-picker/hooks/usePickerInput.ts
+++ b/components/vc-picker/hooks/usePickerInput.ts
@@ -124,7 +124,8 @@ export default function usePickerInput({
           }
         }, 0);
       } else if (open.value) {
-        triggerOpen(false);
+        // The blur event will not close it, as the element might be focused within the panel.
+        // triggerOpen(false);
 
         if (valueChangedRef.value) {
           onSubmit();


### PR DESCRIPTION
resolve #7650 

Fixed the focus on the panel. 
Since the footer can be extended, the focus event might occur inside the panel.