### PR TITLE
fix[slider]: prevent triggering blur when focus shifts from slider handle to slider container

### DIFF
--- a/components/vc-slider/src/common/createSlider.tsx
+++ b/components/vc-slider/src/common/createSlider.tsx
@@ -166,6 +166,12 @@ export default function createSlider(Component) {
         }
       },
       onBlur(e) {
+        // Prevent triggering blur when focus shifts from the slider handle to the slider container.
+        // This avoids ending the drag operation if the user clicks within the slider area.
+        if(this.sliderRef === e.relatedTarget) {
+          return;
+        }
+
         if (!this.dragTrack) {
           this.onEnd();
         }


### PR DESCRIPTION
**Changes:**
Modified the onBlur handler in createSlider.js to check if the focus is shifting from the slider handle to the slider container.
If the e.relatedTarget equals the slider container (this.sliderRef), the blur event is prevented from propagating, thereby avoiding an unintended termination of the drag operation.

https://github.com/user-attachments/assets/8868bbee-8075-4281-8077-ffaa01faa48a