### PR TITLE
feat(image): add "load" event

### DIFF
--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -28,9 +28,10 @@ Previewable image.
 
 ### events
 
-| Events Name | Description          | Arguments              | Version |
-| ----------- | -------------------- | ---------------------- | ------- |
-| error       | Load failed callback | (event: Event) => void | 3.2.0   |
+| Events Name | Description              | Arguments              | Version |
+| ----------- | ------------------------ | ---------------------- | ------- |
+| error       | Load failed callback     | (event: Event) => void | 3.2.0   |
+| load        | Load successful callback | (event: Event) => void | 4.3.0   |
 
 ### previewType
 

--- a/components/image/index.zh-CN.md
+++ b/components/image/index.zh-CN.md
@@ -32,6 +32,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | 事件名称 | 说明         | 回调参数               | 版本  |
 | -------- | ------------ | ---------------------- | ----- |
 | error    | 加载错误回调 | (event: Event) => void | 3.2.0 |
+| load     | 加载成功回调 | (event: Event) => void | 4.3.0 |
 
 ### previewType
 

--- a/components/select/index.en-US.md
+++ b/components/select/index.en-US.md
@@ -63,7 +63,7 @@ Select component to select value from options.
 | searchValue | The current input "search" text | string | - |  |
 | showArrow | Whether to show the drop-down arrow | boolean | single:true, multiple:false |  |
 | showSearch | Whether select is searchable | boolean | single:false, multiple:true |  |
-| size | Size of Select input. `default` `large` `small` | string | default |  |
+| size | Size of Select input. `middle` `large` `small` | string | middle |  |
 | status | Set validation status | 'error' \| 'warning' | - | 3.3.0 |
 | suffixIcon | The custom suffix icon | VNode \| slot | - |  |
 | tagRender | Customize tag render, only applies when `mode` is set to `multiple` or `tags` | slot \| (props) => any | - |  |

--- a/components/select/index.zh-CN.md
+++ b/components/select/index.zh-CN.md
@@ -63,7 +63,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*5oPiTqPxGAUAAA
 | searchValue | 控制搜索文本 | string | - |  |
 | showArrow | 是否显示下拉小箭头 | boolean | 单选为 true,多选为 false |  |
 | showSearch | 配置是否可搜索 | boolean | 单选为 false,多选为 true |  |
-| size | 选择框大小，可选 `large` `small` | string | default |  |
+| size | 选择框大小，可选 `middle` `large` `small` | string | middle |  |
 | status | 设置校验状态 | 'error' \| 'warning' | - | 3.3.0 |
 | suffixIcon | 自定义的选择框后缀图标 | VNode \| slot | - |  |
 | tagRender | 自定义 tag 内容 render，仅在 `mode` 为 `multiple` 或 `tags` 时生效 | slot \| (props) => any | - | 3.0 |

--- a/components/tabs/index.en-US.md
+++ b/components/tabs/index.en-US.md
@@ -24,6 +24,7 @@ Ant Design has 3 types of Tabs for different situations.
 | --- | --- | --- | --- | --- |
 | activeKey(v-model) | Current TabPane's key | string | - |  |
 | animated | Whether to change tabs with animation. Only works while tabPosition=`"top"` \| `"bottom"` | boolean \| {inkBar:boolean, tabPane:boolean} | `true`, `false` when `type="card"` |  |
+| centered | Whether to display the labels in the center | boolean | false | 3.0 |
 | destroyInactiveTabPane | Whether destroy inactive TabPane when change tab | boolean | false |  |
 | hideAdd | Hide plus icon or not. Only works while `type="editable-card"` | boolean | `false` | } |
 | size | preset tab bar size | `large` \| `middle` \| `small` | `middle` |  |

--- a/components/vc-image/src/Image.tsx
+++ b/components/vc-image/src/Image.tsx
@@ -50,6 +50,9 @@ export const imageProps = () => ({
   onError: {
     type: Function as PropType<HTMLImageElement['onerror']>,
   },
+  onLoad: {
+    type: Function as PropType<HTMLImageElement['onload']>,
+  },
 });
 export type ImageProps = Partial<ReturnType<typeof imageProps>>;
 export type ImageStatus = 'normal' | 'error' | 'loading';
