### PR TITLE
feat(cascader): Add dropdownRender Support(#7853)

### DIFF
--- a/components/cascader/demo/dropdownRender.vue
+++ b/components/cascader/demo/dropdownRender.vue
@@ -1,0 +1,79 @@
+<docs>
+---
+order: 11
+title:
+  zh-CN: 扩展菜单
+  en-US: Custom dropdown
+---
+
+## zh-CN
+
+使用 dropdownRender 对下拉菜单进行自由扩展。
+
+## en-US
+
+Customize the dropdown menu via dropdownRender.
+
+</docs>
+<template>
+  <a-cascader v-model:value="value" :options="options" placeholder="Please select">
+    <template #dropdownRender="{ menuNode: menu }">
+      <v-nodes :vnodes="menu" />
+      <a-divider style="margin: 4px 0" />
+      <div style="padding: 8px">The footer is not very short.</div>
+    </template>
+  </a-cascader>
+</template>
+<script lang="ts" setup>
+import { defineComponent, ref } from 'vue';
+import type { CascaderProps } from 'ant-design-vue';
+
+const VNodes = defineComponent({
+  props: {
+    vnodes: {
+      type: Object,
+      required: true,
+    },
+  },
+  render() {
+    return this.vnodes;
+  },
+});
+
+const options: CascaderProps['options'] = [
+  {
+    value: 'zhejiang',
+    label: 'Zhejiang',
+    children: [
+      {
+        value: 'hangzhou',
+        label: 'Hangzhou',
+        children: [
+          {
+            value: 'xihu',
+            label: 'West Lake',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    value: 'jiangsu',
+    label: 'Jiangsu',
+    children: [
+      {
+        value: 'nanjing',
+        label: 'Nanjing',
+        children: [
+          {
+            value: 'zhonghuamen',
+            label: 'Zhong Hua Men',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const value = ref<string[]>([]);
+</script>

--- a/components/cascader/demo/index.vue
+++ b/components/cascader/demo/index.vue
@@ -13,6 +13,7 @@
     <suffix />
     <multipleVue />
     <tagRender />
+    <dropdownRender />
   </demo-sort>
 </template>
 <script>
@@ -29,6 +30,7 @@ import FieldsName from './fields-name.vue';
 import Suffix from './suffix.vue';
 import multipleVue from './multiple.vue';
 import tagRender from './tagRender.vue';
+import dropdownRender from './dropdownRender.vue';
 
 import CN from '../index.zh-CN.md';
 import US from '../index.en-US.md';
@@ -50,6 +52,7 @@ export default defineComponent({
     Suffix,
     multipleVue,
     tagRender,
+    dropdownRender,
   },
 });
 </script>

--- a/components/cascader/index.en-US.md
+++ b/components/cascader/index.en-US.md
@@ -52,6 +52,7 @@ Cascade selection box.
 | suffixIcon | The custom suffix icon | string \| VNode \| slot | - |  |
 | showCheckedStrategy | The way show selected item in box. ** `SHOW_CHILD`: ** just show child treeNode. **`Cascader.SHOW_PARENT`:** just show parent treeNode (when all child treeNode under the parent treeNode are checked) | `Cascader.SHOW_PARENT` \| `Cascader.SHOW_CHILD` | `Cascader.SHOW_PARENT` | 3.3.0 |
 | tagRender | Customize tag render when `multiple` | slot | - | 3.0 |
+| dropdownRender | Customize dropdown content | slot | - | 4.2.7 |
 | value(v-model) | selected value | string\[] \| number\[] | - |  |
 
 ### showSearch

--- a/components/cascader/index.tsx
+++ b/components/cascader/index.tsx
@@ -334,6 +334,7 @@ const Cascader = defineComponent({
             showArrow={formItemInputContext.hasFeedback || props.showArrow}
             onChange={handleChange}
             onBlur={handleBlur}
+            dropdownRender={props.dropdownRender || slots.dropdownRender}
             v-slots={slots}
             ref={selectRef}
           />,

--- a/components/cascader/index.zh-CN.md
+++ b/components/cascader/index.zh-CN.md
@@ -54,6 +54,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*5-ArSLl5UBsAAA
 | size | 输入框大小 | `large` \| `default` \| `small` | `default` |  |
 | suffixIcon | 自定义的选择框后缀图标 | string \| VNode \| slot | - |  |
 | tagRender | 自定义 tag 内容，多选时生效 | slot | - | 3.0 |
+| dropdownRender | 自定义下拉框内容 | slot | - | 4.2.7 |
 | value(v-model) | 指定选中项 | string\[] \| number\[] | - |  |
 
 ### showSearch


### PR DESCRIPTION
首先，感谢你的贡献！ 😄

新特性请提交至 feature 分支，其余可提交至 main 分支。在一个维护者审核通过后合并。请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](./pr_en.md)]

### 这个变动的性质是

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 描述相关需求的来源。
用户希望 Cascader 组件能够支持自定义下拉菜单内容，类似于 Select 组件的 `dropdownRender` 功能，以便在级联选择器的下拉菜单中添加额外的自定义内容（如页脚、按钮等）。
> 2. 要解决的问题。
Cascader 组件目前不支持通过 slot 方式自定义下拉菜单内容，导致用户无法灵活扩展下拉菜单的 UI。而 Select 组件已经支持 `dropdownRender` 功能，Cascader 应该保持一致的 API 设计。
> 3. 相关的 issue 讨论链接。
[#7853](https://github.com/vueComponent/ant-design-vue/issues/7853)
[#8457](https://github.com/vueComponent/ant-design-vue/issues/8457)

### 实现方案和 API（非新功能可选）

> 1. 基本的解决思路和其他可选方案。
**方案**：参考 Cascader 组件的已有的tagRender实现，在 Cascader 组件中同时支持 prop 和 slot 两种方式的 `dropdownRender`。

> 2. 列出最终的 API 实现和用法。
同Select组件一样
```
<Cascader>
  <template #dropdownRender="{ menuNode: menu }">
    <v-nodes :vnodes="menu" />
    <a-divider style="margin: 4px 0" />
    <div style="padding: 8px">自定义内容</div>
  </template>
</Cascader>
```


> 3. 涉及 UI/交互变动需要有截图或 GIF。
新增了 dropdownRender demo，展示了如何在下拉菜单底部添加自定义内容。
<img width="2560" height="1294" alt="image" src="https://github.com/user-attachments/assets/2c3c59e8-96d1-471b-80ca-aa015a2590d3" />


### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
这是一个纯新增功能，不影响现有用户的使用。用户可以自由选择是否使用 dropdownRender。

> 2. 是否有可能隐含的 break change 和其他风险？
无 break change。新增的功能向后兼容，不改变现有 API。

### Changelog 描述（非新功能可选）

> 1. 英文描述
 Cascader: Add dropdownRender slot support for customizing dropdown content.

> 2. 中文描述（可选）
Cascader: 新增 dropdownRender 插槽支持，允许自定义下拉菜单内容。

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。
