### PR TITLE
🐞 fix: tabs Centered 居中显示时显示出现bug(同步antd代码)

### DIFF
--- a/components/tabs/style/index.ts
+++ b/components/tabs/style/index.ts
@@ -858,8 +858,8 @@ const genTabsStyle: GenerateStyle<TabsToken> = (token: TabsToken): CSSObject => 
     [`${componentCls}-centered`]: {
       [`> ${componentCls}-nav, > div > ${componentCls}-nav`]: {
         [`${componentCls}-nav-wrap`]: {
-          [`&:not([class*='${componentCls}-nav-wrap-ping'])`]: {
-            justifyContent: 'center',
+          [`&:not([class*='${componentCls}-nav-wrap-ping']) > ${componentCls}-nav-list`]: {
+            margin: 'auto',
           },
         },
       },


### PR DESCRIPTION
修改前
![修改前](https://github.com/user-attachments/assets/20c5feee-a52e-4d5e-a2fc-eafaa3ef450a)
修改后
![修复后](https://github.com/user-attachments/assets/738058fc-f59e-4b64-b64b-ddc3d0cdc485)
