### PR TITLE
fix(divider): restore orientationMargin and plain text compatibility

### DIFF
--- a/packages/ui/src/components/divider/Divider.vue
+++ b/packages/ui/src/components/divider/Divider.vue
@@ -34,8 +34,8 @@ const innerStyle = computed(() => {
       ? `${props.orientationMargin}px`
       : props.orientationMargin
 
-  if (hasCustomMarginLeft.value) return { marginLeft: margin }
-  if (hasCustomMarginRight.value) return { marginRight: margin }
+  if (props.orientation === 'left') return { marginLeft: margin }
+  if (props.orientation === 'right') return { marginRight: margin }
   return undefined
 })
 </script>

--- a/packages/ui/src/components/divider/Divider.vue
+++ b/packages/ui/src/components/divider/Divider.vue
@@ -8,6 +8,12 @@ defineSlots<DividerSlots>()
 const slots = useSlots()
 
 const hasContent = computed(() => !!slots.default)
+const hasCustomMarginLeft = computed(
+  () => hasContent.value && props.orientation === 'left' && props.orientationMargin != null,
+)
+const hasCustomMarginRight = computed(
+  () => hasContent.value && props.orientation === 'right' && props.orientationMargin != null,
+)
 
 const classes = computed(() => ({
   'ant-divider': true,
@@ -16,6 +22,8 @@ const classes = computed(() => ({
   'ant-divider-plain': props.plain,
   'ant-divider-with-text': hasContent.value,
   [`ant-divider-with-text-${props.orientation}`]: hasContent.value,
+  'ant-divider-no-default-orientation-margin-left': hasCustomMarginLeft.value,
+  'ant-divider-no-default-orientation-margin-right': hasCustomMarginRight.value,
 }))
 
 const innerStyle = computed(() => {
@@ -26,8 +34,8 @@ const innerStyle = computed(() => {
       ? `${props.orientationMargin}px`
       : props.orientationMargin
 
-  if (props.orientation === 'left') return { marginLeft: margin }
-  if (props.orientation === 'right') return { marginRight: margin }
+  if (hasCustomMarginLeft.value) return { marginLeft: margin }
+  if (hasCustomMarginRight.value) return { marginRight: margin }
   return undefined
 })
 </script>

--- a/packages/ui/src/components/divider/__tests__/__snapshots__/demo.test.ts.snap
+++ b/packages/ui/src/components/divider/__tests__/__snapshots__/demo.test.ts.snap
@@ -45,9 +45,9 @@ exports[`Divider demos > demo: Horizontal 1`] = `
 exports[`Divider demos > demo: OrientationMargin 1`] = `
 "<div>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-  <div class="ant-divider ant-divider-horizontal ant-divider-with-text ant-divider-with-text-left" role="separator" aria-orientation="horizontal"><span class="ant-divider-inner-text" style="margin-left: 0px;"> Left with 0 margin </span></div>
+  <div class="ant-divider ant-divider-horizontal ant-divider-with-text ant-divider-with-text-left ant-divider-no-default-orientation-margin-left" role="separator" aria-orientation="horizontal"><span class="ant-divider-inner-text" style="margin-left: 0px;"> Left with 0 margin </span></div>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-  <div class="ant-divider ant-divider-horizontal ant-divider-with-text ant-divider-with-text-right" role="separator" aria-orientation="horizontal"><span class="ant-divider-inner-text" style="margin-right: 50px;"> Right with 50px margin </span></div>
+  <div class="ant-divider ant-divider-horizontal ant-divider-with-text ant-divider-with-text-right ant-divider-no-default-orientation-margin-right" role="separator" aria-orientation="horizontal"><span class="ant-divider-inner-text" style="margin-right: 50px;"> Right with 50px margin </span></div>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 </div>"
 `;

--- a/packages/ui/src/components/divider/__tests__/index.test.ts
+++ b/packages/ui/src/components/divider/__tests__/index.test.ts
@@ -64,6 +64,7 @@ describe('Divider', () => {
       props: { orientation: 'left', orientationMargin: '20px' },
       slots: { default: 'Text' },
     })
+    expect(wrapper.classes('ant-divider-no-default-orientation-margin-left')).toBe(true)
     const inner = wrapper.find('.ant-divider-inner-text')
     expect((inner.element as HTMLElement).style.marginLeft).toBe('20px')
   })
@@ -73,6 +74,7 @@ describe('Divider', () => {
       props: { orientation: 'right', orientationMargin: 30 },
       slots: { default: 'Text' },
     })
+    expect(wrapper.classes('ant-divider-no-default-orientation-margin-right')).toBe(true)
     const inner = wrapper.find('.ant-divider-inner-text')
     expect((inner.element as HTMLElement).style.marginRight).toBe('30px')
   })
@@ -83,8 +85,18 @@ describe('Divider', () => {
       slots: { default: 'Text' },
     })
     const inner = wrapper.find('.ant-divider-inner-text')
+    expect(wrapper.classes('ant-divider-no-default-orientation-margin-left')).toBe(false)
+    expect(wrapper.classes('ant-divider-no-default-orientation-margin-right')).toBe(false)
     expect((inner.element as HTMLElement).style.marginLeft).toBe('')
     expect((inner.element as HTMLElement).style.marginRight).toBe('')
+  })
+
+  it('does not apply orientationMargin classes without content', () => {
+    const wrapper = mount(Divider, {
+      props: { orientation: 'left', orientationMargin: '20px' },
+    })
+    expect(wrapper.classes('ant-divider-no-default-orientation-margin-left')).toBe(false)
+    expect(wrapper.classes('ant-divider-no-default-orientation-margin-right')).toBe(false)
   })
 
   it('renders plain text style', () => {

--- a/packages/ui/src/components/divider/style/index.css
+++ b/packages/ui/src/components/divider/style/index.css
@@ -74,6 +74,34 @@
   @apply inline-block px-4 font-medium text-base;
 }
 
+:where(.ant-divider).ant-divider-horizontal.ant-divider-with-text-left.ant-divider-no-default-orientation-margin-left {
+  &::before {
+    width: 0;
+  }
+
+  &::after {
+    width: 100%;
+  }
+
+  .ant-divider-inner-text {
+    padding-left: 0;
+  }
+}
+
+:where(.ant-divider).ant-divider-horizontal.ant-divider-with-text-right.ant-divider-no-default-orientation-margin-right {
+  &::before {
+    width: 100%;
+  }
+
+  &::after {
+    width: 0;
+  }
+
+  .ant-divider-inner-text {
+    padding-right: 0;
+  }
+}
+
 :where(.ant-divider).ant-divider-plain .ant-divider-inner-text {
-  @apply font-normal;
+  @apply text-sm font-normal;
 }


### PR DESCRIPTION
## What was reviewed

Reviewed `packages/ui/src/components/divider` for:

- correctness
- API compatibility
- styling parity
- tests

## Issues found

1. `orientationMargin` on left/right text dividers did not fully preserve previous layout behavior
2. `plain` text dividers kept larger text styling instead of falling back to normal body text styling

## Changes made

- add compatibility classes for left/right `orientationMargin`
- restore pseudo-element width compensation when custom orientation margin is used
- remove the default inner-text padding on the compensated side
- restore plain divider text styling to normal text size and weight
- add unit test coverage for the compatibility classes
- update divider demo snapshots

## Verification

```bash
..\..\node_modules\.bin\vitest.cmd run src/components/divider/__tests__/index.test.ts src/components/divider/__tests__/demo.test.ts -u
```

Result:
- 20 tests passed
- 1 snapshot updated