### PR TITLE
feat(style): 添加 layer 属性以避免全局样式冲突

### DIFF
--- a/components/_util/cssinjs/StyleContext.tsx
+++ b/components/_util/cssinjs/StyleContext.tsx
@@ -82,6 +82,8 @@ export interface StyleContextProps {
    * Please note that `linters` do not support dynamic update.
    */
   linters?: Linter[];
+  /** Wrap css in a layer to avoid global style conflict */
+  layer?: boolean;
 }
 
 const StyleContextKey: InjectionKey<ShallowRef<Partial<StyleContextProps>>> =
@@ -174,6 +176,8 @@ export const styleProviderProps = () => ({
    * Please note that `linters` do not support dynamic update.
    */
   linters: arrayType<Linter[]>(),
+  /** Wrap css in a layer to avoid global style conflict */
+  layer: booleanType(),
 });
 export type StyleProviderProps = Partial<ExtractPropTypes<ReturnType<typeof styleProviderProps>>>;
 export const StyleProvider = withInstall(

--- a/components/config-provider/style/index.ts
+++ b/components/config-provider/style/index.ts
@@ -12,6 +12,7 @@ const useStyle = (iconPrefixCls: Ref<string>) => {
       token: token.value,
       hashId: '',
       path: ['ant-design-icons', iconPrefixCls.value],
+      layer: { name: 'antd' },
     })),
     () => [
       {

--- a/components/theme/util/genComponentStyleHook.ts
+++ b/components/theme/util/genComponentStyleHook.ts
@@ -55,6 +55,7 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
         token: token.value,
         hashId: hashId.value,
         path: ['Shared', rootPrefixCls.value],
+        layer: { name: 'antd' },
       };
     });
     // Generate style for all a tags in antd component.
@@ -70,6 +71,7 @@ export default function genComponentStyleHook<ComponentName extends OverrideComp
         token: token.value,
         hashId: hashId.value,
         path: [component, prefixCls.value, iconPrefixCls.value],
+        layer: { name: 'antd' },
       };
     });
     return [


### PR DESCRIPTION
在 StyleContextProps 和相关函数中引入 layer 属性，支持样式分层。

================================

TailwindCSS 4 开始已经使用 [CSS 分层](https://developer.mozilla.org/zh-CN/docs/Web/CSS/@layer) 来处理样式覆盖，但是 antdv 没有支持样式分层，动态创建出来的样式放置在默认匿名层。
按照规范默认匿名层具有最高优先级，这样就会造成无法使用 tailwindcss 的 class 覆盖 antdv 样式的问题（比如在button上设置  [text-xl 规则](https://tailwindcss.com/docs/font-size)）

================================

这个功能在 Ant-Design 中已经有了，[具体可以看这里](https://ant.design/docs/react/compatible-style-cn#layer-%E6%A0%B7%E5%BC%8F%E4%BC%98%E5%85%88%E7%BA%A7%E9%99%8D%E6%9D%83)。只是简单搬运过来