### PR TITLE
fix: 修复Anchor小方块无法隐藏问题

### DIFF
--- a/components/anchor/style/index.ts
+++ b/components/anchor/style/index.ts
@@ -102,7 +102,7 @@ const genSharedAnchorStyle: GenerateStyle<AnchorToken> = (token): CSSObject => {
         },
       },
 
-      [`${componentCls}-fixed ${componentCls}-ink ${componentCls}-ink`]: {
+      [`${componentCls}-fixed ${componentCls}-ink ${componentCls}-ink-ball`]: {
         display: 'none',
       },
     },


### PR DESCRIPTION
Anchor组件affix和showInkInFixed同时设置为false时，无法隐藏小方块