### PR TITLE
fix(slider): fix slider last dot can’t click

### DIFF
--- a/components/slider/style/index.tsx
+++ b/components/slider/style/index.tsx
@@ -182,6 +182,7 @@ const genBaseStyle: GenerateStyle<SliderToken> = token => {
         borderRadius: '50%',
         cursor: 'pointer',
         transition: `border-color ${token.motionDurationSlow}`,
+        pointerEvents: 'auto',
 
         '&-active': {
           borderColor: token.colorPrimaryBorder,


### PR DESCRIPTION
### 这个变动的性质是
- 组件样式改进

### 需求背景
slider组件使用marks时最后一个dot无法点击
![20250626-112115](https://github.com/user-attachments/assets/cb02d64e-a218-4902-b095-e5863a964ade)
