### PR TITLE
fix(Pagination): add `selectComponentClass` prop type

### DIFF
--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -35,7 +35,7 @@ export const paginationProps = () => ({
   prefixCls: String,
   selectPrefixCls: String,
   totalBoundaryShowSizeChanger: Number,
-  selectComponentClass: String,
+  selectComponentClass: [String, Object],
   itemRender:
     functionType<
       (opt: {


### PR DESCRIPTION
`Pagination` 组件的 `selectComponentClass` 属性实际上可以是一个具体的组件，类似于 `MiniSelect` 或者 `MiddleSelect`，可以用于替换条数选择器的 `Select` 组件使其更易扩展，但是目前 `selectComponentClass` 被限制为 String 类型，希望能再增加 Object 的类型。

```ts
const paginationProps = {
  ...restProps,
  ...getIconsProps(prefixCls.value),
  prefixCls: prefixCls.value,
  selectPrefixCls: selectPrefixCls.value,
  selectComponentClass: selectComponentClass || (isSmall ? MiniSelect : MiddleSelect),
  locale: locale.value,
  buildOptionText,
  ...attrs,
  class: classNames(
    {
      [`${prefixCls.value}-mini`]: isSmall,
      [`${prefixCls.value}-rtl`]: direction.value === 'rtl',
    },
    attrs.class,
    hashId.value,
  ),
  itemRender,
};
```