### PR TITLE
fix: Select组件用tagRender插槽渲染，点击该部分不会打开下拉列表 #8132

### DIFF
--- a/components/vc-select/Selector/MultipleSelector.tsx
+++ b/components/vc-select/Selector/MultipleSelector.tsx
@@ -151,7 +151,7 @@ const SelectSelector = defineComponent<SelectorProps>({
     ) {
       const onMouseDown = (e: MouseEvent) => {
         onPreventMouseDown(e);
-        props.onToggleOpen(!open);
+        props.onToggleOpen(!props.open);
       };
       let originData = option;
       // For TreeSelect


### PR DESCRIPTION
官方文档即可复现， 复现 gif 如下

![2025-06-18 18 45 11](https://github.com/user-attachments/assets/1b9feb91-e758-4cfc-94ed-daccbf65da2d)

修复之后的效果如下

![2025-06-18 18 47 06](https://github.com/user-attachments/assets/bc8b2a8e-7d77-4b54-a739-bb39564a26f5)
