### PR TITLE
docs: 文档锚点点击晃动问题

### DIFF
--- a/site/src/theme/static/common.less
+++ b/site/src/theme/static/common.less
@@ -2,7 +2,6 @@ html {
   &.rtl {
     direction: rtl;
   }
-  scroll-behavior: smooth;
 }
 
 body {


### PR DESCRIPTION
解决文档当中Anchor 锚点点击后在页面滚动过程中会来回晃动