### PR TITLE
style(steps): reset top direction title  padding-right

### DIFF
--- a/components/steps/style/vertical.ts
+++ b/components/steps/style/vertical.ts
@@ -27,6 +27,7 @@ const genStepsVerticalStyle: GenerateStyle<StepsToken, CSSObject> = token => {
         },
         [`${componentCls}-item-title`]: {
           lineHeight: `${stepsIconSize}px`,
+          paddingInlineEnd: 0,
         },
         [`${componentCls}-item-description`]: {
           paddingBottom: token.paddingSM,


### PR DESCRIPTION
### 这个变动的性质是
 - [ ] 新特性提交
 - [ ] 日常 bug 修复
 - [ ] 站点、文档改进
 - [x] 组件样式改进
 - [ ] TypeScript 定义更新
 - [ ] 重构
 - [ ] 代码风格优化
 - [ ] 分支合并
 - [ ] 其他改动（是关于什么的改动？）

### 需求背景

<img width="1115" height="543" alt="cfb5c0a0e9e673cbb90f41227569de1b" src="https://github.com/user-attachments/assets/8098128c-1f7e-4a91-a2af-5d66cbe89322" />

在steps设置为垂直模式时，title会有右内边距。

When steps is set to vertical mode, the title will have a right padding.

### Changelog 描述（非新功能可选）

移除垂直模式下title的右内边距。

Remove the right padding of the title in vertical mode.

### 请求合并前的自查清单
- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

无