### PR TITLE
fix: AutoComplete 回车bug #7971

### DIFF
--- a/components/vc-select/BaseSelect.tsx
+++ b/components/vc-select/BaseSelect.tsx
@@ -448,7 +448,7 @@ export default defineComponent({
         }
 
         // We only manage open state here, close logic should handle by list component
-        if (!mergedOpen.value) {
+        if (!mergedOpen.value && !props.emptyOptions) {
           onToggleOpen(true);
         }
       }


### PR DESCRIPTION
当 `mergedOpen` 为false时 并且下拉提示选项为空时，不触发`onToggleOpen(true)`