### PR TITLE
docs(timeline): sync Chinese and English docs, add default value 'left' for mode prop

### DIFF
--- a/components/timeline/index.zh-CN.md
+++ b/components/timeline/index.zh-CN.md
@@ -31,7 +31,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*yIl9S4hAIBcAAA
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| mode | 通过设置 `mode` 可以改变时间轴和内容的相对位置 | `left` \| `alternate` \| `right` |  |
+| mode | 通过设置 `mode` 可以改变时间轴和内容的相对位置 | `left` \| `alternate` \| `right` | `left` |
 | pending | 指定最后一个幽灵节点是否存在或内容 | boolean\|string\|slot | false |
 | pendingDot | 当最后一个幽灵节点存在時，指定其时间图点 | string\|slot | `<LoadingOutlined />` |
 | reverse | 节点排序 | boolean | false |


### PR DESCRIPTION
## 问题描述
修复 Timeline 组件中英文文档不一致问题：
- 英文文档中 `mode` 属性的默认值为 `left`
- 中文文档中缺少默认值说明，显示为空白

## 修改内容
- 在中文文档的 `mode` 属性描述中添加默认值 `left`
- 保持中英文文档一致性
