### PR TITLE
docs: add expandColumnWidth prop to table component documentation

### DIFF
--- a/components/table/index.en-US.md
+++ b/components/table/index.en-US.md
@@ -89,6 +89,7 @@ Specify `dataSource` of Table as an array of data.
 | expandColumnTitle | Set the title of the expand column | v-slot | - | 4.0.0 |
 | expandIcon | Customize row expand Icon. | Function(props):VNode \| v-slot:expandIcon="props" | - |  |
 | expandRowByClick | Whether to expand row by clicking anywhere in the whole row | boolean | `false` |  |
+| expandColumnWidth | Set the width of the expand column | number | `auto` |  |
 | footer | Table footer renderer | Function(currentPageData)\| v-slot:footer="currentPageData" |  |  |
 | getPopupContainer | the render container of dropdowns in table | (triggerNode) => HTMLElement | `() => TableHtmlElement` | 1.5.0 |
 | headerCell | custom head cell by slot | v-slot:headerCell="{title, column}" | - | 3.0 |


### PR DESCRIPTION
![Screenshot 2024-09-08 at 2 03 10 AM](https://github.com/user-attachments/assets/9c51796d-2efa-4173-b293-25f9d04cfabe)
While we have the option to set a custom width for the expanded column that contains the plus icon, this wasn’t mentioned in the documentation. Therefore, I’ve added this information alongside the other expanded column documentation.