### PR TITLE
feat: export configContentInject and formatToken

### DIFF
--- a/components/config-provider/index.tsx
+++ b/components/config-provider/index.tsx
@@ -290,6 +290,7 @@ const ConfigProvider = defineComponent({
 });
 
 ConfigProvider.config = setGlobalConfig;
+ConfigProvider.useConfigContextInject = useConfigContextInject;
 
 ConfigProvider.install = function (app: App) {
   app.component(ConfigProvider.name, ConfigProvider);
@@ -298,4 +299,5 @@ ConfigProvider.install = function (app: App) {
 export default ConfigProvider as typeof ConfigProvider &
   Plugin & {
     readonly config: typeof setGlobalConfig;
+    readonly useConfigContextInject: typeof useConfigContextInject;
   };

--- a/components/theme/index.ts
+++ b/components/theme/index.ts
@@ -4,6 +4,7 @@ import type { GlobalToken } from './interface';
 import defaultAlgorithm from './themes/default';
 import darkAlgorithm from './themes/dark';
 import compactAlgorithm from './themes/compact';
+import formatToken from './util/alias';
 
 // ZombieJ: We export as object to user but array in internal.
 // This is used to minimize the bundle size for antd package but safe to refactor as object also.
@@ -25,6 +26,7 @@ export default {
   defaultSeed: defaultConfig.token,
 
   useToken,
+  formatToken,
   defaultAlgorithm,
   darkAlgorithm,
   compactAlgorithm,


### PR DESCRIPTION
我在基于antdv封装上层组件时，遇到如下两个问题：

1. 我无法获取到useConfigContextInject，除非使用esm导入：

```ts 
import { useConfigContextInject } from 'ant-design-vue/es/config-provider/context';
const { getPrefixCls, direction, csp, iconPrefixCls, theme } = useConfigContextInject();
```

他在esm下工作良好，但当打包umd使用cdn导入时，全局变量antd并没有暴露useConfigContextInject，我未寻找到其他获取useConfigContextInject的方式，因此希望可以antdv可以对外暴露useConfigContextInject。我尝试的暴露方式是通过ConfigProvider组件：

```tsx
const { getPrefixCls, direction, csp, iconPrefixCls, theme } = ConfigProvider.useConfigContextInject();
```

该api暴露方式和antd基本一致：
<img width="907" alt="image" src="https://github.com/user-attachments/assets/912c3108-66a7-46fc-beeb-71cf3464f86a" />

2. 当在外部基于Derivative (designer) Token 生成 Alias (developer) Token时，需要借助antdv内部的formatToken方法，此方法涉及内容较多，大量拷贝至外部应该不是很好的方式，它同样可以在esm下导入，但umd下需要antdv对外暴露：

```tsx
import formatToken from 'ant-design-vue/es/theme/util/alias';
```

formatToken应该可以作为theme的工具方法，和useToken一起暴露给外部
(components/theme/index.ts)：

```diff
import formatToken from './util/alias';

export default {
  useToken,
+  formatToken,
  defaultAlgorithm,
  darkAlgorithm,
  compactAlgorithm,
};
```
Use:
```tsx
import { theme } from 'ant-design-vue';
const AliasToken = theme.formatToken(DerivativeToken);
```
