### PR TITLE
docs: update the description information of the range picker api

### DIFF
--- a/components/date-picker/index.zh-CN.md
+++ b/components/date-picker/index.zh-CN.md
@@ -188,8 +188,8 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*3OpRQKcygo8AAA
 
 | 事件名称 | 说明 | 回调参数 |
 | --- | --- | --- |
-| calendarChange | 待选日期发生变化的回调 | function(dates: \[dayjs, dayjs] \| \[string, string], dateStrings: \[string, string], info: { range:`start`\|`end` }) |
-| change | 日期范围发生变化的回调 | function(dates: \[dayjs, dayjs] \| \[string, string], dateStrings: \[string, string]) |
+| calendarChange | 待选日期发生变化的回调 | function(dates: \[dayjs, dayjs] \| \[string, string] \| null, dateStrings: \[string, string], info: { range:`start`\|`end` }) |
+| change | 日期范围发生变化的回调 | function(dates: \[dayjs, dayjs] \| \[string, string] \| null, dateStrings: \[string, string]) |
 | ok | 点击确定按钮的回调 | function(dates: \[dayjs, dayjs] \| \[string, string]) |
 
 #### formatType


### PR DESCRIPTION
When the event is a change or a calendarChange, clear the input, dates may be null, but in the official documentation, its type definition is [dayjs, dayjs] | [string, string], The correct one should be [dayjs, dayjs] | [string, string] | null.
Mini demo: https://codesandbox.io/p/sandbox/lively-violet-gmltsk