### PR TITLE
fix[slider]: prevent text selection while dragging handle

### DIFF
--- a/components/slider/style/index.tsx
+++ b/components/slider/style/index.tsx
@@ -88,6 +88,7 @@ const genBaseStyle: GenerateStyle<SliderToken> = token => {
         width: token.handleSize,
         height: token.handleSize,
         outline: 'none',
+        userSelect: 'none',
 
         [`${componentCls}-dragging`]: {
           zIndex: 1,


### PR DESCRIPTION
**Changes:**
Added 'user-select: none' in slider styles to prevent text selection while dragging the handle (like in React AntD)