### PR TITLE
fix: #8064 修复 tree checkbox 垂直对齐问题

### DIFF
--- a/components/tree/style/index.ts
+++ b/components/tree/style/index.ts
@@ -65,7 +65,6 @@ type TreeToken = DerivativeToken & {
 export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => {
   const { treeCls, treeNodeCls, treeNodePadding, treeTitleHeight } = token;
 
-  const treeCheckBoxMarginVertical = (treeTitleHeight - token.fontSizeLG) / 2;
   const treeCheckBoxMarginHorizontal = token.paddingXS;
 
   return {
@@ -260,7 +259,6 @@ export const genBaseStyle = (prefixCls: string, token: TreeToken): CSSObject => 
       [`${treeCls}-checkbox`]: {
         top: 'initial',
         marginInlineEnd: treeCheckBoxMarginHorizontal,
-        marginBlockStart: treeCheckBoxMarginVertical,
       },
 
       // >>> Title


### PR DESCRIPTION
- 移除不必要的 checkbox vertical margin，因为 checkbox 样式已将自身设置为 align-self: center;