### PR TITLE
fix(slider): fix incorrect placement of dots and marker text

### DIFF
--- a/components/vc-slider/src/common/Marks.tsx
+++ b/components/vc-slider/src/common/Marks.tsx
@@ -40,7 +40,8 @@ const Marks = (_: any, { attrs, slots }: any) => {
       });
 
       const bottomStyle = {
-        marginBottom: '-50%',
+        transform: `translateY(${reverse ? `-50%` : `50%`})`,
+        msTransform: `translateY(${reverse ? `-50%` : `50%`})`,
         [reverse ? 'top' : 'bottom']: `${((point - min) / range) * 100}%`,
       };
 

--- a/components/vc-slider/src/common/Steps.tsx
+++ b/components/vc-slider/src/common/Steps.tsx
@@ -53,8 +53,18 @@ const Steps = (_: any, { attrs }) => {
       (!included && point === upperBound) ||
       (included && point <= upperBound && point >= lowerBound);
     let style = vertical
-      ? { ...dotStyle, [reverse ? 'top' : 'bottom']: offset }
-      : { ...dotStyle, [reverse ? 'right' : 'left']: offset };
+      ? {
+          ...dotStyle,
+          [reverse ? 'top' : 'bottom']: offset,
+          transform: `translateY(${reverse ? '-50%' : '50%'})`,
+          msTransform: `translateY(${reverse ? '-50%' : '50%'})`,
+        }
+      : {
+          ...dotStyle,
+          [reverse ? 'right' : 'left']: offset,
+          transform: `translateX(${reverse ? '50%' : '-50%'})`,
+          msTransform: `translateX(${reverse ? '50%' : '-50%'})`,
+        };
     if (isActived) {
       style = { ...style, ...activeDotStyle };
     }


### PR DESCRIPTION
Before:

<img width="171" alt="image" src="https://github.com/user-attachments/assets/ac620ace-21f7-4016-9ae2-e46ea914cd1d" />
<img width="212" alt="image" src="https://github.com/user-attachments/assets/fcc9ae96-d9b4-4006-838e-004d88f7d0d1" />

After:

<img width="127" alt="image" src="https://github.com/user-attachments/assets/6ad2c7f5-8b24-45bf-900b-75c90dd52019" />
<img width="169" alt="image" src="https://github.com/user-attachments/assets/1e14fa62-4e57-4c84-b544-d69d6ef760f0" />

本来打算调整一下竖排文字的间距，但实在没找到对应的代码位置。

<img width="1295" alt="image" src="https://github.com/user-attachments/assets/30fc7a00-adb3-4681-a9d4-fb4d3dfccd60" />

<img width="1541" alt="image" src="https://github.com/user-attachments/assets/fcdd5565-1408-4caa-8557-a22a2c6fc3c6" />

只找到这一处给 mark 设置 `insetInlineStart` 的，根据 antd 的样式，把 10px 改成 17px 即可。