### PR TITLE
fix(webpack.config)，修复build esm文件时会将dayjs打包的问题

### DIFF
--- a/antd-tools/getWebpackConfig.js
+++ b/antd-tools/getWebpackConfig.js
@@ -195,6 +195,13 @@ All rights reserved.
           amd: 'vue',
           module: 'vue',
         },
+        dayjs: {
+          root: 'dayjs',
+          commonjs2: 'dayjs',
+          commonjs: 'dayjs',
+          amd: 'dayjs',
+          module: 'dayjs',
+        },
       },
     ];
     if (esm) {


### PR DESCRIPTION
build后，打包的esm文件中包含dayjs。
会导致引入自己的dayjs，设置中文失败。
将其加入config.externals后，修复此问题