### PR TITLE
fix(slider): fix incorrect placement of dot

### DIFF
--- a/components/vc-slider/src/common/Steps.tsx
+++ b/components/vc-slider/src/common/Steps.tsx
@@ -53,8 +53,8 @@ const Steps = (_: any, { attrs }) => {
       (!included && point === upperBound) ||
       (included && point <= upperBound && point >= lowerBound);
     let style = vertical
-      ? { ...dotStyle, [reverse ? 'top' : 'bottom']: offset }
-      : { ...dotStyle, [reverse ? 'right' : 'left']: offset };
+      ? { ...dotStyle, [reverse ? 'top' : 'bottom']: offset, transform: 'translateY(50%)' }
+      : { ...dotStyle, [reverse ? 'right' : 'left']: offset, transform: 'translateX(-50%)' };
     if (isActived) {
       style = { ...style, ...activeDotStyle };
     }


### PR DESCRIPTION
Before:

https://antdv.com/components/slider-cn/#components-slider-demo-mark
https://antdv.com/components/slider-cn/#components-slider-demo-vertical

<img width="150" alt="image" src="https://github.com/user-attachments/assets/2859e2de-1b42-437b-ab09-ab2debc0c0ad" />
<img width="123" alt="image" src="https://github.com/user-attachments/assets/7e064cf2-e037-464a-ad6e-0b7c0ab6bbd9" />

After:

<img width="145" alt="image" src="https://github.com/user-attachments/assets/cd2dc5f6-e3a4-4ee7-8a34-c36b1013d3a3" />
<img width="103" alt="image" src="https://github.com/user-attachments/assets/e32650cf-d8a2-4f5d-83aa-1603e1011954" />
