### PR TITLE
docs(table): ajax 示例文档

### DIFF
--- a/components/table/demo/ajax.vue
+++ b/components/table/demo/ajax.vue
@@ -79,8 +79,9 @@ type APIResult = {
   }[];
 };
 
-const queryData = (params: APIParams) => {
-  return axios.get<APIResult>('https://randomuser.me/api?noinfo', { params });
+const queryData = async (params: APIParams) => {
+  const res = await axios.get<APIResult>('https://randomuser.me/api?noinfo', { params })
+  return res.data.results;
 };
 
 const {
@@ -90,7 +91,6 @@ const {
   current,
   pageSize,
 } = usePagination(queryData, {
-  formatResult: res => res.data.results,
   pagination: {
     currentKey: 'page',
     pageSizeKey: 'results',

--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
     "vue-i18n": "^9.1.7",
     "vue-infinite-scroll": "^2.0.2",
     "vue-loader": "^17.0.0",
-    "vue-request": "^1.0.2",
+    "vue-request": "^2.0.4",
     "vue-router": "^4.0.0",
     "vue-style-loader": "^4.1.2",
     "vue-tsc": "^1.0.6",


### PR DESCRIPTION
在vue-request最新版本^2.0.4下,已经不再支持formatResult属性

迁移文档:
https://www.attojs.com/guide/migration.html#%E5%8F%98%E6%9B%B4%E5%88%97%E8%A1%A8