### PR TITLE
feat(Tree): draggable property support function type（#8450）

### DIFF
--- a/components/tree/Tree.tsx
+++ b/components/tree/Tree.tsx
@@ -6,7 +6,7 @@ import PropTypes from '../_util/vue-types';
 import { filterEmpty } from '../_util/props-util';
 import initDefaultProps from '../_util/props-util/initDefaultProps';
 import type { DataNode, EventDataNode, FieldNames, Key, ScrollTo } from '../vc-tree/interface';
-import type { TreeNodeProps } from '../vc-tree/props';
+import type { TreeNodeProps, DraggableFn } from '../vc-tree/props';
 import { treeProps as vcTreeProps } from '../vc-tree/props';
 import useConfigInject from '../config-provider/hooks/useConfigInject';
 import type { SwitcherIconProps } from './utils/iconUtil';
@@ -119,7 +119,7 @@ export const treeProps = () => {
     selectable: booleanType(),
 
     loadedKeys: arrayType<Key[]>(),
-    draggable: booleanType(),
+    draggable: someType<boolean | DraggableFn>([Boolean, Function]),
     showIcon: booleanType(),
     icon: functionType<(nodeProps: AntdTreeNodeAttribute) => any>(),
     switcherIcon: PropTypes.any,
@@ -217,12 +217,14 @@ export default defineComponent({
         blockNode,
         checkable,
         selectable,
+        draggable,
         fieldNames = props.replaceFields,
         motion = props.openAnimation,
         itemHeight = 28,
         onDoubleclick,
         onDblclick,
       } = props as TreeProps;
+
       const newProps = {
         ...attrs,
         ...omit(props, [
@@ -233,6 +235,7 @@ export default defineComponent({
         ]),
         showLine: Boolean(showLine),
         dropIndicatorRender,
+        draggable,
         fieldNames,
         icon,
         itemHeight,

--- a/components/tree/index.en-US.md
+++ b/components/tree/index.en-US.md
@@ -26,7 +26,7 @@ Almost anything can be represented in a tree structure. Examples include directo
 | checkStrictly | Check treeNode precisely; parent treeNode and children treeNodes are not associated | boolean | false |  |
 | defaultExpandAll | Whether to expand all treeNodes by default | boolean | false |  |
 | disabled | whether disabled the tree | bool | false |  |
-| draggable | Specifies whether this Tree is draggable (IE > 8) | boolean | false |  |
+| draggable | Specifies whether this Tree is draggable (IE > 8) | boolean \| function(node) | false |  |
 | expandedKeys(v-model) | (Controlled) Specifies the keys of the expanded treeNodes | string\[] \| number\[] | \[] |  |
 | fieldNames | Replace the title,key and children fields in treeNode with the corresponding fields in treeData | object | { children:'children', title:'title', key:'key' } | 3.0.0 |
 | filterTreeNode | Defines a function to filter (highlight) treeNodes. When the function returns `true`, the corresponding treeNode will be highlighted | function(node) | - |  |

--- a/components/tree/index.zh-CN.md
+++ b/components/tree/index.zh-CN.md
@@ -27,7 +27,7 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*1GeUQJPTGUYAAA
 | checkStrictly | checkable 状态下节点选择完全受控（父子节点选中状态不再关联） | boolean | false |  |  |
 | defaultExpandAll | 默认展开所有树节点, 如果是异步数据，需要在数据返回后再实例化，建议用 v-if="data.length"；当有 expandedKeys 时，defaultExpandAll 将失效 | boolean | false |  |  |
 | disabled | 将树禁用 | bool | false |  |  |
-| draggable | 设置节点可拖拽 | boolean | false |  |  |
+| draggable | 设置节点可拖拽（支持函数形式） | boolean \| function(node) | false |  |  |
 | expandedKeys(v-model) | （受控）展开指定的树节点 | string\[] \| number\[] | \[] |  |  |
 | fieldNames | 替换 treeNode 中 title,key,children 字段为 treeData 中对应的字段 | object | {children:'children', title:'title', key:'key' } | 3.0.0 |  |
 | filterTreeNode | 按需筛选树节点（高亮），返回 true | function(node) | - |  |  |


### PR DESCRIPTION
## 🔥 功能说明
为 Tree 组件的 `draggable` 属性添加函数类型支持，可实现基于节点数据的动态拖拽控制。

## ✨ 解决的问题
当前 `draggable` 只支持布尔值，无法根据节点数据动态控制拖拽状态。
Ant Design React 版本已支持此功能，Vue 版本缺失该功能。

## 📝 修改内容
### 1. 类型定义
- ✅ 更新 `draggable` 属性类型：`boolean | DraggableFn`，vc已有 `DraggableFn` 类型：`(node: EventDataNode) => boolean`

### 2. 组件实现
- ✅ 直接传递函数给底层 `vc-tree`
- ✅ 保持向后兼容（布尔值完全支持）

### 3. 文档更新
- ✅ 更新中英文 API 文档

### 4. 测试验证
- [x] 本地功能测试通过
- [x] TypeScript 类型检查通过
- [x] 向后兼容测试通过

## 🎯 使用示例
```vue
<template>
  <a-tree 
    :tree-data="treeData"
    :draggable="checkDraggable"
  />
</template>
<script setup>
const treeData = [
  { key: 'admin', title: '管理员', role: 'admin' },
  { key: 'user', title: '普通用户', role: 'user' },
];

const checkDraggable = (node) => {
  return node.role === 'admin'; // 仅管理员可拖拽
};
</script>