### PR TITLE
fix(Select): clear input after pasting text with tokenSeparators

### DIFF
--- a/components/vc-select/Selector/MultipleSelector.tsx
+++ b/components/vc-select/Selector/MultipleSelector.tsx
@@ -209,9 +209,14 @@ const SelectSelector = defineComponent<SelectorProps>({
 
     const handleInput = (e: Event) => {
       const composing = (e.target as any).composing;
-      targetValue.value = (e.target as any).value;
       if (!composing) {
+        // Process input first (may split tokenSeparators and clear searchValue)
         props.onInputChange(e);
+        // Sync with reactive inputValue to handle token splitting (searchValue becomes '')
+        targetValue.value = inputValue.value;
+      } else {
+        // During composition, sync directly from DOM
+        targetValue.value = (e.target as any).value;
       }
     };
 


### PR DESCRIPTION
### Problem

When pasting text like `Lucy,Jack` into Select with `mode="tags"` and `tokenSeparators`, 
the text is correctly split into tags, but the original pasted string remains in the input field.

### Steps to reproduce

1. Use `<a-select mode="tags" :token-separators="[',']" />`
2. Paste `Lucy,Jack` into the input
3. Tags are created but `Lucy,Jack` remains visible in input

### Solution

Changed order of operations in `MultipleSelector.handleInput`:
- Process `onInputChange` first (triggers token splitting, clears `searchValue`)
- Then sync `targetValue` with reactive `inputValue` state

### Changes

- `components/vc-select/Selector/MultipleSelector.tsx`