### PR TITLE
Fix modals flickering on multiple modals open

### DIFF
--- a/components/modal/useModal/index.tsx
+++ b/components/modal/useModal/index.tsx
@@ -65,7 +65,7 @@ function useModal(): readonly [
   // =========================== Hook ===========================
   const getConfirmFunc = (withFunc: (config: ModalFuncProps) => ModalFuncProps) =>
     function hookConfirm(config: Ref<ModalFuncProps> | ModalFuncProps) {
-      uuid += 1;
+      const modalId = uuid++;
       const open = shallowRef(true);
       const modalRef = shallowRef<HookModalRef>(null);
       const configRef = shallowRef(unref(config));
@@ -91,7 +91,7 @@ function useModal(): readonly [
       let closeFunc: Function | undefined;
       const modal = () => (
         <HookModal
-          key={`modal-${uuid}`}
+          key={`modal-${modalId}`}
           config={withFunc(configRef.value)}
           ref={modalRef}
           open={open.value}


### PR DESCRIPTION
**Problem**

When multiple modals are opened using `Modal.confirm`, previously opened modals **rerender unexpectedly** due to their VNode keys changing.

The root cause is that all modals share a **global mutable** `uuid` for keys. The render function closes over this mutable variable, so previously created modals can see the updated `uuid`, leading to unstable keys and unnecessary remounts.

Note: Vue’s **useId()** cannot be used here because these modals are created imperatively, outside of component setup, which triggers a Vue warning.