### PR TITLE
fix(Input): hide default browser search cancel button when allowClear…

### DIFF
--- a/components/input/style/index.ts
+++ b/components/input/style/index.ts
@@ -200,6 +200,16 @@ export const genBasicInputStyle = (token: InputToken): CSSObject => ({
   '&-textarea-rtl': {
     direction: 'rtl',
   },
+
+  // Hide default browser search clear button
+  '&[type="search"]::-webkit-search-cancel-button': {
+    display: 'none',
+  },
+  '&[type="search"]::-ms-clear': {
+    display: 'none',
+    width: 0,
+    height: 0,
+  },
 });
 
 export const genInputGroupStyle = (token: InputToken): CSSObject => {


### PR DESCRIPTION
主要优化：
- 在 Input 组件type 为 search 时，隐藏浏览器默认的 search cancel 按钮,避免在使用allowClear会出现两个清除按钮。