### PR TITLE
docs(input): fix TextArea API table formatting

### DIFF
--- a/components/input/index.zh-CN.md
+++ b/components/input/index.zh-CN.md
@@ -49,11 +49,11 @@ coverDark: https://mdn.alipayobjects.com/huamei_7uahnr/afts/img/A*sBqqTatJ-AkAAA
 ### TextArea
 
 | 参数 | 说明 | 类型 | 默认值 | 版本 |  |
-| --- | --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- | --- |
 | allowClear | 可以点击清除图标删除内容 | boolean |  | 1.5.0 |  |
 | autosize | 自适应内容高度，可设置为 `true | false` 或对象：`{ minRows: 2, maxRows: 6 }` | boolean\|object | false |  |
 | defaultValue | 输入框默认内容 | string |  |  |  |
-_| showCount | 是否展示字数 | boolean \| { formatter: (info: { value: string, count: number, maxLength?: number }) => string } | false |  |  |_
+| showCount | 是否展示字数 | boolean \| { formatter: (info: { value: string, count: number, maxLength?: number }) => string } | false |  |  | \_ |
 | value(v-model) | 输入框内容 | string |  |  |  |
 
 ### TextArea 事件


### PR DESCRIPTION
Remove extra dash causing table column misalignment for showCount property.

<img width="1918" height="560" alt="image" src="https://github.com/user-attachments/assets/3adb9684-ebb3-4e33-a0ba-2d14f2368484" />
