### PR TITLE
chore: add ant-design-x-vue link at ecosystem

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -73,6 +73,7 @@ $ yarn add ant-design-vue
 | [vue-dash-event](https://github.com/vueComponent/vue-dash-event) | 在 DOM 模板中，您可以使用 ant-design-vue 组件的自定义事件（camelCase） |
 | [@formily/antdv](https://github.com/formilyjs/antdv) | 这是一个结合了 Formily 和 ant-design-vue 的组件库 |
 | [@ant-design-vue/nuxt](https://github.com/vueComponent/ant-design-vue-nuxt) | ant-design-vue 的 nuxt 模块扩展 |
+| [ant-design-x-vue](https://github.com/wzc520pyfm/ant-design-x-vue) | 基于 Ant Design X 设计规范的 Vue AI 界面解决方案 |
 
 ## 问答
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ If you are in a bad network environment, you can try other registries and tools 
 | [vue-dash-event](https://github.com/vueComponent/vue-dash-event) | The library function, implemented in the DOM template, can use the custom event of the ant-design-vue component (camelCase) |
 | [@formily/antdv](https://github.com/formilyjs/antdv) | The Library with Formily and ant-design-vue |
 | [@ant-design-vue/nuxt](https://github.com/vueComponent/ant-design-vue-nuxt) | A nuxt module for ant-design-vue |
+| [ant-design-x-vue](https://github.com/wzc520pyfm/ant-design-x-vue) | A Vue AI interface solutions base on the Ant Design X design specification |
 
 ## Donation
 


### PR DESCRIPTION
antd团队推出了专注于ai交互的[Antd Design X](https://github.com/ant-design/x)组件库。
我相应地创建了其Vue版本[Antd Design X Vue](https://github.com/wzc520pyfm/ant-design-x-vue)，功能已同步完成。
期望在Ecosystem添加仓库链接。