### PR TITLE
feat: allow range picker switch with doubleClick

### DIFF
--- a/components/vc-picker/PanelContext.tsx
+++ b/components/vc-picker/PanelContext.tsx
@@ -23,6 +23,9 @@ export type PanelContextProps = {
 
   /** Only used for TimePicker and this is a deprecated prop */
   defaultOpenValue?: Ref<any>;
+
+  /** Double click state for RangePicker */
+  isDoubleClickRef?: Ref<boolean>;
 };
 
 const PanelContextKey: InjectionKey<PanelContextProps> = Symbol('PanelContextProps');

--- a/components/vc-picker/panels/PanelBody.tsx
+++ b/components/vc-picker/panels/PanelBody.tsx
@@ -49,7 +49,7 @@ function PanelBody<DateType>(_props: PanelBodyProps<DateType>) {
     titleCell,
     headerCells,
   } = useMergeProps(_props);
-  const { onDateMouseenter, onDateMouseleave, mode } = useInjectPanel();
+  const { onDateMouseenter, onDateMouseleave, mode, isDoubleClickRef } = useInjectPanel();
 
   const cellPrefixCls = `${prefixCls}-cell`;
 
@@ -96,6 +96,14 @@ function PanelBody<DateType>(_props: PanelBodyProps<DateType>) {
           onClick={e => {
             e.stopPropagation();
             if (!disabled) {
+              onSelect(currentDate);
+            }
+          }}
+          onDblclick={e => {
+            e.stopPropagation();
+            if (!disabled && isDoubleClickRef) {
+              // 设置双击状态
+              isDoubleClickRef.value = true;
               onSelect(currentDate);
             }
           }}


### PR DESCRIPTION
Make the rangepicker of datepicker consistent with the react version of antd, allowing double-clicking to select a date and switch to the next one when showing time

允许 datepicker 的RangePicker在 showtime 下和 antd 表现一致，允许双击选择并切换至下一个日期（十分秒将使用默认值）