### PR TITLE
fix(segmented): unable to switch again when the switch is rejected

### DIFF
--- a/components/segmented/src/segmented.tsx
+++ b/components/segmented/src/segmented.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, shallowRef, computed } from 'vue';
+import { defineComponent, shallowRef, computed, nextTick } from 'vue';
 import type { ExtractPropTypes, FunctionalComponent } from 'vue';
 import classNames from '../../_util/classNames';
 import useConfigInject from '../../config-provider/hooks/useConfigInject';
@@ -75,6 +75,10 @@ const SegmentedOption: FunctionalComponent<
     }
 
     emit('change', event, value);
+
+    nextTick(() => {
+      (event.target as HTMLInputElement).checked = checked;
+    });
   };
 
   return (


### PR DESCRIPTION
When the switch does not meet some business conditions and is rejected (the value does not change), the input radio is actually marked as checked internally, and clicking the switch again cannot trigger the change event. 
 
Here is an example:
```vue
<template>
  <a-segmented :value="value" :options="data" @change="handleChange" />
</template>

<script lang="ts" setup>
import { reactive, ref } from 'vue';
import { Modal } from 'ant-design-vue';
const data = reactive(['Daily', 'Weekly', 'Monthly', 'Quarterly', 'Yearly']);
const value = ref(data[0]);
const confirm = () => {
  return new Promise(resolve => {
    Modal.confirm({
      title: 'Confirm',
      content: 'Are you sure you want to confirm?',
      onOk: () => {
        resolve(true);
      },
      onCancel: () => {
        resolve(false);
      },
    });
  });
};
const handleChange = v => {
  confirm().then(res => {
    if (res) {
      value.value = v;
    } else {
      console.log('reject');
    }
  });
};
</script>
```