### PR TITLE
fix(select): 修复多选模式下key可能为undefined的场景

### DIFF
--- a/components/vc-select/Select.tsx
+++ b/components/vc-select/Select.tsx
@@ -240,6 +240,8 @@ export default defineComponent({
           //     warning(false, '`label` of `value` is not same as `label` in Select options.');
           //   }
           // }
+        } else {
+          rawKey = rawValue;
         }
 
         return {


### PR DESCRIPTION
# 场景
Select组件为多选模式下，options从远程加载时。如果初始值中包含未加载到的option选项，会导致key值为undefined。
OverFlow组件在渲染标签Item时，如果没有key值会使用index作为key，并且当option的value值为number类型，则会导致key值重复并且删除Selected值会出现问题。

# 关联代码
```
 // ================================= Item =================================
  const getKey = (item: any, index: number) => {
    if (typeof props.itemKey === 'function') {
      return props.itemKey(item);
    }
    return (props.itemKey && (item as any)?.[props.itemKey]) ?? index;
  };
```

# 复现场景

![录屏2025-02-14 14 43 25](https://github.com/user-attachments/assets/576735f6-85ea-45b8-884d-7408809b4b27)


https://codesandbox.io/p/sandbox/elastic-river-ng9wcp?file=%2Fsrc%2FApp.vue%3A10%2C31

# 修复后

https://github.com/user-attachments/assets/615a0e13-e967-4a37-9c1f-f1984061451d