@@ -69,7 +72,7 @@ const ImageInternal = defineComponent({
   name: 'VcImage',
   inheritAttrs: false,
   props: imageProps(),
-  emits: ['click', 'error'],
+  emits: ['click', 'error', 'load'],
   setup(props, { attrs, slots, emit }) {
     const prefixCls = computed(() => props.prefixCls);
     const previewPrefixCls = computed(() => `${prefixCls.value}-preview`);
@@ -118,8 +121,9 @@ const ImageInternal = defineComponent({
     } = groupContext;
     const currentId = ref(uuid++);
     const canPreview = computed(() => props.preview && !isError.value);
-    const onLoad = () => {
+    const onLoad = (e: Event) => {
       status.value = 'normal';
+      emit('load', e);
     };
     const onError = (e: Event) => {
       status.value = 'error';
@@ -158,16 +162,6 @@ const ImageInternal = defineComponent({
       }
     };
 
-    const img = ref<HTMLImageElement>(null);
-    watch(
-      () => img,
-      () => {
-        if (status.value !== 'loading') return;
-        if (img.value.complete && (img.value.naturalWidth || img.value.naturalHeight)) {
-          onLoad();
-        }
-      },
-    );
     let unRegister = () => {};
     onMounted(() => {
       watch(
@@ -266,7 +260,6 @@ const ImageInternal = defineComponent({
                     src: fallback,
                   }
                 : { onLoad, onError, src: imgSrc })}
-              ref={img}
             />
 
             {status.value === 'loading' && (

--- a/site/src/components/antdv-token-previewer/ColorPanel.tsx
+++ b/site/src/components/antdv-token-previewer/ColorPanel.tsx
@@ -2,10 +2,11 @@ import type { InputProps } from 'ant-design-vue';
 import { ConfigProvider, Input, InputNumber, Select, theme } from 'ant-design-vue';
 import classNames from 'ant-design-vue/es/_util/classNames';
 import type { PropType } from 'vue';
-import { defineComponent, watchEffect, watch, computed, toRefs, ref } from 'vue';
+import { defineComponent, watchEffect, computed, toRefs, ref } from 'vue';
 import { HexColorPicker, RgbaColorPicker } from '../vue-colorful';
 import tinycolor from 'tinycolor2';
 import makeStyle from './utils/makeStyle';
+import type { ValueType } from 'ant-design-vue/es/input-number/src/utils/MiniDecimal';
 
 const { useToken } = theme;
 
@@ -168,24 +169,42 @@ const RgbColorInput = defineComponent({
   setup(props) {
     const { value, alpha } = toRefs(props);
 
-    watch(value, val => {
-      props.onChange(val);
-    });
-
+    const handleChange = (val: ValueType, key: 'r' | 'g' | 'b' | 'a') => {
+      value.value[key] = val;
+      props.onChange(value.value);
+    };
     return () => {
       return (
         <div class="color-panel-rgba-input">
           <ConfigProvider theme={{ components: { InputNumber: { handleWidth: 12 } } }}>
             <div class="color-panel-rgba-input-part">
-              <InputNumber min={0} max={255} size="small" v-model={[value.value.r, 'value']} />
+              <InputNumber
+                min={0}
+                max={255}
+                size="small"
+                value={value.value.r}
+                onChange={val => handleChange(val, 'r')}
+              />
               <div class="color-panel-mode-title">R</div>
             </div>
             <div class="color-panel-rgba-input-part">
-              <InputNumber min={0} max={255} size="small" v-model={[value.value.g, 'value']} />
+              <InputNumber
+                min={0}
+                max={255}
+                size="small"
+                value={value.value.g}
+                onChange={val => handleChange(val, 'g')}
+              />
               <div class="color-panel-mode-title">G</div>
             </div>
             <div class="color-panel-rgba-input-part">
-              <InputNumber min={0} max={255} size="small" v-model={[value.value.b, 'value']} />
+              <InputNumber
+                min={0}
+                max={255}
+                size="small"
+                value={value.value.b}
+                onChange={val => handleChange(val, 'b')}
+              />
               <div class="color-panel-mode-title">B</div>
             </div>
             {alpha.value && (
@@ -195,7 +214,8 @@ const RgbColorInput = defineComponent({
                   max={1}
                   step={0.01}
                   size="small"
-                  v-model={[value.value.a, 'value']}
+                  value={value.value.a}
+                  onChange={val => handleChange(val, 'a')}
                 />
                 <div class="color-panel-mode-title">A</div>
               </div>


### PR DESCRIPTION
`onLoad` 事件在某些情况下是需要的（目前`4.2.6`版本的 `a-image`的 `@load="onLoad"` 事件是不生效的），比如：
1. 我需要在图片加载成功之后才显示图片，使用 `v-if` 控制，在 `onLoad` 里设置为 true；
2. 给图片组件的父容器加 loading 效果，在 `onLoad` 里设置 loading 为 false。
3. 等等。

移除 `watch` 监听 img 是因为：
1. 目前旧的这种是不生效的：
[ant-design-vue/components/vc-image/src/Image.tsx](https://github.com/vueComponent/ant-design-vue/blob/4a37016f4e3f829838b2e2b3cd128af220d67be8/components/vc-image/src/Image.tsx#L163)
```ts
const img = ref<HTMLImageElement>(null);
watch(
    () => img,
    () => {},
);
```
应该改为：
```
watch(
    () => img.value,
    () => {},
);

// or
watch(img,() => {});
```
2. 可以减少 watch 监听，而且一般情况下使用 `img` 标签的 onLoad 事件基本能满足大部分情况。
如果一定要的话，我会改为下面这种，为了满足 `onLoad` 的 event 参数：
（但是会触发两次 `emit('load', e)` 事件，需要再添加额外判断来实现只触发一次）
```ts
const img = ref<HTMLImageElement>(null);
watch(
  () => img.value,
  () => {
    if (status.value !== "loading") return;
    if (
      img.value.complete &&
      (img.value.naturalWidth || img.value.naturalHeight)
    ) {
      const loadEvent = new Event("load");
      Object.defineProperty(loadEvent, "target", {
        value: img.value,
        enumerable: true,
      });
      onLoad(loadEvent);
    }
  }
);

// or
onMounted(() => {
  nextTick(() => {
    if (status.value !== "loading") return;
    if (
      img.value.complete &&
      (img.value.naturalWidth || img.value.naturalHeight)
    ) {
      const loadEvent = new Event("load");
      Object.defineProperty(loadEvent, "target", {
        value: img.value,
        enumerable: true,
      });
      onLoad(loadEvent);
    }
  });
});
```