### PR TITLE
fix(vcSelect):Maintain keyboard events when using a custom element.

### DIFF
--- a/components/vc-select/BaseSelect.tsx
+++ b/components/vc-select/BaseSelect.tsx
@@ -840,6 +840,7 @@ export default defineComponent({
                     customizeRawInputElement,
                     {
                       ref: selectorDomRef,
+                      tabindex: 0,
                     },
                     false,
                     true,
@@ -877,7 +878,11 @@ export default defineComponent({
 
       // Render raw
       if (customizeRawInputElement) {
-        renderNode = selectorNode;
+        renderNode = (
+          <div onKeydown={onInternalKeyDown} onKeyup={onInternalKeyUp}>
+            {selectorNode}
+          </div>
+        );
       } else {
         renderNode = (
           <div


### PR DESCRIPTION
This can still keep the mouse up and down when customizing the element. There are bugs in 'ant-vue-x', please review the merge