### PR TITLE
fix(message): restore API compatibility and thenable chaining semantics

### DIFF
--- a/packages/ui/src/components/message/MessageContainer.vue
+++ b/packages/ui/src/components/message/MessageContainer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="ant-message" :style="containerStyle">
+  <div class="ant-message" :class="{ 'ant-message-rtl': rtl }" :style="containerStyle">
     <TransitionGroup name="ant-move-up" tag="div">
       <MessageItem
         v-for="item in messages"
@@ -19,6 +19,7 @@ import type { InternalMessageItem } from './types'
 const props = defineProps<{
   messages: InternalMessageItem[]
   top?: number | string
+  rtl?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -36,4 +37,6 @@ const containerStyle = computed(() => {
 function onClose(id: string) {
   emit('close', id)
 }
+
+const rtl = computed(() => props.rtl === true)
 </script>

--- a/packages/ui/src/components/message/MessageContainer.vue
+++ b/packages/ui/src/components/message/MessageContainer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="ant-message" :class="{ 'ant-message-rtl': rtl }" :style="containerStyle">
+  <div class="ant-message" :class="{ 'ant-message-rtl': rtl }" :style="containerStyle" :dir="rtl ? 'rtl' : undefined">
     <TransitionGroup name="ant-move-up" tag="div">
       <MessageItem
         v-for="item in messages"
@@ -18,8 +18,10 @@ import type { InternalMessageItem } from './types'
 
 const props = defineProps<{
   messages: InternalMessageItem[]
-  top?: number | string
-  rtl?: boolean
+  config: {
+    top?: number | string
+    rtl?: boolean
+  }
 }>()
 
 const emit = defineEmits<{
@@ -28,8 +30,8 @@ const emit = defineEmits<{
 
 const containerStyle = computed(() => {
   const style: Record<string, string> = {}
-  if (props.top != null) {
-    style.top = typeof props.top === 'number' ? `${props.top}px` : props.top
+  if (props.config.top != null) {
+    style.top = typeof props.config.top === 'number' ? `${props.config.top}px` : props.config.top
   }
   return style
 })
@@ -38,5 +40,5 @@ function onClose(id: string) {
   emit('close', id)
 }
 
-const rtl = computed(() => props.rtl === true)
+const rtl = computed(() => props.config.rtl === true)
 </script>

--- a/packages/ui/src/components/message/MessageItem.vue
+++ b/packages/ui/src/components/message/MessageItem.vue
@@ -84,7 +84,7 @@ onMounted(() => {
 })
 
 watch(
-  () => props.item.args.duration,
+  () => props.item.args,
   () => {
     clearTimer()
     startTimer()

--- a/packages/ui/src/components/message/MessageItem.vue
+++ b/packages/ui/src/components/message/MessageItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="itemClasses" :style="item.args.style">
+  <div :class="itemClasses" :style="item.args.style" @click="handleClick">
     <div class="ant-message-notice-content">
       <span v-if="iconNode" class="ant-message-icon">
         <component :is="iconNode" />
@@ -14,7 +14,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onBeforeUnmount, isVNode, type Component } from 'vue'
+import { computed, onMounted, onBeforeUnmount, watch, isVNode, type Component } from 'vue'
 import {
   InfoCircleFilled,
   CheckCircleFilled,
@@ -75,9 +75,21 @@ function clearTimer() {
   }
 }
 
+function handleClick(event: MouseEvent) {
+  props.item.args.onClick?.(event)
+}
+
 onMounted(() => {
   startTimer()
 })
+
+watch(
+  () => props.item.args.duration,
+  () => {
+    clearTimer()
+    startTimer()
+  },
+)
 
 onBeforeUnmount(() => {
   clearTimer()

--- a/packages/ui/src/components/message/__tests__/index.test.ts
+++ b/packages/ui/src/components/message/__tests__/index.test.ts
@@ -1,12 +1,27 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { message } from '@ant-design-vue/ui'
+import { message } from '../index'
 
 describe('message', () => {
   beforeEach(() => {
+    message.config({
+      top: 8,
+      duration: 3,
+      maxCount: undefined,
+      getContainer: () => document.body,
+      rtl: false,
+    })
     message.destroy()
   })
 
   afterEach(() => {
+    vi.useRealTimers()
+    message.config({
+      top: 8,
+      duration: 3,
+      maxCount: undefined,
+      getContainer: () => document.body,
+      rtl: false,
+    })
     message.destroy()
   })
 
@@ -26,6 +41,10 @@ describe('message', () => {
     expect(typeof message.warning).toBe('function')
   })
 
+  it('has warn method', () => {
+    expect(typeof message.warn).toBe('function')
+  })
+
   it('has loading method', () => {
     expect(typeof message.loading).toBe('function')
   })
@@ -42,6 +61,10 @@ describe('message', () => {
     expect(typeof message.config).toBe('function')
   })
 
+  it('has useMessage method', () => {
+    expect(typeof message.useMessage).toBe('function')
+  })
+
   it('returns a destroy function', () => {
     const destroy = message.info('Test')
     expect(typeof destroy).toBe('function')
@@ -50,5 +73,76 @@ describe('message', () => {
   it('returns a thenable', () => {
     const result = message.info('Test')
     expect(typeof result.then).toBe('function')
+  })
+
+  it('supports object overload on type methods', () => {
+    const destroy = message.success({
+      content: 'Object params',
+      duration: 0,
+      key: 'object-overload',
+    })
+    expect(typeof destroy).toBe('function')
+    message.destroy('object-overload')
+  })
+
+  it('applies getContainer config', async () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+
+    message.config({ getContainer: () => host })
+    message.info('Container test', 0)
+
+    await Promise.resolve()
+    expect(host.querySelector('.ant-message')).not.toBeNull()
+
+    host.remove()
+  })
+
+  it('calls onClose when destroy all', () => {
+    const onClose = vi.fn()
+    message.open({ content: 'Close me', duration: 0, onClose })
+
+    message.destroy()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves then after actual close', async () => {
+    const onResolved = vi.fn()
+    const close = message.open({ content: 'Thenable', duration: 0 })
+
+    close.then(onResolved)
+    expect(onResolved).not.toHaveBeenCalled()
+
+    close()
+    await Promise.resolve()
+    expect(onResolved).toHaveBeenCalledTimes(1)
+  })
+
+  it('resets auto-close timer when updating same key', async () => {
+    vi.useFakeTimers()
+
+    message.open({ key: 'same-key', content: 'Loading', type: 'loading', duration: 10 })
+    const updated = message.open({ key: 'same-key', content: 'Done', type: 'success', duration: 1 })
+    const onResolved = vi.fn()
+    updated.then(onResolved)
+
+    await Promise.resolve()
+    vi.advanceTimersByTime(999)
+    expect(onResolved).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    vi.advanceTimersByTime(1000)
+    await Promise.resolve()
+
+    expect(onResolved).toHaveBeenCalledTimes(1)
+  })
+
+  it('supports chained then calls', async () => {
+    const close = message.open({ content: 'Chain', duration: 0 })
+
+    const chained = close.then(() => 'step1').then((val) => `${val}-step2`)
+    close()
+
+    await expect(chained).resolves.toBe('step1-step2')
   })
 })

--- a/packages/ui/src/components/message/__tests__/index.test.ts
+++ b/packages/ui/src/components/message/__tests__/index.test.ts
@@ -106,6 +106,21 @@ describe('message', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  it('calls onClick when message is clicked', async () => {
+    const onClick = vi.fn()
+    message.open({ content: 'Clickable', duration: 0, onClick })
+
+    await Promise.resolve()
+    const textNode = Array.from(document.querySelectorAll('.ant-message-text')).find(
+      (node) => node.textContent?.trim() === 'Clickable',
+    )
+    const notice = textNode?.closest('.ant-message-notice') as HTMLElement | null
+    expect(notice).not.toBeNull()
+
+    notice?.click()
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
   it('resolves then after actual close', async () => {
     const onResolved = vi.fn()
     const close = message.open({ content: 'Thenable', duration: 0 })

--- a/packages/ui/src/components/message/__tests__/index.test.ts
+++ b/packages/ui/src/components/message/__tests__/index.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick } from 'vue'
 import { message } from '../index'
 
 describe('message', () => {
@@ -159,5 +161,93 @@ describe('message', () => {
     close()
 
     await expect(chained).resolves.toBe('step1-step2')
+  })
+
+  describe('useMessage', () => {
+    it('returns an instance and a context holder', () => {
+      const [api, contextHolder] = message.useMessage()
+      expect(typeof api.info).toBe('function')
+      expect(typeof api.success).toBe('function')
+      expect(typeof api.error).toBe('function')
+      expect(typeof api.warning).toBe('function')
+      expect(typeof api.warn).toBe('function')
+      expect(typeof api.loading).toBe('function')
+      expect(typeof api.open).toBe('function')
+      expect(typeof api.destroy).toBe('function')
+      expect(typeof api.config).toBe('function')
+      expect(typeof contextHolder).toBe('function')
+    })
+
+    it('renders messages inside the context holder', async () => {
+      const Wrapper = defineComponent({
+        setup() {
+          const [api, contextHolder] = message.useMessage()
+          return { api, contextHolder }
+        },
+        render() {
+          return h('div', [this.contextHolder()])
+        },
+      })
+
+      const wrapper = mount(Wrapper)
+      wrapper.vm.api.info('Hook message')
+
+      await nextTick()
+      expect(wrapper.find('.ant-message').exists()).toBe(true)
+      expect(wrapper.find('.ant-message-text').text()).toBe('Hook message')
+
+      wrapper.vm.api.destroy()
+      wrapper.unmount()
+    })
+
+    it('does not affect the global message singleton', async () => {
+      const Wrapper = defineComponent({
+        setup() {
+          const [api, contextHolder] = message.useMessage()
+          return { api, contextHolder }
+        },
+        render() {
+          return h('div', [this.contextHolder()])
+        },
+      })
+
+      const wrapper = mount(Wrapper)
+      wrapper.vm.api.info('Hook only')
+      message.info('Global only')
+
+      await nextTick()
+      // Hook holder should only contain its own message
+      const hookTexts = wrapper.findAll('.ant-message-text').map((w) => w.text())
+      expect(hookTexts).toContain('Hook only')
+      expect(hookTexts).not.toContain('Global only')
+
+      wrapper.vm.api.destroy()
+      message.destroy()
+      wrapper.unmount()
+    })
+
+    it('supports thenable on hook messages', async () => {
+      const Wrapper = defineComponent({
+        setup() {
+          const [api, contextHolder] = message.useMessage()
+          return { api, contextHolder }
+        },
+        render() {
+          return h('div', [this.contextHolder()])
+        },
+      })
+
+      const wrapper = mount(Wrapper)
+      const onResolved = vi.fn()
+      const close = wrapper.vm.api.open({ content: 'Thenable hook', duration: 0 })
+      close.then(onResolved)
+
+      expect(onResolved).not.toHaveBeenCalled()
+      close()
+      await Promise.resolve()
+      expect(onResolved).toHaveBeenCalledTimes(1)
+
+      wrapper.unmount()
+    })
   })
 })

--- a/packages/ui/src/components/message/style/index.css
+++ b/packages/ui/src/components/message/style/index.css
@@ -12,6 +12,10 @@
   gap: 8px;
 }
 
+:where(.ant-message.ant-message-rtl) {
+  direction: rtl;
+}
+
 /* Message notice */
 :where(.ant-message-notice) {
   @apply text-center;

--- a/packages/ui/src/components/message/types.ts
+++ b/packages/ui/src/components/message/types.ts
@@ -2,16 +2,19 @@ import type { VNode, CSSProperties } from 'vue'
 import type { Slot } from '@/utils/types'
 
 export type MessageType = 'info' | 'success' | 'error' | 'warning' | 'loading'
+export type MessageContent = string | VNode | (() => VNode)
 
 export interface MessageArgsProps {
   /** Message content */
-  content: string | VNode | (() => VNode)
+  content: MessageContent
   /** Message type */
   type?: MessageType
   /** Duration in seconds (0 = never auto-close) */
   duration?: number
   /** Callback when message closes */
   onClose?: () => void
+  /** Click callback */
+  onClick?: (e: MouseEvent) => void
   /** Custom icon */
   icon?: VNode | (() => VNode)
   /** Unique key for update/destroy */
@@ -40,21 +43,25 @@ export interface MessageInstance {
   success: MessageFn
   error: MessageFn
   warning: MessageFn
+  warn: MessageFn
   loading: MessageFn
   open: (args: MessageArgsProps) => MessageReturn
   destroy: (key?: string | number) => void
   config: (options: MessageConfigOptions) => void
+  useMessage: () => readonly [MessageInstance, () => VNode | null]
 }
 
-export type MessageFn = (
-  content: string | VNode | (() => VNode),
-  duration?: number,
-  onClose?: () => void,
-) => MessageReturn
+export type MessageFn = {
+  (content: MessageContent, duration?: number, onClose?: () => void): MessageReturn
+  (args: MessageArgsProps): MessageReturn
+}
 
 export interface MessageReturn {
   (): void // call to destroy
-  then: (resolve: () => void) => void
+  then: <TResult1 = void, TResult2 = never>(
+    onfulfilled?: ((value: void) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ) => Promise<TResult1 | TResult2>
 }
 
 export interface InternalMessageItem {

--- a/packages/ui/src/components/message/useMessage.ts
+++ b/packages/ui/src/components/message/useMessage.ts
@@ -1,7 +1,8 @@
-import { createApp, reactive, type VNode } from 'vue'
+import { createApp, reactive } from 'vue'
 import MessageContainer from './MessageContainer.vue'
 import type {
   MessageArgsProps,
+  MessageContent,
   MessageConfigOptions,
   MessageInstance,
   MessageReturn,
@@ -24,22 +25,55 @@ const globalConfig: MessageConfigOptions = {
 
 let mounted = false
 let containerApp: ReturnType<typeof createApp> | null = null
+let containerEl: HTMLElement | null = null
+let messageRootEl: HTMLElement | null = null
+
+const closeResolvers = new Map<string, Array<() => void>>()
+
+function addCloseResolver(id: string, resolve: () => void) {
+  const list = closeResolvers.get(id) ?? []
+  list.push(resolve)
+  closeResolvers.set(id, list)
+}
+
+function flushCloseResolvers(id: string) {
+  const list = closeResolvers.get(id)
+  if (!list?.length) return
+  closeResolvers.delete(id)
+  list.forEach((resolve) => resolve())
+}
+
+function syncContainerStyles() {
+  if (!messageRootEl) return
+
+  if (globalConfig.top != null) {
+    messageRootEl.style.top =
+      typeof globalConfig.top === 'number' ? `${globalConfig.top}px` : globalConfig.top
+  }
+
+  messageRootEl.classList.toggle('ant-message-rtl', globalConfig.rtl === true)
+}
 
 function ensureMounted() {
   if (mounted || typeof document === 'undefined') return
 
   const container = document.createElement('div')
-  document.body.appendChild(container)
+  const host = globalConfig.getContainer?.() ?? document.body
+  host.appendChild(container)
+  containerEl = container
 
   containerApp = createApp(MessageContainer, {
     messages,
     top: globalConfig.top,
+    rtl: globalConfig.rtl,
     onClose: (id: string) => {
       removeMessage(id)
     },
   })
 
   containerApp.mount(container)
+  messageRootEl = container.querySelector('.ant-message') as HTMLElement | null
+  syncContainerStyles()
   mounted = true
 }
 
@@ -48,7 +82,25 @@ function removeMessage(id: string) {
   if (idx > -1) {
     const [item] = messages.splice(idx, 1)
     item.args.onClose?.()
+    flushCloseResolvers(id)
   }
+}
+
+function buildMessageReturn(id: string): MessageReturn {
+  const destroy = () => removeMessage(id)
+  destroy.then = (onfulfilled, onrejected) => {
+    const closePromise = new Promise<void>((resolve) => {
+      const exists = messages.some((m) => m.id === id)
+      if (!exists) {
+        resolve()
+        return
+      }
+      addCloseResolver(id, resolve)
+    })
+
+    return closePromise.then(onfulfilled, onrejected)
+  }
+  return destroy as MessageReturn
 }
 
 function addMessage(args: MessageArgsProps): MessageReturn {
@@ -58,19 +110,19 @@ function addMessage(args: MessageArgsProps): MessageReturn {
   if (args.key != null) {
     const existing = messages.find((m) => m.args.key === args.key)
     if (existing) {
-      existing.args = { ...args }
-      const destroy = () => removeMessage(existing.id)
-      destroy.then = (resolve: () => void) => {
-        const duration = args.duration ?? globalConfig.duration ?? 3
-        setTimeout(resolve, duration * 1000)
+      existing.args = {
+        ...args,
+        duration: args.duration ?? globalConfig.duration ?? 3,
       }
-      return destroy as MessageReturn
+      return buildMessageReturn(existing.id)
     }
   }
 
   // Enforce maxCount
   if (globalConfig.maxCount && messages.length >= globalConfig.maxCount) {
-    messages.splice(0, messages.length - globalConfig.maxCount + 1)
+    while (messages.length >= globalConfig.maxCount) {
+      removeMessage(messages[0].id)
+    }
   }
 
   const id = genId()
@@ -84,21 +136,26 @@ function addMessage(args: MessageArgsProps): MessageReturn {
 
   messages.push(item)
 
-  const destroy = () => removeMessage(id)
-  destroy.then = (resolve: () => void) => {
-    const duration = item.args.duration ?? 3
-    setTimeout(resolve, duration * 1000)
-  }
+  return buildMessageReturn(id)
+}
 
-  return destroy as MessageReturn
+function isArgsProps(content: unknown): content is MessageArgsProps {
+  return !!content && typeof content === 'object' && 'content' in (content as MessageArgsProps)
 }
 
 function createTypeFn(type: MessageType) {
   return (
-    content: string | VNode | (() => VNode),
+    content: MessageContent | MessageArgsProps,
     duration?: number,
     onClose?: () => void,
   ): MessageReturn => {
+    if (isArgsProps(content)) {
+      return addMessage({
+        ...content,
+        type,
+      })
+    }
+
     return addMessage({ content, type, duration, onClose })
   }
 }
@@ -108,6 +165,7 @@ export const message: MessageInstance = {
   success: createTypeFn('success'),
   error: createTypeFn('error'),
   warning: createTypeFn('warning'),
+  warn: createTypeFn('warning'),
   loading: createTypeFn('loading'),
   open: (args: MessageArgsProps) => addMessage(args),
   destroy: (key?: string | number) => {
@@ -115,10 +173,22 @@ export const message: MessageInstance = {
       const item = messages.find((m) => m.args.key === key)
       if (item) removeMessage(item.id)
     } else {
-      messages.splice(0, messages.length)
+      while (messages.length) {
+        removeMessage(messages[0].id)
+      }
     }
   },
   config: (options: MessageConfigOptions) => {
+    const moveContainer =
+      mounted && !!options.getContainer && containerEl && options.getContainer() !== containerEl.parentElement
+
     Object.assign(globalConfig, options)
+
+    if (moveContainer && containerEl) {
+      options.getContainer?.().appendChild(containerEl)
+    }
+
+    syncContainerStyles()
   },
+  useMessage: () => [message, () => null],
 }

--- a/packages/ui/src/components/message/useMessage.ts
+++ b/packages/ui/src/components/message/useMessage.ts
@@ -22,11 +22,14 @@ const globalConfig: MessageConfigOptions = {
   duration: 3,
   maxCount: undefined,
 }
+const containerConfig = reactive<Pick<MessageConfigOptions, 'top' | 'rtl'>>({
+  top: globalConfig.top,
+  rtl: globalConfig.rtl,
+})
 
 let mounted = false
 let containerApp: ReturnType<typeof createApp> | null = null
 let containerEl: HTMLElement | null = null
-let messageRootEl: HTMLElement | null = null
 
 const closeResolvers = new Map<string, Array<() => void>>()
 
@@ -43,17 +46,6 @@ function flushCloseResolvers(id: string) {
   list.forEach((resolve) => resolve())
 }
 
-function syncContainerStyles() {
-  if (!messageRootEl) return
-
-  if (globalConfig.top != null) {
-    messageRootEl.style.top =
-      typeof globalConfig.top === 'number' ? `${globalConfig.top}px` : globalConfig.top
-  }
-
-  messageRootEl.classList.toggle('ant-message-rtl', globalConfig.rtl === true)
-}
-
 function ensureMounted() {
   if (mounted || typeof document === 'undefined') return
 
@@ -64,16 +56,13 @@ function ensureMounted() {
 
   containerApp = createApp(MessageContainer, {
     messages,
-    top: globalConfig.top,
-    rtl: globalConfig.rtl,
+    config: containerConfig,
     onClose: (id: string) => {
       removeMessage(id)
     },
   })
 
   containerApp.mount(container)
-  messageRootEl = container.querySelector('.ant-message') as HTMLElement | null
-  syncContainerStyles()
   mounted = true
 }
 
@@ -87,7 +76,7 @@ function removeMessage(id: string) {
 }
 
 function buildMessageReturn(id: string): MessageReturn {
-  const destroy = () => removeMessage(id)
+  const destroy = (() => removeMessage(id)) as MessageReturn
   destroy.then = (onfulfilled, onrejected) => {
     const closePromise = new Promise<void>((resolve) => {
       const exists = messages.some((m) => m.id === id)
@@ -100,7 +89,7 @@ function buildMessageReturn(id: string): MessageReturn {
 
     return closePromise.then(onfulfilled, onrejected)
   }
-  return destroy as MessageReturn
+  return destroy
 }
 
 function addMessage(args: MessageArgsProps): MessageReturn {
@@ -179,16 +168,21 @@ export const message: MessageInstance = {
     }
   },
   config: (options: MessageConfigOptions) => {
-    const moveContainer =
-      mounted && !!options.getContainer && containerEl && options.getContainer() !== containerEl.parentElement
+    let nextContainer: HTMLElement | null | undefined
+    let moveContainer = false
 
-    Object.assign(globalConfig, options)
-
-    if (moveContainer && containerEl) {
-      options.getContainer?.().appendChild(containerEl)
+    if (mounted && containerEl && options.getContainer) {
+      nextContainer = options.getContainer()
+      moveContainer = !!nextContainer && nextContainer !== containerEl.parentElement
     }
 
-    syncContainerStyles()
+    Object.assign(globalConfig, options)
+    containerConfig.top = globalConfig.top
+    containerConfig.rtl = globalConfig.rtl
+
+    if (moveContainer && containerEl && nextContainer) {
+      nextContainer.appendChild(containerEl)
+    }
   },
   useMessage: () => [message, () => null],
 }

--- a/packages/ui/src/components/message/useMessage.ts
+++ b/packages/ui/src/components/message/useMessage.ts
@@ -107,11 +107,13 @@ function addMessage(args: MessageArgsProps): MessageReturn {
     }
   }
 
-  // Enforce maxCount
+  // Enforce maxCount with a fixed snapshot to avoid re-entrant infinite loops.
   if (globalConfig.maxCount && messages.length >= globalConfig.maxCount) {
-    while (messages.length >= globalConfig.maxCount) {
-      removeMessage(messages[0].id)
-    }
+    const removeCount = messages.length - globalConfig.maxCount + 1
+    const idsToRemove = messages.slice(0, removeCount).map((m) => m.id)
+    idsToRemove.forEach((id) => {
+      removeMessage(id)
+    })
   }
 
   const id = genId()

--- a/packages/ui/src/components/message/useMessage.ts
+++ b/packages/ui/src/components/message/useMessage.ts
@@ -1,4 +1,4 @@
-import { createApp, reactive } from 'vue'
+import { createApp, reactive, h, type VNode } from 'vue'
 import MessageContainer from './MessageContainer.vue'
 import type {
   MessageArgsProps,
@@ -10,41 +10,158 @@ import type {
   InternalMessageItem,
 } from './types'
 
-let seed = 0
-function genId() {
-  return `ant-message-${++seed}`
-}
+// ─── Global config ──────────────────────────────────────────────
 
-// Global state
-const messages = reactive<InternalMessageItem[]>([])
 const globalConfig: MessageConfigOptions = {
   top: 8,
   duration: 3,
   maxCount: undefined,
 }
+
 const containerConfig = reactive<Pick<MessageConfigOptions, 'top' | 'rtl'>>({
   top: globalConfig.top,
   rtl: globalConfig.rtl,
 })
 
+// ─── Helpers ────────────────────────────────────────────────────
+
+// VNodes don't have a `content` property, so this safely distinguishes MessageArgsProps from VNode
+function isArgsProps(content: unknown): content is MessageArgsProps {
+  return !!content && typeof content === 'object' && 'content' in (content as MessageArgsProps)
+}
+
+// ─── Message controller factory ─────────────────────────────────
+
+function createMessageController(idPrefix: string, beforeAdd?: () => void) {
+  const messages = reactive<InternalMessageItem[]>([])
+  const resolvers = new Map<string, Array<() => void>>()
+  let seed = 0
+
+  function genId() {
+    return `${idPrefix}-${++seed}`
+  }
+
+  function addResolver(id: string, resolve: () => void) {
+    const list = resolvers.get(id) ?? []
+    list.push(resolve)
+    resolvers.set(id, list)
+  }
+
+  function flushResolvers(id: string) {
+    const list = resolvers.get(id)
+    if (!list?.length) return
+    resolvers.delete(id)
+    list.forEach((r) => r())
+  }
+
+  function remove(id: string) {
+    const idx = messages.findIndex((m) => m.id === id)
+    if (idx > -1) {
+      const [item] = messages.splice(idx, 1)
+      item.args.onClose?.()
+      flushResolvers(id)
+    }
+  }
+
+  function buildReturn(id: string): MessageReturn {
+    const destroy = (() => remove(id)) as MessageReturn
+    destroy.then = (onfulfilled, onrejected) => {
+      const p = new Promise<void>((resolve) => {
+        if (!messages.some((m) => m.id === id)) {
+          resolve()
+          return
+        }
+        addResolver(id, resolve)
+      })
+      return p.then(onfulfilled, onrejected)
+    }
+    return destroy
+  }
+
+  function add(args: MessageArgsProps): MessageReturn {
+    beforeAdd?.()
+
+    if (args.key != null) {
+      const existing = messages.find((m) => m.args.key === args.key)
+      if (existing) {
+        existing.args = {
+          ...args,
+          duration: args.duration ?? globalConfig.duration ?? 3,
+        }
+        return buildReturn(existing.id)
+      }
+    }
+
+    // Enforce maxCount with a fixed snapshot to avoid re-entrant infinite loops.
+    if (globalConfig.maxCount && messages.length >= globalConfig.maxCount) {
+      const removeCount = messages.length - globalConfig.maxCount + 1
+      const idsToRemove = messages.slice(0, removeCount).map((m) => m.id)
+      idsToRemove.forEach((id) => remove(id))
+    }
+
+    const id = genId()
+    messages.push({
+      id,
+      args: {
+        ...args,
+        duration: args.duration ?? globalConfig.duration ?? 3,
+      },
+    })
+    return buildReturn(id)
+  }
+
+  function destroy(key?: string | number) {
+    if (key != null) {
+      const item = messages.find((m) => m.args.key === key)
+      if (item) remove(item.id)
+    } else {
+      while (messages.length) {
+        remove(messages[0].id)
+      }
+    }
+  }
+
+  function typeFn(type: MessageType) {
+    return (
+      content: MessageContent | MessageArgsProps,
+      duration?: number,
+      onClose?: () => void,
+    ): MessageReturn => {
+      if (isArgsProps(content)) {
+        return add({ ...content, type })
+      }
+      return add({ content, type, duration, onClose })
+    }
+  }
+
+  return { messages, add, remove, destroy, typeFn }
+}
+
+// ─── Instance builder ───────────────────────────────────────────
+
+function buildInstance(
+  ctrl: ReturnType<typeof createMessageController>,
+  configFn: (options: MessageConfigOptions) => void,
+): MessageInstance {
+  return {
+    info: ctrl.typeFn('info'),
+    success: ctrl.typeFn('success'),
+    error: ctrl.typeFn('error'),
+    warning: ctrl.typeFn('warning'),
+    warn: ctrl.typeFn('warning'),
+    loading: ctrl.typeFn('loading'),
+    open: (args: MessageArgsProps) => ctrl.add(args),
+    destroy: ctrl.destroy,
+    config: configFn,
+    useMessage: useMessageHook,
+  }
+}
+
+// ─── Global singleton (createApp-based) ─────────────────────────
+
 let mounted = false
 let containerApp: ReturnType<typeof createApp> | null = null
 let containerEl: HTMLElement | null = null
-
-const closeResolvers = new Map<string, Array<() => void>>()
-
-function addCloseResolver(id: string, resolve: () => void) {
-  const list = closeResolvers.get(id) ?? []
-  list.push(resolve)
-  closeResolvers.set(id, list)
-}
-
-function flushCloseResolvers(id: string) {
-  const list = closeResolvers.get(id)
-  if (!list?.length) return
-  closeResolvers.delete(id)
-  list.forEach((resolve) => resolve())
-}
 
 function ensureMounted() {
   if (mounted || typeof document === 'undefined') return
@@ -55,10 +172,10 @@ function ensureMounted() {
   containerEl = container
 
   containerApp = createApp(MessageContainer, {
-    messages,
+    messages: globalCtrl.messages,
     config: containerConfig,
     onClose: (id: string) => {
-      removeMessage(id)
+      globalCtrl.remove(id)
     },
   })
 
@@ -66,125 +183,43 @@ function ensureMounted() {
   mounted = true
 }
 
-function removeMessage(id: string) {
-  const idx = messages.findIndex((m) => m.id === id)
-  if (idx > -1) {
-    const [item] = messages.splice(idx, 1)
-    item.args.onClose?.()
-    flushCloseResolvers(id)
-  }
-}
+const globalCtrl = createMessageController('ant-message', ensureMounted)
 
-function buildMessageReturn(id: string): MessageReturn {
-  const destroy = (() => removeMessage(id)) as MessageReturn
-  destroy.then = (onfulfilled, onrejected) => {
-    const closePromise = new Promise<void>((resolve) => {
-      const exists = messages.some((m) => m.id === id)
-      if (!exists) {
-        resolve()
-        return
-      }
-      addCloseResolver(id, resolve)
-    })
+export const message: MessageInstance = buildInstance(globalCtrl, (options) => {
+  let nextContainer: HTMLElement | null | undefined
+  let moveContainer = false
 
-    return closePromise.then(onfulfilled, onrejected)
-  }
-  return destroy
-}
-
-function addMessage(args: MessageArgsProps): MessageReturn {
-  ensureMounted()
-
-  // If key exists, update the existing message
-  if (args.key != null) {
-    const existing = messages.find((m) => m.args.key === args.key)
-    if (existing) {
-      existing.args = {
-        ...args,
-        duration: args.duration ?? globalConfig.duration ?? 3,
-      }
-      return buildMessageReturn(existing.id)
-    }
+  if (mounted && containerEl && options.getContainer) {
+    nextContainer = options.getContainer()
+    moveContainer = !!nextContainer && nextContainer !== containerEl.parentElement
   }
 
-  // Enforce maxCount with a fixed snapshot to avoid re-entrant infinite loops.
-  if (globalConfig.maxCount && messages.length >= globalConfig.maxCount) {
-    const removeCount = messages.length - globalConfig.maxCount + 1
-    const idsToRemove = messages.slice(0, removeCount).map((m) => m.id)
-    idsToRemove.forEach((id) => {
-      removeMessage(id)
-    })
+  Object.assign(globalConfig, options)
+  containerConfig.top = globalConfig.top
+  containerConfig.rtl = globalConfig.rtl
+
+  if (moveContainer && containerEl && nextContainer) {
+    nextContainer.appendChild(containerEl)
   }
+})
 
-  const id = genId()
-  const item: InternalMessageItem = {
-    id,
-    args: {
-      ...args,
-      duration: args.duration ?? globalConfig.duration ?? 3,
-    },
-  }
+// ─── Hook-based useMessage ──────────────────────────────────────
 
-  messages.push(item)
+function useMessageHook(): readonly [MessageInstance, () => VNode | null] {
+  const ctrl = createMessageController('ant-message-hook')
 
-  return buildMessageReturn(id)
-}
-
-function isArgsProps(content: unknown): content is MessageArgsProps {
-  return !!content && typeof content === 'object' && 'content' in (content as MessageArgsProps)
-}
-
-function createTypeFn(type: MessageType) {
-  return (
-    content: MessageContent | MessageArgsProps,
-    duration?: number,
-    onClose?: () => void,
-  ): MessageReturn => {
-    if (isArgsProps(content)) {
-      return addMessage({
-        ...content,
-        type,
-      })
-    }
-
-    return addMessage({ content, type, duration, onClose })
-  }
-}
-
-export const message: MessageInstance = {
-  info: createTypeFn('info'),
-  success: createTypeFn('success'),
-  error: createTypeFn('error'),
-  warning: createTypeFn('warning'),
-  warn: createTypeFn('warning'),
-  loading: createTypeFn('loading'),
-  open: (args: MessageArgsProps) => addMessage(args),
-  destroy: (key?: string | number) => {
-    if (key != null) {
-      const item = messages.find((m) => m.args.key === key)
-      if (item) removeMessage(item.id)
-    } else {
-      while (messages.length) {
-        removeMessage(messages[0].id)
-      }
-    }
-  },
-  config: (options: MessageConfigOptions) => {
-    let nextContainer: HTMLElement | null | undefined
-    let moveContainer = false
-
-    if (mounted && containerEl && options.getContainer) {
-      nextContainer = options.getContainer()
-      moveContainer = !!nextContainer && nextContainer !== containerEl.parentElement
-    }
-
+  const instance = buildInstance(ctrl, (options) => {
     Object.assign(globalConfig, options)
     containerConfig.top = globalConfig.top
     containerConfig.rtl = globalConfig.rtl
+  })
 
-    if (moveContainer && containerEl && nextContainer) {
-      nextContainer.appendChild(containerEl)
-    }
-  },
-  useMessage: () => [message, () => null],
+  const contextHolder = () =>
+    h(MessageContainer, {
+      messages: ctrl.messages,
+      config: containerConfig,
+      onClose: ctrl.remove,
+    })
+
+  return [instance, contextHolder] as const
 }


### PR DESCRIPTION
This PR reviews and fixes the `message` implementation in ui to improve API compatibility and runtime behavior after the SFC + CSS refactor.

## What Changed
- Added compatibility APIs:
  - `message.warn` alias
  - `message.useMessage` entry
- Restored typed method object overload support:
  - `message.success({ content, key, duration, ... })`
- Added `onClick` typing and forwarding for message items.
- Fixed thenable behavior:
  - `message.xxx(...).then(...).then(...)` now supports proper Promise chaining.
  - `then` now resolves on actual close.
- Improved close semantics:
  - Ensure `onClose` is triggered consistently in `destroy()` and `maxCount` overflow paths.
- Improved config behavior:
  - Support `getContainer` mounting/migration.
  - Sync `top` and `rtl` updates to mounted container.
- Added/updated regression tests for:
  - API surface compatibility (`warn`, `useMessage`)
  - Object overload behavior
  - `getContainer` behavior
  - `onClose` consistency
  - Thenable resolution and chained `then`
  - Keyed update timer reset behavior

## Validation
- Ran:
  - `npm --prefix packages/ui run test -- src/components/message/__tests__/index.test.ts --run`
- Result: passed

## Notes
- This is a minimal compatibility-focused fix set intended for component review under issue #8497.