### PR TITLE
Scrollbar should not be shown when table Y-axis does not overflow (scroll → auto)

### DIFF
--- a/components/_util/getScrollBarSize.ts
+++ b/components/_util/getScrollBarSize.ts
@@ -54,9 +54,12 @@ export function getTargetScrollBarSize(target: HTMLElement) {
     return { width: 0, height: 0 };
   }
 
+  const hasVertical = target.scrollHeight > target.clientHeight;
+  const hasHorizontal = target.scrollWidth > target.clientWidth;
+
   const { width, height } = getComputedStyle(target, '::-webkit-scrollbar');
   return {
-    width: ensureSize(width),
-    height: ensureSize(height),
+    width: hasVertical ? ensureSize(width) : 0,
+    height: hasHorizontal ? ensureSize(height) : 0,
   };
 }

--- a/components/vc-table/Table.tsx
+++ b/components/vc-table/Table.tsx
@@ -379,7 +379,7 @@ export default defineComponent({
     watchEffect(() => {
       if (fixHeader.value) {
         scrollYStyle.value = {
-          overflowY: 'scroll',
+          overflowY: 'auto',
           maxHeight: toPx(props.scroll.y),
         };
       }


### PR DESCRIPTION
fix this issue https://github.com/vueComponent/ant-design-vue/issues/8484

### 这个变动的性质是

- [ ]  新特性提交
- [ ]  日常 bug 修复
- [ ]  站点、文档改进
- [x]  组件样式改进
- [ ]  TypeScript 定义更新
- [ ]  重构
- [ ]  代码风格优化
- [ ]  分支合并
- [ ]  其他改动（是关于什么的改动？）

### 需求背景

table组件在设置scroll: { y }后始终显示滚动指示器，即便表格实际高度小于y值

### Changelog 描述（非新功能可选）

> 锚定版本 antd v4.2.6

1. 将table的滚动属性overflowY: scroll修改为overflowY: auto
2. 修改getScrollBarSize工具，使其在未存在滚动条时返回0值，以支持上述属性

### 请求合并前的自查清单

- [x]  文档已补充或无须补充
- [x]  代码演示已提供或无须提供
- [x]  TypeScript 定义已补充或无须补充
- [x]  Changelog 已提供或无须提供
