### PR TITLE
fix: FormExpose ts type error

### DIFF
--- a/components/form/Form.tsx
+++ b/components/form/Form.tsx
@@ -77,8 +77,8 @@ export const formProps = () => ({
 export type FormProps = Partial<ExtractPropTypes<ReturnType<typeof formProps>>>;
 
 export type FormExpose = {
-  resetFields: (name?: NamePath) => void;
-  clearValidate: (name?: NamePath) => void;
+  resetFields: (nameList?: NamePath[]) => void;
+  clearValidate: (nameList?: NamePath[]) => void;
   validateFields: (
     nameList?: NamePath[] | string,
     options?: ValidateOptions,


### PR DESCRIPTION
Fixed form methods type:
(name?: NamePath) => (nameList?: NamePath[])
1. clearValidate
2. resetFields

### 这个变动的性质是
- [ ]  新特性提交
- [ ]  日常 bug 修复
- [ ]  站点、文档改进
- [ ]  组件样式改进
- [X]  TypeScript 定义更新
- [ ]  重构
- [ ]  代码风格优化
- [ ]  分支合并
- [ ]  其他改动（是关于什么的改动？）
