### PR TITLE
fix(tooltip): when arrowPointAtCenter is true,the arrow not in center

### DIFF
--- a/components/_util/placements.ts
+++ b/components/_util/placements.ts
@@ -94,11 +94,18 @@ export default function getPlacements(config: PlacementsConfig) {
     },
   };
   Object.keys(placementMap).forEach(key => {
+    const centerIndex = key.search(/[A-Z]/);
+    let pointsKey: Direction = key;
+    if (centerIndex > 0) {
+      pointsKey = key.substring(0, centerIndex);
+    }
     placementMap[key] = arrowPointAtCenter
       ? {
           ...placementMap[key],
           overflow: getOverflowOptions(autoAdjustOverflow),
+          points: placementMap[pointsKey].points,
           targetOffset,
+          offset: targetOffset,
         }
       : {
           ...placements[key],


### PR DESCRIPTION
Prop `arrowPointAtCenter`(or `arrow='{pointAtCenter:true}'`) not show arrow at center.

demo: https://antdv.com/components/tooltip#components-tooltip-demo-arrow
