### PR TITLE
feat(image): add "load" event 图片组件添加 “load” 事件

### DIFF
--- a/components/image/index.en-US.md
+++ b/components/image/index.en-US.md
@@ -28,9 +28,10 @@ Previewable image.
 
 ### events
 
-| Events Name | Description          | Arguments              | Version |
-| ----------- | -------------------- | ---------------------- | ------- |
-| error       | Load failed callback | (event: Event) => void | 3.2.0   |
+| Events Name | Description              | Arguments              | Version |
+| ----------- | ------------------------ | ---------------------- | ------- |
+| error       | Load failed callback     | (event: Event) => void | 3.2.0   |
+| load        | Load successful callback | (event: Event) => void | 4.3.0   |
 
 ### previewType
 

--- a/components/image/index.zh-CN.md
+++ b/components/image/index.zh-CN.md
@@ -32,6 +32,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*LVQ3R5JjjJEAAA
 | 事件名称 | 说明         | 回调参数               | 版本  |
 | -------- | ------------ | ---------------------- | ----- |
 | error    | 加载错误回调 | (event: Event) => void | 3.2.0 |
+| load     | 加载成功回调 | (event: Event) => void | 4.3.0 |
 
 ### previewType
 

--- a/components/vc-image/src/Image.tsx
+++ b/components/vc-image/src/Image.tsx
@@ -50,6 +50,9 @@ export const imageProps = () => ({
   onError: {
     type: Function as PropType<HTMLImageElement['onerror']>,
   },
+  onLoad: {
+    type: Function as PropType<HTMLImageElement['onload']>,
+  },
 });
 export type ImageProps = Partial<ReturnType<typeof imageProps>>;
 export type ImageStatus = 'normal' | 'error' | 'loading';
@@ -69,7 +72,7 @@ const ImageInternal = defineComponent({
   name: 'VcImage',
   inheritAttrs: false,
   props: imageProps(),
-  emits: ['click', 'error'],
+  emits: ['click', 'error', 'load'],
   setup(props, { attrs, slots, emit }) {
     const prefixCls = computed(() => props.prefixCls);
     const previewPrefixCls = computed(() => `${prefixCls.value}-preview`);
@@ -118,8 +121,9 @@ const ImageInternal = defineComponent({
     } = groupContext;
     const currentId = ref(uuid++);
     const canPreview = computed(() => props.preview && !isError.value);
-    const onLoad = () => {
+    const onLoad = (e: Event) => {
       status.value = 'normal';
+      emit('load', e);
     };
     const onError = (e: Event) => {
       status.value = 'error';
@@ -158,16 +162,6 @@ const ImageInternal = defineComponent({
       }
     };
 
-    const img = ref<HTMLImageElement>(null);
-    watch(
-      () => img,
-      () => {
-        if (status.value !== 'loading') return;
-        if (img.value.complete && (img.value.naturalWidth || img.value.naturalHeight)) {
-          onLoad();
-        }
-      },
-    );
     let unRegister = () => {};
     onMounted(() => {
       watch(
@@ -266,7 +260,6 @@ const ImageInternal = defineComponent({
                     src: fallback,
                   }
                 : { onLoad, onError, src: imgSrc })}
-              ref={img}
             />
 
             {status.value === 'loading' && (


### PR DESCRIPTION
`onLoad` 事件在某些情况下是需要的，比如：
1. 我需要在图片加载成功之后才显示图片，使用 `v-if` 控制，在 `onLoad` 里设置为 true；
2. 给图片组件的父容器加 loading 效果，在 `onLoad` 里设置 loading 为 false。
3. 等等。

（目前`4.2.6`版本的 `a-image`的 `@load="onLoad"` 事件是不生效的）[复现demo](https://codesandbox.io/p/sandbox/zi-ding-yi-yu-lan-tu-pian-ant-design-vue-4-2-6-forked-m2hdl8?file=%2Fsrc%2Fdemo.vue%3A14%2C1&workspaceId=ws_7yN6Xs8WMfHzxrjok7B9RC)

本次修改，移除 `watch` 监听 img 是因为：
1. 目前旧的这种是不生效的：
[ant-design-vue/components/vc-image/src/Image.tsx](https://github.com/vueComponent/ant-design-vue/blob/4a37016f4e3f829838b2e2b3cd128af220d67be8/components/vc-image/src/Image.tsx#L163)
```ts
const img = ref<HTMLImageElement>(null);
watch(
    () => img,
    () => {},
);
```
应该改为：
```
watch(
    () => img.value,
    () => {},
);

// or
watch(img,() => {});
```
2. 可以减少 watch 监听，而且一般情况下使用 `img` 标签的 onLoad 事件基本能满足大部分情况。
如果一定要的话，我会改为下面这种，为了满足 `onLoad` 的 event 参数：
（但是会触发两次 `emit('load', e)` 事件，需要再添加额外判断来实现只触发一次）
```ts
const img = ref<HTMLImageElement>(null);
watch(
  () => img.value,
  () => {
    if (status.value !== "loading") return;
    if (
      img.value.complete &&
      (img.value.naturalWidth || img.value.naturalHeight)
    ) {
      const loadEvent = new Event("load");
      Object.defineProperty(loadEvent, "target", {
        value: img.value,
        enumerable: true,
      });
      onLoad(loadEvent);
    }
  }
);

// or
onMounted(() => {
  nextTick(() => {
    if (status.value !== "loading") return;
    if (
      img.value.complete &&
      (img.value.naturalWidth || img.value.naturalHeight)
    ) {
      const loadEvent = new Event("load");
      Object.defineProperty(loadEvent, "target", {
        value: img.value,
        enumerable: true,
      });
      onLoad(loadEvent);
    }
  });
});
```