### PR TITLE
fix(upload): add "null" to the TypeScript type of "capture"

### DIFF
--- a/components/upload/interface.tsx
+++ b/components/upload/interface.tsx
@@ -96,7 +96,7 @@ type BeforeUploadValueType = void | boolean | string | Blob | FileType;
 
 function uploadProps<T = any>() {
   return {
-    capture: someType<boolean | 'user' | 'environment'>([Boolean, String]),
+    capture: someType<boolean | 'user' | 'environment' | null>([Boolean, String]),
     type: stringType<UploadType>(),
     name: String,
     defaultFileList: arrayType<Array<UploadFile<T>>>(),

--- a/components/vc-upload/interface.tsx
+++ b/components/vc-upload/interface.tsx
@@ -6,7 +6,7 @@ export type Action = string | ((file: RcFile) => string | PromiseLike<string>);
 
 export const uploadProps = () => {
   return {
-    capture: [Boolean, String] as PropType<boolean | 'user' | 'environment'>,
+    capture: [Boolean, String] as PropType<boolean | 'user' | 'environment' | null>,
     multipart: { type: Boolean, default: undefined },
     name: String,
     disabled: { type: Boolean, default: undefined },


### PR DESCRIPTION
文档描述为
<img width="278" height="66" alt="image" src="https://github.com/user-attachments/assets/92dc1954-d7ba-4c68-91c7-e00f4414e1b7" />

但设置`:capture="null"`  ts会飘红报错
<img width="769" height="314" alt="image" src="https://github.com/user-attachments/assets/e7cee837-a6ed-45d0-abc1-67eca01adc8e" />


建议修改capture的ts类型，增加`null`
```
capture: someType<boolean | 'user' | 'environment' | null>([Boolean, String]),
capture: [Boolean, String] as PropType<boolean | 'user' | 'environment' | null>,
```
或者改文档描述为 
```
You can set `:capture="undefined"`
你可以设置 `:capture="undefined"`
```
看代码`{...(capture != null ? { capture } : {})}`是用`!=`比较的，所以传`undefined`也可以

且这一描述一开始应该是针对这个[issue5986](https://github.com/vueComponent/ant-design-vue/issues/5986)加的吧
