### PR TITLE
refactor: improve cleanup of loading timer in button component

### DIFF
--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -69,7 +69,7 @@ export default defineComponent({
     watch(
       loadingOrDelay,
       val => {
-        clearTimeout(delayTimeoutRef.value);
+        cleanupTimer()
         if (typeof loadingOrDelay.value === 'number') {
           delayTimeoutRef.value = setTimeout(() => {
             innerLoading.value = val;
@@ -149,6 +149,13 @@ export default defineComponent({
       return child;
     };
 
+    const cleanupTimer = () => {
+      if (delayTimeoutRef.value) {
+        clearTimeout(delayTimeoutRef.value);
+        delayTimeoutRef.value = undefined;
+      }
+    }
+
     watchEffect(() => {
       devWarning(
         !(props.ghost && isUnBorderedButtonType(props.type)),
@@ -160,9 +167,7 @@ export default defineComponent({
     onMounted(fixTwoCNChar);
     onUpdated(fixTwoCNChar);
 
-    onBeforeUnmount(() => {
-      delayTimeoutRef.value && clearTimeout(delayTimeoutRef.value);
-    });
+    onBeforeUnmount(cleanupTimer);
 
     const focus = () => {
       buttonNodeRef.value?.focus();


### PR DESCRIPTION
Fixed performance issue with rendering a big number of buttons (e.g. in table cells). clearTimeout is slow operation which takes a lot of time if we call it hundreds of time