### PR TITLE
fix(image) image loaded show placeholder

### DIFF
--- a/components/vc-image/src/Image.tsx
+++ b/components/vc-image/src/Image.tsx
@@ -268,8 +268,8 @@ const ImageInternal = defineComponent({
                 : { onLoad, onError, src: imgSrc })}
               ref={img}
             />
-
-            {status.value === 'loading' && (
+            {/* Loading or Error Placeholder */}
+            {(status.value === 'loading' || status.value === 'error') && (
               <div aria-hidden="true" class={`${prefixCls}-placeholder`}>
                 {placeholder || (slots.placeholder && slots.placeholder())}
               </div>


### PR DESCRIPTION
fix this issue https://github.com/vueComponent/ant-design-vue/issues/8189
图片加载成功后placeholder会对透明的png图片显示造成干扰
loading和error状态才显示placeholder normal状态直接显示图片即可