### PR TITLE
fix: add visibility:hidden to selector:after

### DIFF
--- a/components/select/style/multiple.less
+++ b/components/select/style/multiple.less
@@ -54,6 +54,7 @@
         width: 0;
         margin: @select-multiple-item-spacing-half 0;
         line-height: @select-multiple-item-height;
+        visibility: hidden;
         content: '\a0';
       }
     }


### PR DESCRIPTION
在某些情况下，Select会显示字母A；给-selector:after加上了visibility:hidden;样式
如下所示：
.ant-select-multiple .ant-select-selector:after {
    content: "Â ";
    display: inline-block;
    line-height: 24px;
    margin: 2px 0;
    width: 0
}