### PR TITLE
fix(Form): #7929 a-form组件在使用layout="inline"布局时，窗口缩小后表单项都挤在了一起，希望可以在…

### DIFF
--- a/components/form/style/index.ts
+++ b/components/form/style/index.ts
@@ -357,7 +357,6 @@ const genInlineStyle: GenerateStyle<FormToken> = token => {
         flex: 'none',
         flexWrap: 'nowrap',
         marginInlineEnd: token.margin,
-        marginBottom: 0,
 
         '&-with-help': {
           marginBottom: token.marginLG,


### PR DESCRIPTION
…一行容纳不下时增加上下间隙

使用 ant-form-item 的 margin-bottom： 24px，而不是直接设置为 0