### PR TITLE
fix(select): select component not taking keys according to the corresponding value when passing fieldNames

### DIFF
--- a/components/vc-select/utils/valueUtil.ts
+++ b/components/vc-select/utils/valueUtil.ts
@@ -2,11 +2,13 @@ import type { BaseOptionType, DefaultOptionType, RawValueType, FieldNames } from
 import { warning } from '../../vc-util/warning';
 import type { FlattenOptionData } from '../interface';
 
-function getKey(data: BaseOptionType, index: number) {
+function getKey(data: BaseOptionType, index: number, fieldNames?: FieldNames) {
   const { key } = data;
   let value: RawValueType;
 
-  if ('value' in data) {
+  if (fieldNames && fieldNames.value && data[fieldNames.value] !== undefined) {
+    ({ [fieldNames.value]: value } = data);
+  } else if ('value' in data) {
     ({ value } = data);
   }
 
@@ -54,7 +56,7 @@ export function flattenOptions<OptionType extends BaseOptionType = DefaultOption
         const value = data[fieldValue];
         // Option
         flattenList.push({
-          key: getKey(data, flattenList.length),
+          key: getKey(data, flattenList.length, fieldNames),
           groupOption: isGroupOption,
           data,
           label,
@@ -67,7 +69,7 @@ export function flattenOptions<OptionType extends BaseOptionType = DefaultOption
         }
         // Option Group
         flattenList.push({
-          key: getKey(data, flattenList.length),
+          key: getKey(data, flattenList.length, fieldNames),
           group: true,
           data,
           label: grpLabel,


### PR DESCRIPTION
When clicking on the dropdown menu to select and scroll.

Select1 is incorrect because the key was not generated based on the value in fieldNames,And the keys in the options object array hit duplicate value values. while Select2 is correct because the value itself generates the key as a unique value.
```
<template>
  Select1: An error occurred when clicking on the dropdown menu, selecting and scrolling
  <a-select
    style="width: 200px"
    v-model:value="state.id1"
    :fieldNames="{ label: 'value', value: 'code' }"
    :options="arr1"
  />
  Select2: correct
  <a-select
    style="width: 200px"
    v-model:value="state.id2"
    :options="arr2"
  />
</template>
<script setup lang="ts">
import { ref } from "vue";

const state = ref({
  id1: "",
  id2: "",
});

// Hit value with duplicate values
const arr1 = generateObjectsWithRepeat(['code', 'value'], 40, 'value', 'X', 10);

const arr2 = generateObjectsWithRepeat(['value', 'label'], 40, 'label', 'X', 10);

function generateObjectsWithRepeat(keys, count, repeatKey, repeatValue, repeatTimes) {
  const arr = [];
  for (let i = 0; i < count; i++) {
    const obj = {};
    keys.forEach((key, idx) => {
      obj[key] = `${key}_${i+1}`;
    });
    arr.push(obj);
  }
  let inserted = 0;
  while (inserted < repeatTimes) {
    const idx = Math.floor(Math.random() * count);
    if (arr[idx][repeatKey] !== repeatValue) {
      arr[idx][repeatKey] = repeatValue;
      inserted++;
    }
  }
  return arr;
}
</script>
```