### PR TITLE
fix: select最后一个tag，hover展示有意义的label

### DIFF
--- a/components/vc-select/Selector/MultipleSelector.tsx
+++ b/components/vc-select/Selector/MultipleSelector.tsx
@@ -203,8 +203,9 @@ const SelectSelector = defineComponent<SelectorProps>({
         typeof maxTagPlaceholder === 'function'
           ? maxTagPlaceholder(omittedValues)
           : maxTagPlaceholder;
-
-      return defaultRenderSelector(content, content, false);
+      const title = omittedValues.map(item => item.label).join('，')
+      
+      return defaultRenderSelector(title, content, false);
     }
 
     const handleInput = (e: Event) => {


### PR DESCRIPTION
修复 [#7877](https://github.com/vueComponent/ant-design-vue/issues/7877)