### PR TITLE
fix(float-button): correct border-radius for grouped and standalone buttons

### DIFF
--- a/components/float-button/style/index.ts
+++ b/components/float-button/style/index.ts
@@ -137,19 +137,8 @@ const floatButtonGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = token 
     },
     [`${groupPrefixCls}-square`]: {
       [`${componentCls}-square`]: {
-        borderRadius: 0,
+        borderRadius: borderRadiusLG,
         padding: 0,
-        '&:first-child': {
-          borderStartStartRadius: borderRadiusLG,
-          borderStartEndRadius: borderRadiusLG,
-        },
-        '&:last-child': {
-          borderEndStartRadius: borderRadiusLG,
-          borderEndEndRadius: borderRadiusLG,
-        },
-        '&:not(:last-child)': {
-          borderBottom: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
-        },
         [`${antCls}-badge`]: {
           [`${antCls}-badge-count`]: {
             top: -(floatButtonBodyPadding + badgeOffset),
@@ -193,6 +182,18 @@ const floatButtonGroupStyle: GenerateStyle<FloatButtonToken, CSSObject> = token 
       [`${componentCls}-square`]: {
         boxShadow: 'none',
         padding: floatButtonBodyPadding,
+        borderRadius: 0,
+        '&:first-child': {
+          borderStartStartRadius: borderRadiusLG,
+          borderStartEndRadius: borderRadiusLG,
+        },
+        '&:last-child': {
+          borderEndStartRadius: borderRadiusLG,
+          borderEndEndRadius: borderRadiusLG,
+        },
+        '&:not(:last-child)': {
+          borderBottom: `${token.lineWidth}px ${token.lineType} ${token.colorSplit}`,
+        },
         [`${componentCls}-body`]: {
           width: token.floatButtonBodySize,
           height: token.floatButtonBodySize,


### PR DESCRIPTION
Fixes [#8117](https://github.com/vueComponent/ant-design-vue/issues/8117)

This PR fixes incorrect `border-radius` in the _FloatButton_ component.

Previously, standalone buttons with `shape="square"` were affected by `:last-child` logic, which caused layout issues.
This logic (`:first-child`, `:last-child`, separators) is now applied only to grouped buttons inside `.ant-float-btn-shadow`.

Now it works as expected.

![float-button](https://github.com/user-attachments/assets/3b52ec8b-2dfb-4b03-bbde-39890363ecfc)
