### PR TITLE
fix(modal): restore confirm dialog behavior

### DIFF
--- a/packages/ui/src/components/modal/ConfirmDialog.vue
+++ b/packages/ui/src/components/modal/ConfirmDialog.vue
@@ -62,7 +62,13 @@ import {
 } from '@ant-design/icons-vue'
 import Button from '../button'
 import Modal from './Modal.vue'
-import type { ModalButtonType, ModalFuncProps, ModalRenderContent, ModalType } from './types'
+import type {
+  ModalButtonType,
+  ModalFuncConfigUpdate,
+  ModalFuncProps,
+  ModalRenderContent,
+  ModalType,
+} from './types'
 
 defineOptions({ name: 'AConfirmDialog' })
 
@@ -80,6 +86,7 @@ const okLoading = ref(false)
 const cancelLoading = ref(false)
 const okBtnRef = ref<{ focus: () => void } | null>(null)
 const cancelBtnRef = ref<{ focus: () => void } | null>(null)
+const isLoading = computed(() => okLoading.value || cancelLoading.value)
 
 function resolveOkTypeProps(okType?: ModalButtonType) {
   if (!okType) return {}
@@ -151,18 +158,20 @@ const confirmClasses = computed(() => {
 
 const okButtonAttrs = computed(() => ({
   ...resolveOkTypeProps(config.value.okType),
-  loading: okLoading.value,
   ...(config.value.okButtonProps ?? {}),
+  loading: okLoading.value || config.value.okButtonProps?.loading,
+  disabled: isLoading.value || config.value.okButtonProps?.disabled,
 }))
 
 const cancelButtonAttrs = computed(() => ({
   variant: 'outlined' as const,
-  loading: cancelLoading.value,
   ...(config.value.cancelButtonProps ?? {}),
+  loading: cancelLoading.value || config.value.cancelButtonProps?.loading,
+  disabled: isLoading.value || config.value.cancelButtonProps?.disabled,
 }))
 
 async function onOk() {
-  if (okLoading.value) return
+  if (isLoading.value) return
 
   const action = config.value.onOk
   if (!action) {
@@ -192,8 +201,8 @@ async function onOk() {
   }
 }
 
-async function onCancel() {
-  if (cancelLoading.value) return
+async function handleCancel(event?: MouseEvent | KeyboardEvent) {
+  if (isLoading.value) return
 
   const action = config.value.onCancel
   if (!action) {
@@ -202,12 +211,12 @@ async function onCancel() {
   }
 
   if (action.length) {
-    action(close)
+    action(close, event)
     return
   }
 
   try {
-    const result = action()
+    const result = event === undefined ? action() : action(event)
     if (!isThenable(result)) {
       if (!result) {
         close()
@@ -224,6 +233,10 @@ async function onCancel() {
   }
 }
 
+async function onCancel() {
+  await handleCancel()
+}
+
 function close() {
   if (!open.value) return
   okLoading.value = false
@@ -232,12 +245,7 @@ function close() {
 }
 
 function onDialogCancel(event: MouseEvent | KeyboardEvent) {
-  try {
-    config.value.onCancel?.(() => {}, event)
-  } catch {
-    // Follow legacy confirm behavior and close even if onCancel throws.
-  }
-  close()
+  void handleCancel(event)
 }
 
 function onAfterLeave() {
@@ -245,8 +253,11 @@ function onAfterLeave() {
   emit('destroy')
 }
 
-function update(newConfig: Partial<ModalFuncProps>) {
-  Object.assign(config.value, newConfig)
+function update(newConfig: ModalFuncConfigUpdate) {
+  Object.assign(
+    config.value,
+    typeof newConfig === 'function' ? newConfig(config.value) : newConfig,
+  )
 }
 
 defineExpose({ close, update })

--- a/packages/ui/src/components/modal/ConfirmDialog.vue
+++ b/packages/ui/src/components/modal/ConfirmDialog.vue
@@ -114,7 +114,7 @@ const RenderContent = defineComponent({
   name: 'ModalRenderContent',
   props: {
     value: {
-      type: [String, Number, Boolean, Object, Array, Function] as PropType<ModalRenderContent>,
+      type: null as unknown as PropType<ModalRenderContent>,
       default: undefined,
     },
   },

--- a/packages/ui/src/components/modal/ConfirmDialog.vue
+++ b/packages/ui/src/components/modal/ConfirmDialog.vue
@@ -1,224 +1,252 @@
 <template>
-  <Portal :visible="open" :get-container="getContainer">
-    <div :class="wrapClasses" :style="wrapStyle" @click="onMaskClick" @keydown="onKeydown">
-      <Transition name="ant-zoom" @after-leave="onAfterLeave">
-        <div
-          v-if="open"
-          ref="dialogRef"
-          class="ant-modal ant-modal-confirm"
-          :class="confirmClasses"
-          :style="modalStyle"
-          role="dialog"
-          aria-modal="true"
-          tabindex="-1"
-          @click.stop
-        >
-          <div class="ant-modal-body">
-            <div class="ant-modal-confirm-body-wrapper">
-              <div class="ant-modal-confirm-body">
-                <span v-if="iconNode" class="ant-modal-confirm-icon">
-                  <component :is="iconNode" />
-                </span>
-                <span v-if="config.title" class="ant-modal-confirm-title">
-                  <component :is="config.title" v-if="typeof config.title === 'function'" />
-                  <template v-else>{{ config.title }}</template>
-                </span>
-                <div v-if="config.content" class="ant-modal-confirm-content">
-                  <component :is="config.content" v-if="typeof config.content === 'function'" />
-                  <template v-else>{{ config.content }}</template>
-                </div>
-              </div>
-              <div class="ant-modal-confirm-btns">
-                <button
-                  v-if="showCancel"
-                  class="ant-btn ant-btn-outlined"
-                  v-bind="(config.cancelButtonProps as any)"
-                  @click="onCancel"
-                >
-                  {{ config.cancelText || 'Cancel' }}
-                </button>
-                <button
-                  ref="okBtnRef"
-                  class="ant-btn ant-btn-solid"
-                  :class="{ 'ant-btn-danger': config.type === 'error' }"
-                  v-bind="(config.okButtonProps as any)"
-                  :disabled="loading"
-                  @click="onOk"
-                >
-                  <span v-if="loading" class="ant-btn-loading-icon">
-                    <LoadingOutlined />
-                  </span>
-                  {{ config.okText || 'OK' }}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </Transition>
-    </div>
+  <Modal
+    :open="open"
+    :width="config.width ?? 416"
+    :centered="config.centered"
+    :closable="config.closable ?? false"
+    :mask="config.mask ?? true"
+    :mask-closable="config.maskClosable ?? false"
+    :keyboard="config.keyboard ?? true"
+    :z-index="config.zIndex"
+    :body-style="config.bodyStyle"
+    :mask-style="config.maskStyle"
+    :wrap-class-name="config.wrapClassName"
+    :get-container="config.getContainer"
+    :footer="false"
+    :class="confirmClasses"
+    @cancel="onDialogCancel"
+    @after-close="onAfterLeave"
+  >
+    <template v-if="config.closeIcon !== undefined" #closeIcon>
+      <RenderContent :value="config.closeIcon" />
+    </template>
 
-    <Transition name="ant-fade">
-      <div v-if="open" class="ant-modal-mask" :style="maskStyle" />
-    </Transition>
-  </Portal>
+    <div class="ant-modal-confirm-body-wrapper">
+      <div class="ant-modal-confirm-body">
+        <span v-if="iconNode !== undefined && iconNode !== null" class="ant-modal-confirm-icon">
+          <RenderContent :value="iconNode" />
+        </span>
+        <span v-if="config.title !== undefined" class="ant-modal-confirm-title">
+          <RenderContent :value="config.title" />
+        </span>
+        <div v-if="config.content !== undefined" class="ant-modal-confirm-content">
+          <RenderContent :value="config.content" />
+        </div>
+      </div>
+
+      <RenderContent v-if="config.footer !== undefined" :value="config.footer" />
+      <div v-else class="ant-modal-confirm-btns">
+        <Button
+          v-if="showCancel"
+          ref="cancelBtnRef"
+          v-bind="cancelButtonAttrs"
+          @click="onCancel"
+        >
+          {{ config.cancelText || 'Cancel' }}
+        </Button>
+        <Button ref="okBtnRef" v-bind="okButtonAttrs" @click="onOk">
+          {{ config.okText || 'OK' }}
+        </Button>
+      </div>
+    </div>
+  </Modal>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, nextTick, type Component } from 'vue'
+import { computed, defineComponent, h, nextTick, onMounted, ref, toRef, type PropType } from 'vue'
 import {
   InfoCircleOutlined,
   CheckCircleOutlined,
   CloseCircleOutlined,
   ExclamationCircleOutlined,
-  LoadingOutlined,
 } from '@ant-design/icons-vue'
-import { Portal } from '@/_internal/portal'
-import type { ModalFuncProps, ModalType } from './types'
+import Button from '../button'
+import Modal from './Modal.vue'
+import type { ModalButtonType, ModalFuncProps, ModalRenderContent, ModalType } from './types'
+
+defineOptions({ name: 'AConfirmDialog' })
 
 const props = defineProps<{
   config: ModalFuncProps
 }>()
+const config = toRef(props, 'config')
 
 const emit = defineEmits<{
   (e: 'destroy'): void
 }>()
 
 const open = ref(true)
-const loading = ref(false)
+const okLoading = ref(false)
+const cancelLoading = ref(false)
+const okBtnRef = ref<{ focus: () => void } | null>(null)
+const cancelBtnRef = ref<{ focus: () => void } | null>(null)
 
-const dialogRef = ref<HTMLElement | null>(null)
-const okBtnRef = ref<HTMLElement | null>(null)
+function resolveOkTypeProps(okType?: ModalButtonType) {
+  if (!okType) return {}
+  if (okType === 'danger') return { danger: true }
+  if (okType === 'primary' || okType === 'default') return { type: okType }
+  return { variant: okType }
+}
+
+function renderSomeContent(content?: ModalRenderContent) {
+  if (typeof content === 'function') {
+    return content()
+  }
+  return content
+}
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return !!value && typeof (value as PromiseLike<unknown>).then === 'function'
+}
+
+const RenderContent = defineComponent({
+  name: 'ModalRenderContent',
+  props: {
+    value: {
+      type: [String, Number, Boolean, Object, Array, Function] as PropType<ModalRenderContent>,
+      default: undefined,
+    },
+  },
+  setup(renderProps) {
+    return () => renderSomeContent(renderProps.value)
+  },
+})
 
 // Focus management
 onMounted(() => {
   nextTick(() => {
-    if (props.config.autoFocusButton === 'cancel') {
-      // focus cancel button if exists
-    } else if (props.config.autoFocusButton !== null) {
+    if (config.value.autoFocusButton === 'cancel') {
+      cancelBtnRef.value?.focus()
+    } else if (config.value.autoFocusButton !== null) {
       okBtnRef.value?.focus()
     }
   })
 })
 
 const showCancel = computed(() => {
-  if (props.config.okCancel !== undefined) return props.config.okCancel
-  return props.config.type === 'confirm'
+  if (config.value.okCancel !== undefined) return config.value.okCancel
+  return (config.value.type || 'confirm') === 'confirm'
 })
 
-const typeIconMap: Record<ModalType, Component> = {
-  info: InfoCircleOutlined,
-  success: CheckCircleOutlined,
-  error: CloseCircleOutlined,
-  warning: ExclamationCircleOutlined,
-  confirm: ExclamationCircleOutlined,
+const typeIconMap: Record<ModalType, ModalRenderContent> = {
+  info: () => h(InfoCircleOutlined),
+  success: () => h(CheckCircleOutlined),
+  error: () => h(CloseCircleOutlined),
+  warning: () => h(ExclamationCircleOutlined),
+  confirm: () => h(ExclamationCircleOutlined),
 }
 
 const iconNode = computed(() => {
-  if (props.config.icon) {
-    return typeof props.config.icon === 'function' ? props.config.icon : () => props.config.icon
+  if (Object.prototype.hasOwnProperty.call(config.value, 'icon')) {
+    return config.value.icon ?? null
   }
-  const type = props.config.type || 'confirm'
+  const type = config.value.type || 'confirm'
   return typeIconMap[type]
 })
 
 const confirmClasses = computed(() => {
-  const type = props.config.type || 'confirm'
-  return [
-    `ant-modal-confirm-${type}`,
-    props.config.class,
-    props.config.wrapClassName,
-  ]
+  const type = config.value.type || 'confirm'
+  return ['ant-modal-confirm', `ant-modal-confirm-${type}`, config.value.class]
 })
 
-const wrapClasses = computed(() => [
-  'ant-modal-wrap',
-  { 'ant-modal-centered': props.config.centered },
-])
+const okButtonAttrs = computed(() => ({
+  ...resolveOkTypeProps(config.value.okType),
+  loading: okLoading.value,
+  ...(config.value.okButtonProps ?? {}),
+}))
 
-const wrapStyle = computed(() => {
-  const style: Record<string, string> = {}
-  if (props.config.zIndex != null) {
-    style.zIndex = String(props.config.zIndex)
-  }
-  return style
-})
-
-const modalStyle = computed(() => {
-  const style: Record<string, string> = {}
-  const width = props.config.width ?? 416
-  if (typeof width === 'number') {
-    style.width = `${width}px`
-  } else {
-    style.width = width
-  }
-  return style
-})
-
-const maskStyle = computed(() => {
-  const style: Record<string, string> = {}
-  if (props.config.zIndex != null) {
-    style.zIndex = String(props.config.zIndex)
-  }
-  return style
-})
-
-const getContainer = computed(() => undefined)
+const cancelButtonAttrs = computed(() => ({
+  variant: 'outlined' as const,
+  loading: cancelLoading.value,
+  ...(config.value.cancelButtonProps ?? {}),
+}))
 
 async function onOk() {
-  if (props.config.onOk) {
-    const result = props.config.onOk()
-    if (result && typeof result === 'object' && 'then' in result) {
-      loading.value = true
-      try {
-        await result
-        close()
-      } catch {
-        loading.value = false
-      }
-      return
-    }
+  if (okLoading.value) return
+
+  const action = config.value.onOk
+  if (!action) {
+    close()
+    return
   }
-  close()
+
+  if (action.length) {
+    action(close)
+    return
+  }
+
+  const result = action()
+  if (!isThenable(result)) {
+    if (!result) {
+      close()
+    }
+    return
+  }
+
+  okLoading.value = true
+  try {
+    await result
+    close()
+  } catch {
+    okLoading.value = false
+  }
 }
 
 async function onCancel() {
-  if (props.config.onCancel) {
-    const result = props.config.onCancel()
-    if (result && typeof result === 'object' && 'then' in result) {
-      try {
-        await result
-      } catch {
-        return
+  if (cancelLoading.value) return
+
+  const action = config.value.onCancel
+  if (!action) {
+    close()
+    return
+  }
+
+  if (action.length) {
+    action(close)
+    return
+  }
+
+  try {
+    const result = action()
+    if (!isThenable(result)) {
+      if (!result) {
+        close()
       }
+      return
     }
+
+    cancelLoading.value = true
+    await result
+    close()
+  } catch {
+    cancelLoading.value = false
+    // Keep dialog open on rejected cancel promises.
+  }
+}
+
+function close() {
+  if (!open.value) return
+  okLoading.value = false
+  cancelLoading.value = false
+  open.value = false
+}
+
+function onDialogCancel(event: MouseEvent | KeyboardEvent) {
+  try {
+    config.value.onCancel?.(() => {}, event)
+  } catch {
+    // Follow legacy confirm behavior and close even if onCancel throws.
   }
   close()
 }
 
-function close() {
-  open.value = false
-}
-
-function onMaskClick() {
-  if (props.config.maskClosable) {
-    onCancel()
-  }
-}
-
-function onKeydown(e: KeyboardEvent) {
-  if (props.config.keyboard !== false && e.key === 'Escape') {
-    e.stopPropagation()
-    onCancel()
-  }
-}
-
 function onAfterLeave() {
-  props.config.afterClose?.()
+  config.value.afterClose?.()
   emit('destroy')
 }
 
 function update(newConfig: Partial<ModalFuncProps>) {
-  Object.assign(props.config, newConfig)
+  Object.assign(config.value, newConfig)
 }
 
 defineExpose({ close, update })

--- a/packages/ui/src/components/modal/ConfirmDialog.vue
+++ b/packages/ui/src/components/modal/ConfirmDialog.vue
@@ -26,10 +26,10 @@
         <span v-if="iconNode !== undefined && iconNode !== null" class="ant-modal-confirm-icon">
           <RenderContent :value="iconNode" />
         </span>
-        <span v-if="config.title !== undefined" class="ant-modal-confirm-title">
+        <span v-if="config.title != null" class="ant-modal-confirm-title">
           <RenderContent :value="config.title" />
         </span>
-        <div v-if="config.content !== undefined" class="ant-modal-confirm-content">
+        <div v-if="config.content != null" class="ant-modal-confirm-content">
           <RenderContent :value="config.content" />
         </div>
       </div>
@@ -104,6 +104,10 @@ function renderSomeContent(content?: ModalRenderContent) {
 
 function isThenable(value: unknown): value is PromiseLike<unknown> {
   return !!value && typeof (value as PromiseLike<unknown>).then === 'function'
+}
+
+function shouldCloseOnSyncResult(result: unknown) {
+  return result !== false
 }
 
 const RenderContent = defineComponent({
@@ -186,7 +190,7 @@ async function onOk() {
 
   const result = action()
   if (!isThenable(result)) {
-    if (!result) {
+    if (shouldCloseOnSyncResult(result)) {
       close()
     }
     return
@@ -218,7 +222,7 @@ async function handleCancel(event?: MouseEvent | KeyboardEvent) {
   try {
     const result = event === undefined ? action() : action(event)
     if (!isThenable(result)) {
-      if (!result) {
+      if (shouldCloseOnSyncResult(result)) {
         close()
       }
       return

--- a/packages/ui/src/components/modal/ConfirmDialog.vue
+++ b/packages/ui/src/components/modal/ConfirmDialog.vue
@@ -63,12 +63,12 @@ import {
 import Button from '../button'
 import Modal from './Modal.vue'
 import type {
-  ModalButtonType,
   ModalFuncConfigUpdate,
   ModalFuncProps,
   ModalRenderContent,
   ModalType,
 } from './types'
+import { resolveOkTypeProps } from './types'
 
 defineOptions({ name: 'AConfirmDialog' })
 
@@ -87,13 +87,6 @@ const cancelLoading = ref(false)
 const okBtnRef = ref<{ focus: () => void } | null>(null)
 const cancelBtnRef = ref<{ focus: () => void } | null>(null)
 const isLoading = computed(() => okLoading.value || cancelLoading.value)
-
-function resolveOkTypeProps(okType?: ModalButtonType) {
-  if (!okType) return {}
-  if (okType === 'danger') return { danger: true }
-  if (okType === 'primary' || okType === 'default') return { type: okType }
-  return { variant: okType }
-}
 
 function renderSomeContent(content?: ModalRenderContent) {
   if (typeof content === 'function') {

--- a/packages/ui/src/components/modal/Modal.vue
+++ b/packages/ui/src/components/modal/Modal.vue
@@ -72,8 +72,8 @@ import { ref, computed, watch, useSlots, useAttrs, onBeforeUnmount, nextTick, ge
 import { CloseOutlined } from '@ant-design/icons-vue'
 import { Portal } from '@/_internal/portal'
 import Button from '../button'
-import type { ModalButtonType, ModalProps, ModalEmits, ModalSlots } from './types'
-import { modalDefaultProps } from './types'
+import type { ModalProps, ModalEmits, ModalSlots } from './types'
+import { modalDefaultProps, resolveOkTypeProps } from './types'
 
 defineOptions({ name: 'AModal', inheritAttrs: false })
 
@@ -166,12 +166,6 @@ const showFooter = computed(() => {
 })
 
 // --- Button attrs ---
-function resolveOkTypeProps(okType?: ModalButtonType) {
-  if (!okType) return {}
-  if (okType === 'danger') return { danger: true }
-  if (okType === 'primary' || okType === 'default') return { type: okType }
-  return { variant: okType }
-}
 
 const okBtnAttrs = computed(() => {
   return {

--- a/packages/ui/src/components/modal/Modal.vue
+++ b/packages/ui/src/components/modal/Modal.vue
@@ -6,8 +6,9 @@
           v-if="shouldRender"
           v-show="mergedOpen"
           ref="modalRef"
+          v-bind="dialogAttrs"
           :class="modalClasses"
-          :style="modalStyle"
+          :style="[attrs.style, modalStyle]"
           role="dialog"
           aria-modal="true"
           :aria-labelledby="titleId"
@@ -42,24 +43,12 @@
           <!-- Footer -->
           <div v-if="showFooter" class="ant-modal-footer">
             <slot name="footer">
-              <button
-                class="ant-btn ant-btn-outlined"
-                v-bind="cancelBtnAttrs"
-                @click="onCancel"
-              >
+              <Button v-bind="cancelBtnAttrs" @click="onCancel">
                 {{ props.cancelText }}
-              </button>
-              <button
-                class="ant-btn ant-btn-solid"
-                v-bind="okBtnAttrs"
-                :disabled="props.confirmLoading"
-                @click="onOk"
-              >
-                <span v-if="props.confirmLoading" class="ant-btn-loading-icon">
-                  <LoadingOutlined />
-                </span>
+              </Button>
+              <Button v-bind="okBtnAttrs" @click="onOk">
                 {{ props.okText }}
-              </button>
+              </Button>
             </slot>
           </div>
         </div>
@@ -69,7 +58,7 @@
     <!-- Mask -->
     <Transition name="ant-fade">
       <div
-        v-if="shouldRender"
+        v-if="shouldRender && props.mask"
         v-show="mergedOpen"
         class="ant-modal-mask"
         :style="maskStyles"
@@ -79,27 +68,26 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, useSlots, onMounted, onBeforeUnmount, nextTick, getCurrentInstance } from 'vue'
-import { CloseOutlined, LoadingOutlined } from '@ant-design/icons-vue'
+import { ref, computed, watch, useSlots, useAttrs, onBeforeUnmount, nextTick, getCurrentInstance } from 'vue'
+import { CloseOutlined } from '@ant-design/icons-vue'
 import { Portal } from '@/_internal/portal'
-import type { ModalProps, ModalEmits, ModalSlots } from './types'
+import Button from '../button'
+import type { ModalButtonType, ModalProps, ModalEmits, ModalSlots } from './types'
 import { modalDefaultProps } from './types'
 
-defineOptions({ name: 'AModal' })
+defineOptions({ name: 'AModal', inheritAttrs: false })
 
 const props = withDefaults(defineProps<ModalProps>(), modalDefaultProps)
 const emit = defineEmits<ModalEmits>()
 defineSlots<ModalSlots>()
 const slots = useSlots()
+const attrs = useAttrs()
 
 const modalRef = ref<HTMLElement | null>(null)
 
-// --- Unique ID for aria-labelledby ---
-let _uid = 0
-const titleId = `ant-modal-title-${++_uid}`
-
 // --- Open state ---
 const instance = getCurrentInstance()!
+const titleId = `ant-modal-title-${instance.uid}`
 const isControlled = computed(() => {
   const rawProps = instance.vnode.props || {}
   return 'open' in rawProps || 'visible' in rawProps
@@ -178,20 +166,26 @@ const showFooter = computed(() => {
 })
 
 // --- Button attrs ---
+function resolveOkTypeProps(okType?: ModalButtonType) {
+  if (!okType) return {}
+  if (okType === 'danger') return { danger: true }
+  if (okType === 'primary' || okType === 'default') return { type: okType }
+  return { variant: okType }
+}
+
 const okBtnAttrs = computed(() => {
-  const attrs: Record<string, any> = {}
-  if (props.okButtonProps) {
-    Object.assign(attrs, props.okButtonProps)
+  return {
+    ...resolveOkTypeProps(props.okType),
+    loading: props.confirmLoading,
+    ...(props.okButtonProps ?? {}),
   }
-  return attrs
 })
 
 const cancelBtnAttrs = computed(() => {
-  const attrs: Record<string, any> = {}
-  if (props.cancelButtonProps) {
-    Object.assign(attrs, props.cancelButtonProps)
+  return {
+    variant: 'outlined' as const,
+    ...(props.cancelButtonProps ?? {}),
   }
-  return attrs
 })
 
 // --- Styles ---
@@ -220,7 +214,12 @@ const modalStyle = computed(() => {
   return style
 })
 
-const modalClasses = computed(() => ['ant-modal'])
+const dialogAttrs = computed(() => {
+  const { class: _class, style: _style, ...rest } = attrs
+  return rest
+})
+
+const modalClasses = computed(() => ['ant-modal', attrs.class])
 
 const maskStyles = computed(() => {
   const style: Record<string, string> = {}

--- a/packages/ui/src/components/modal/Modal.vue
+++ b/packages/ui/src/components/modal/Modal.vue
@@ -176,8 +176,8 @@ function resolveOkTypeProps(okType?: ModalButtonType) {
 const okBtnAttrs = computed(() => {
   return {
     ...resolveOkTypeProps(props.okType),
-    loading: props.confirmLoading,
     ...(props.okButtonProps ?? {}),
+    loading: props.confirmLoading,
   }
 })
 

--- a/packages/ui/src/components/modal/__tests__/index.test.ts
+++ b/packages/ui/src/components/modal/__tests__/index.test.ts
@@ -366,6 +366,65 @@ describe('Modal static methods', () => {
 
     expect(cancelButton?.getAttribute('aria-busy')).toBe('true')
     expect(document.body.querySelector('.ant-btn-loading-icon')).not.toBeNull()
+    expect(document.body.querySelectorAll('.ant-modal-confirm-btns .ant-btn')[1]?.getAttribute('disabled')).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('keeps dialog open when close button cancel promise rejects', async () => {
+    const wrapper = mount(ConfirmDialog, {
+      props: {
+        config: {
+          type: 'confirm',
+          title: 'Reject close',
+          closable: true,
+          onCancel: () => Promise.reject(new Error('reject close')),
+        },
+      },
+    })
+
+    await flushModalTicks()
+
+    const closeButton = document.body.querySelector('.ant-modal-close') as HTMLButtonElement | null
+    expect(closeButton).not.toBeNull()
+
+    closeButton?.click()
+    await flushModalTicks()
+
+    expect(document.body.querySelector('.ant-modal-confirm')).not.toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('blocks cancel while async ok is pending', async () => {
+    const onCancel = vi.fn()
+    const wrapper = mount(ConfirmDialog, {
+      props: {
+        config: {
+          type: 'confirm',
+          title: 'Async ok',
+          onOk: () => new Promise(() => {}),
+          onCancel,
+        },
+      },
+    })
+
+    await flushModalTicks()
+
+    const buttons = document.body.querySelectorAll('.ant-modal-confirm-btns .ant-btn')
+    const okButton = buttons[1] as HTMLButtonElement | undefined
+    const cancelButtonNode = buttons[0] as HTMLButtonElement | undefined
+
+    okButton?.click()
+    await flushModalTicks()
+
+    expect(okButton?.getAttribute('aria-busy')).toBe('true')
+    expect(cancelButtonNode?.getAttribute('disabled')).toBe('')
+
+    cancelButtonNode?.click()
+    await flushModalTicks()
+
+    expect(onCancel).not.toHaveBeenCalled()
 
     wrapper.unmount()
   })

--- a/packages/ui/src/components/modal/__tests__/index.test.ts
+++ b/packages/ui/src/components/modal/__tests__/index.test.ts
@@ -339,6 +339,29 @@ describe('Modal static methods', () => {
     expect(dialog?.querySelector('.ant-modal-confirm-content')).toBeNull()
   })
 
+  it('does not warn when closeIcon or footer is null', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const wrapper = mount(ConfirmDialog, {
+      props: {
+        config: {
+          title: 'No warnings',
+          closeIcon: null,
+          footer: null,
+        },
+      },
+    })
+
+    await flushModalTicks()
+
+    expect(
+      warnSpy.mock.calls.some(([message]) => String(message).includes('Invalid prop')),
+    ).toBe(false)
+
+    wrapper.unmount()
+    warnSpy.mockRestore()
+  })
+
   it('supports function updater for static confirm', async () => {
     const modal = Modal.success({
       title: 'Before update',

--- a/packages/ui/src/components/modal/__tests__/index.test.ts
+++ b/packages/ui/src/components/modal/__tests__/index.test.ts
@@ -325,6 +325,20 @@ describe('Modal static methods', () => {
     expect(buttons?.[1].className).toContain('ant-btn-danger')
   })
 
+  it('hides title and content wrappers when set to null', async () => {
+    Modal.confirm({
+      title: null,
+      content: null,
+      icon: null,
+    })
+
+    await flushModalTicks()
+
+    const dialog = document.body.querySelector('.ant-modal-confirm')
+    expect(dialog?.querySelector('.ant-modal-confirm-title')).toBeNull()
+    expect(dialog?.querySelector('.ant-modal-confirm-content')).toBeNull()
+  })
+
   it('supports function updater for static confirm', async () => {
     const modal = Modal.success({
       title: 'Before update',
@@ -341,6 +355,78 @@ describe('Modal static methods', () => {
     expect(document.body.querySelector('.ant-modal-confirm-content')?.textContent).toContain(
       'new content',
     )
+  })
+
+  it('closes static confirm when sync onOk returns truthy', async () => {
+    Modal.confirm({
+      title: 'Truthy ok',
+      onOk: () => true,
+    })
+
+    await flushModalTicks()
+
+    const okButton = document.body.querySelectorAll('.ant-modal-confirm-btns .ant-btn')[1] as
+      | HTMLButtonElement
+      | undefined
+    okButton?.click()
+    await flushModalTicks()
+
+    expect(document.body.querySelector('.ant-modal-confirm')?.getAttribute('style')).toContain(
+      'display: none',
+    )
+  })
+
+  it('keeps static confirm open when sync onOk returns false', async () => {
+    Modal.confirm({
+      title: 'False ok',
+      onOk: () => false,
+    })
+
+    await flushModalTicks()
+
+    const okButton = document.body.querySelectorAll('.ant-modal-confirm-btns .ant-btn')[1] as
+      | HTMLButtonElement
+      | undefined
+    okButton?.click()
+    await flushModalTicks()
+
+    expect(document.body.querySelector('.ant-modal-confirm')).not.toBeNull()
+  })
+
+  it('closes static confirm when sync onCancel returns truthy', async () => {
+    Modal.confirm({
+      title: 'Truthy cancel',
+      onCancel: () => true,
+    })
+
+    await flushModalTicks()
+
+    const cancelButton = document.body.querySelector('.ant-modal-confirm-btns .ant-btn') as
+      | HTMLButtonElement
+      | null
+    cancelButton?.click()
+    await flushModalTicks()
+
+    expect(document.body.querySelector('.ant-modal-confirm')?.getAttribute('style')).toContain(
+      'display: none',
+    )
+  })
+
+  it('keeps static confirm open when sync onCancel returns false', async () => {
+    Modal.confirm({
+      title: 'False cancel',
+      onCancel: () => false,
+    })
+
+    await flushModalTicks()
+
+    const cancelButton = document.body.querySelector('.ant-modal-confirm-btns .ant-btn') as
+      | HTMLButtonElement
+      | null
+    cancelButton?.click()
+    await flushModalTicks()
+
+    expect(document.body.querySelector('.ant-modal-confirm')).not.toBeNull()
   })
 
   it('shows loading on async cancel', async () => {
@@ -369,6 +455,21 @@ describe('Modal static methods', () => {
     expect(document.body.querySelectorAll('.ant-modal-confirm-btns .ant-btn')[1]?.getAttribute('disabled')).toBe('')
 
     wrapper.unmount()
+  })
+
+  it('keeps confirmLoading as the source of truth for modal ok button loading', () => {
+    const wrapper = mount(Modal, {
+      props: {
+        open: true,
+        confirmLoading: true,
+        okButtonProps: { loading: false },
+      },
+      ...globalStubs,
+    })
+
+    const buttons = wrapper.findAll('.ant-modal-footer button')
+    expect(buttons[1].attributes('aria-busy')).toBe('true')
+    expect(wrapper.find('.ant-btn-loading-icon').exists()).toBe(true)
   })
 
   it('keeps dialog open when close button cancel promise rejects', async () => {

--- a/packages/ui/src/components/modal/__tests__/index.test.ts
+++ b/packages/ui/src/components/modal/__tests__/index.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
-import { Modal } from '@ant-design-vue/ui'
 import { mount } from '@vue/test-utils'
-import { nextTick } from 'vue'
+import { h, nextTick } from 'vue'
+import Modal from '..'
+import ConfirmDialog from '../ConfirmDialog.vue'
 
 // Stub teleport to render content inline for testing
 const globalStubs = {
@@ -11,6 +12,18 @@ const globalStubs = {
     },
   },
 }
+
+async function flushModalTicks() {
+  await nextTick()
+  await nextTick()
+  await nextTick()
+  await nextTick()
+}
+
+afterEach(() => {
+  Modal.destroyAll()
+  document.body.innerHTML = ''
+})
 
 describe('Modal', () => {
   it('should render correctly when open', () => {
@@ -140,13 +153,21 @@ describe('Modal', () => {
     expect(wrapper.find('.ant-modal-mask').exists()).toBe(true)
   })
 
+  it('hides mask when mask is false', () => {
+    const wrapper = mount(Modal, {
+      props: { open: true, mask: false },
+      ...globalStubs,
+    })
+    expect(wrapper.find('.ant-modal-mask').exists()).toBe(false)
+  })
+
   it('shows loading state on OK button', () => {
     const wrapper = mount(Modal, {
       props: { open: true, confirmLoading: true },
       ...globalStubs,
     })
     const buttons = wrapper.findAll('.ant-modal-footer button')
-    expect(buttons[1].attributes('disabled')).toBeDefined()
+    expect(buttons[1].attributes('aria-busy')).toBe('true')
     expect(wrapper.find('.ant-btn-loading-icon').exists()).toBe(true)
   })
 
@@ -167,6 +188,34 @@ describe('Modal', () => {
       ...globalStubs,
     })
     expect(wrapper.find('.custom-title').exists()).toBe(true)
+  })
+
+  it('forwards class and style attrs to the dialog container', () => {
+    const wrapper = mount(Modal, {
+      props: { open: true },
+      attrs: {
+        class: 'custom-modal-class',
+        style: 'max-width: 640px;',
+      },
+      ...globalStubs,
+    })
+    const dialog = wrapper.find('.ant-modal')
+    expect(dialog.classes()).toContain('custom-modal-class')
+    expect(dialog.attributes('style')).toContain('max-width: 640px')
+  })
+
+  it('applies button props to the default footer buttons', () => {
+    const wrapper = mount(Modal, {
+      props: {
+        open: true,
+        okType: 'danger',
+        cancelButtonProps: { danger: true },
+      },
+      ...globalStubs,
+    })
+    const buttons = wrapper.findAll('.ant-modal-footer .ant-btn')
+    expect(buttons[0].classes()).toContain('ant-btn-danger')
+    expect(buttons[1].classes()).toContain('ant-btn-danger')
   })
 
   it('has proper aria attributes', () => {
@@ -219,5 +268,105 @@ describe('Modal static methods', () => {
 
   it('has destroyAll method', () => {
     expect(typeof Modal.destroyAll).toBe('function')
+  })
+
+  it('renders static confirm vnode content', async () => {
+    Modal.confirm({
+      title: h('span', { class: 'confirm-title-node' }, 'VNode title'),
+      content: h('div', { class: 'confirm-content-node' }, 'VNode content'),
+    })
+
+    await flushModalTicks()
+
+    expect(document.body.querySelector('.confirm-title-node')?.textContent).toBe('VNode title')
+    expect(document.body.querySelector('.confirm-content-node')?.textContent).toBe('VNode content')
+  })
+
+  it('passes getContainer, wrapClassName and mask to ConfirmDialog', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const wrapper = mount(ConfirmDialog, {
+      props: {
+        config: {
+          title: h('span', { class: 'confirm-title-node' }, 'VNode title'),
+          content: h('div', { class: 'confirm-content-node' }, 'VNode content'),
+          getContainer: () => container,
+          wrapClassName: 'custom-confirm-wrap',
+          mask: false,
+        },
+      },
+    })
+
+    await flushModalTicks()
+
+    expect(container.querySelector('.confirm-title-node')?.textContent).toBe('VNode title')
+    expect(container.querySelector('.confirm-content-node')?.textContent).toBe('VNode content')
+    expect(container.querySelector('.custom-confirm-wrap')).not.toBeNull()
+    expect(container.querySelector('.ant-modal-mask')).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('supports icon null and danger okType for static confirm', async () => {
+    Modal.confirm({
+      title: 'Delete this task?',
+      icon: null,
+      okType: 'danger',
+    })
+
+    await flushModalTicks()
+
+    const dialog = document.body.querySelector('.ant-modal-confirm')
+    expect(dialog?.querySelector('.ant-modal-confirm-icon')).toBeNull()
+
+    const buttons = dialog?.querySelectorAll('.ant-modal-confirm-btns .ant-btn')
+    expect(buttons).toHaveLength(2)
+    expect(buttons?.[1].className).toContain('ant-btn-danger')
+  })
+
+  it('supports function updater for static confirm', async () => {
+    const modal = Modal.success({
+      title: 'Before update',
+      content: 'old content',
+    })
+
+    modal.update((prev) => ({
+      ...prev,
+      content: 'new content',
+    }))
+
+    await flushModalTicks()
+
+    expect(document.body.querySelector('.ant-modal-confirm-content')?.textContent).toContain(
+      'new content',
+    )
+  })
+
+  it('shows loading on async cancel', async () => {
+    const wrapper = mount(ConfirmDialog, {
+      props: {
+        config: {
+          type: 'confirm',
+          title: 'Async cancel',
+          onCancel: () => new Promise(() => {}),
+        },
+      },
+    })
+
+    await flushModalTicks()
+
+    const cancelButton = document.body.querySelector('.ant-modal-confirm-btns .ant-btn') as
+      | HTMLButtonElement
+      | null
+    expect(cancelButton).not.toBeNull()
+
+    cancelButton?.click()
+    await flushModalTicks()
+
+    expect(cancelButton?.getAttribute('aria-busy')).toBe('true')
+    expect(document.body.querySelector('.ant-btn-loading-icon')).not.toBeNull()
+
+    wrapper.unmount()
   })
 })

--- a/packages/ui/src/components/modal/confirm.ts
+++ b/packages/ui/src/components/modal/confirm.ts
@@ -1,27 +1,43 @@
-import { createApp, ref, h, type App } from 'vue'
+import { createApp, shallowRef, h, type App } from 'vue'
 import ConfirmDialog from './ConfirmDialog.vue'
-import type { ModalFuncProps, ModalFuncReturn, ModalType } from './types'
+import type { ModalFuncConfigUpdate, ModalFuncProps, ModalFuncReturn, ModalType } from './types'
 
 const openDialogs: Array<{ app: App; destroy: () => void }> = []
+type ConfirmDialogInstance = {
+  close: () => void
+  update: (newConfig: Partial<ModalFuncProps>) => void
+}
 
 export function confirm(config: ModalFuncProps): ModalFuncReturn {
   const container = document.createElement('div')
   document.body.appendChild(container)
 
-  const configRef = ref({ ...config })
+  const configRef = shallowRef({ ...config })
 
-  let dialogInstance: any = null
+  let dialogInstance: ConfirmDialogInstance | null = null
+  let cleanedUp = false
+  let closing = false
+
+  function cleanup() {
+    if (cleanedUp) return
+    cleanedUp = true
+    dialogInstance = null
+    app.unmount()
+    if (container.parentNode) {
+      container.parentNode.removeChild(container)
+    }
+    const idx = openDialogs.indexOf(entry)
+    if (idx > -1) openDialogs.splice(idx, 1)
+  }
 
   const app = createApp({
     setup() {
       return () =>
         h(ConfirmDialog, {
           config: configRef.value,
-          onDestroy: () => {
-            destroy()
-          },
-          ref: (el: any) => {
-            dialogInstance = el
+          onDestroy: cleanup,
+          ref: (el) => {
+            dialogInstance = el as unknown as ConfirmDialogInstance | null
           },
         })
     },
@@ -34,16 +50,20 @@ export function confirm(config: ModalFuncProps): ModalFuncReturn {
   openDialogs.push(entry)
 
   function destroy() {
-    app.unmount()
-    if (container.parentNode) {
-      container.parentNode.removeChild(container)
+    if (cleanedUp || closing) return
+    if (dialogInstance) {
+      closing = true
+      dialogInstance.close()
+      return
     }
-    const idx = openDialogs.indexOf(entry)
-    if (idx > -1) openDialogs.splice(idx, 1)
+    cleanup()
   }
 
-  function update(newConfig: Partial<ModalFuncProps>) {
-    configRef.value = { ...configRef.value, ...newConfig }
+  function update(newConfig: ModalFuncConfigUpdate) {
+    configRef.value =
+      typeof newConfig === 'function'
+        ? newConfig(configRef.value)
+        : { ...configRef.value, ...newConfig }
   }
 
   return { destroy, update }

--- a/packages/ui/src/components/modal/confirm.ts
+++ b/packages/ui/src/components/modal/confirm.ts
@@ -1,12 +1,8 @@
 import { createApp, shallowRef, h, type App } from 'vue'
 import ConfirmDialog from './ConfirmDialog.vue'
-import type { ModalFuncConfigUpdate, ModalFuncProps, ModalFuncReturn, ModalType } from './types'
+import type { ConfirmDialogInstance, ModalFuncConfigUpdate, ModalFuncProps, ModalFuncReturn, ModalType } from './types'
 
 const openDialogs: Array<{ app: App; destroy: () => void }> = []
-type ConfirmDialogInstance = {
-  close: () => void
-  update: (newConfig: ModalFuncConfigUpdate) => void
-}
 
 export function confirm(config: ModalFuncProps): ModalFuncReturn {
   const container = document.createElement('div')

--- a/packages/ui/src/components/modal/confirm.ts
+++ b/packages/ui/src/components/modal/confirm.ts
@@ -5,7 +5,7 @@ import type { ModalFuncConfigUpdate, ModalFuncProps, ModalFuncReturn, ModalType 
 const openDialogs: Array<{ app: App; destroy: () => void }> = []
 type ConfirmDialogInstance = {
   close: () => void
-  update: (newConfig: Partial<ModalFuncProps>) => void
+  update: (newConfig: ModalFuncConfigUpdate) => void
 }
 
 export function confirm(config: ModalFuncProps): ModalFuncReturn {

--- a/packages/ui/src/components/modal/style/index.css
+++ b/packages/ui/src/components/modal/style/index.css
@@ -114,15 +114,15 @@
 
 :where(.ant-modal-confirm-body) {
   display: flex;
-  align-items: flex-start;
-  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
 }
 
 :where(.ant-modal-confirm-icon) {
   font-size: 22px;
   line-height: 1;
-  flex-shrink: 0;
-  margin-top: 1px;
+  flex: none;
+  margin-inline-end: 12px;
 }
 
 :where(.ant-modal-confirm-info) .ant-modal-confirm-icon {
@@ -147,6 +147,12 @@
   font-weight: 600;
   line-height: 1.5;
   color: var(--color-neutral);
+  display: block;
+  flex: 0 0 100%;
+  overflow: hidden;
+}
+
+:where(.ant-modal-confirm-icon + .ant-modal-confirm-title) {
   flex: 1;
 }
 
@@ -155,6 +161,13 @@
   font-size: var(--ant-font-size);
   color: var(--color-neutral-secondary);
   line-height: var(--ant-line-height);
+  flex-basis: 100%;
+  max-width: 100%;
+}
+
+:where(.ant-modal-confirm-icon + .ant-modal-confirm-title + .ant-modal-confirm-content) {
+  margin-inline-start: 34px;
+  max-width: calc(100% - 34px);
 }
 
 :where(.ant-modal-confirm-btns) {

--- a/packages/ui/src/components/modal/types.ts
+++ b/packages/ui/src/components/modal/types.ts
@@ -132,3 +132,15 @@ export interface ModalFuncReturn {
   destroy: () => void
   update: (newConfig: ModalFuncConfigUpdate) => void
 }
+
+export interface ConfirmDialogInstance {
+  close: () => void
+  update: (newConfig: ModalFuncConfigUpdate) => void
+}
+
+export function resolveOkTypeProps(okType?: ModalButtonType): Record<string, unknown> {
+  if (!okType) return {}
+  if (okType === 'danger') return { danger: true }
+  if (okType === 'primary' || okType === 'default') return { type: okType }
+  return { variant: okType }
+}

--- a/packages/ui/src/components/modal/types.ts
+++ b/packages/ui/src/components/modal/types.ts
@@ -1,8 +1,13 @@
-import type { CSSProperties, VNode } from 'vue'
-import type { Slot, ScopedSlot } from '@/utils/types'
+import type { CSSProperties } from 'vue'
+import type { Slot, SlotReturnType } from '@/utils/types'
 import type { ButtonProps } from '../button/types'
 
 export type ModalType = 'info' | 'success' | 'error' | 'warning' | 'confirm'
+export type ModalButtonType =
+  | NonNullable<ButtonProps['variant']>
+  | NonNullable<ButtonProps['type']>
+  | 'danger'
+export type ModalRenderContent = SlotReturnType | (() => SlotReturnType)
 
 export interface ModalProps {
   /** Whether the modal is visible (v-model:open) */
@@ -34,7 +39,7 @@ export interface ModalProps {
   /** Cancel button text */
   cancelText?: string
   /** OK button type */
-  okType?: ButtonProps['variant']
+  okType?: ModalButtonType
   /** OK button props */
   okButtonProps?: Partial<ButtonProps>
   /** Cancel button props */
@@ -90,12 +95,12 @@ export interface ModalSlots {
 
 export interface ModalFuncProps {
   type?: ModalType
-  title?: string | (() => VNode)
-  content?: string | (() => VNode)
-  icon?: VNode | (() => VNode)
+  title?: ModalRenderContent
+  content?: ModalRenderContent
+  icon?: ModalRenderContent
   okText?: string
   cancelText?: string
-  okType?: ButtonProps['variant']
+  okType?: ModalButtonType
   okButtonProps?: Partial<ButtonProps>
   cancelButtonProps?: Partial<ButtonProps>
   onOk?: (...args: any[]) => any | Promise<any>
@@ -107,13 +112,23 @@ export interface ModalFuncProps {
   maskClosable?: boolean
   keyboard?: boolean
   zIndex?: number
+  bodyStyle?: CSSProperties
+  maskStyle?: CSSProperties
+  getContainer?: () => HTMLElement
+  closable?: boolean
   class?: string
   wrapClassName?: string
+  footer?: ModalRenderContent
+  closeIcon?: ModalRenderContent
   autoFocusButton?: 'ok' | 'cancel' | null
   okCancel?: boolean
 }
 
+export type ModalFuncConfigUpdate =
+  | Partial<ModalFuncProps>
+  | ((prevConfig: ModalFuncProps) => ModalFuncProps)
+
 export interface ModalFuncReturn {
   destroy: () => void
-  update: (newConfig: Partial<ModalFuncProps>) => void
+  update: (newConfig: ModalFuncConfigUpdate) => void
 }

--- a/packages/ui/src/components/modal/useModal.ts
+++ b/packages/ui/src/components/modal/useModal.ts
@@ -1,11 +1,6 @@
 import { defineComponent, shallowRef, h, shallowReactive } from 'vue'
 import ConfirmDialog from './ConfirmDialog.vue'
-import type { ModalFuncConfigUpdate, ModalFuncProps, ModalFuncReturn, ModalType } from './types'
-
-type ConfirmDialogInstance = {
-  close: () => void
-  update: (newConfig: ModalFuncConfigUpdate) => void
-}
+import type { ConfirmDialogInstance, ModalFuncConfigUpdate, ModalFuncProps, ModalFuncReturn, ModalType } from './types'
 
 interface ModalEntry {
   key: number

--- a/packages/ui/src/components/modal/useModal.ts
+++ b/packages/ui/src/components/modal/useModal.ts
@@ -4,7 +4,7 @@ import type { ModalFuncConfigUpdate, ModalFuncProps, ModalFuncReturn, ModalType 
 
 type ConfirmDialogInstance = {
   close: () => void
-  update: (newConfig: Partial<ModalFuncProps>) => void
+  update: (newConfig: ModalFuncConfigUpdate) => void
 }
 
 interface ModalEntry {

--- a/packages/ui/src/components/modal/useModal.ts
+++ b/packages/ui/src/components/modal/useModal.ts
@@ -1,11 +1,16 @@
-import { defineComponent, ref, h, shallowReactive } from 'vue'
+import { defineComponent, shallowRef, h, shallowReactive } from 'vue'
 import ConfirmDialog from './ConfirmDialog.vue'
-import type { ModalFuncProps, ModalFuncReturn, ModalType } from './types'
+import type { ModalFuncConfigUpdate, ModalFuncProps, ModalFuncReturn, ModalType } from './types'
+
+type ConfirmDialogInstance = {
+  close: () => void
+  update: (newConfig: Partial<ModalFuncProps>) => void
+}
 
 interface ModalEntry {
   key: number
   config: ModalFuncProps
-  resolve: (() => void) | null
+  instance: ConfirmDialogInstance | null
 }
 
 export function useModal(): [
@@ -21,19 +26,30 @@ export function useModal(): [
   let nextKey = 0
   const entries = shallowReactive<ModalEntry[]>([])
 
+  function removeEntry(entry: ModalEntry) {
+    const idx = entries.indexOf(entry)
+    if (idx > -1) entries.splice(idx, 1)
+  }
+
   function open(config: ModalFuncProps): ModalFuncReturn {
     const key = nextKey++
-    const configRef = ref({ ...config })
-    const entry: ModalEntry = { key, config: configRef.value, resolve: null }
+    const configRef = shallowRef({ ...config })
+    const entry: ModalEntry = { key, config: configRef.value, instance: null }
     entries.push(entry)
 
     function destroy() {
-      const idx = entries.indexOf(entry)
-      if (idx > -1) entries.splice(idx, 1)
+      if (entry.instance) {
+        entry.instance.close()
+        return
+      }
+      removeEntry(entry)
     }
 
-    function update(newConfig: Partial<ModalFuncProps>) {
-      Object.assign(configRef.value, newConfig)
+    function update(newConfig: ModalFuncConfigUpdate) {
+      configRef.value =
+        typeof newConfig === 'function'
+          ? newConfig(configRef.value)
+          : { ...configRef.value, ...newConfig }
       entry.config = { ...configRef.value }
       // Trigger reactivity
       const idx = entries.indexOf(entry)
@@ -67,9 +83,11 @@ export function useModal(): [
           h(ConfirmDialog, {
             key: entry.key,
             config: entry.config,
+            ref: (el) => {
+              entry.instance = el as unknown as ConfirmDialogInstance | null
+            },
             onDestroy: () => {
-              const idx = entries.indexOf(entry)
-              if (idx > -1) entries.splice(idx, 1)
+              removeEntry(entry)
             },
           }),
         )


### PR DESCRIPTION
## Summary

- Align the packages/ui modal confirm flow with legacy behavior by reusing Modal inside ConfirmDialog.
- Preserve VNode title, content, and icon rendering for static confirm and useModal flows.
- Restore getContainer, mask, wrap class, close lifecycle, and function-based update behavior.
- Sync async OK and Cancel loading states to prevent repeated actions while promises are pending.
- Add regression coverage for static confirm, custom containers, function updaters, and async cancel flows.

## Testing

- packages/ui modal index tests
- packages/ui modal demo tests
- packages/ui app integration tests

## Result

- 50 related tests passed

Related: #8497 