### PR TITLE
fix: Avoid using aria-hidden on a focused element

### DIFF
--- a/components/vc-dialog/Content.tsx
+++ b/components/vc-dialog/Content.tsx
@@ -143,9 +143,9 @@ export default defineComponent({
               onMousedown={onMousedown}
               onMouseup={onMouseup}
             >
-              <div tabindex={0} ref={sentinelStartRef} style={sentinelStyle} aria-hidden="true" />
+              <div tabindex={0} ref={sentinelStartRef} style={sentinelStyle} />
               {modalRender ? modalRender({ originVNode: content }) : content}
-              <div tabindex={0} ref={sentinelEndRef} style={sentinelStyle} aria-hidden="true" />
+              <div tabindex={0} ref={sentinelEndRef} style={sentinelStyle} />
             </div>
           ) : null}
         </Transition>


### PR DESCRIPTION
## Problem
When I open a Modal I have error in browser's console:

> [!CAUTION]
Blocked aria-hidden on a div element because the element that just received focus must not be hidden from assistive technology users. Avoid using aria-hidden on a focused element or its ancestor. Consider using the inert attribute instead, which will also prevent focus. For more details, see the aria-hidden section of the WAI-ARIA specification at https://w3c.github.io/aria/#aria-hidden. `<div tabindex=​"0" aria-hidden=​"true" style=​"width:​ 0px;​ height:​ 0px;​ overflow:​ hidden;​ outline:​ none;​">​</div>​`


![image](https://github.com/user-attachments/assets/d091fb4b-3f4b-4f9c-8776-5ce316b1afc4)

## Solution
I removed `aria-hidden` attribute like in https://github.com/react-component/dialog/pull/449

## Related issues
https://github.com/vueComponent/ant-design-vue/issues/7769 https://github.com/vueComponent/ant-design-vue/issues/7783
