### PR TITLE
fix(result): restore compatibility and a11y

### DIFF
--- a/packages/ui/src/components/result/Result.vue
+++ b/packages/ui/src/components/result/Result.vue
@@ -62,7 +62,7 @@ const iconClasses = computed(() => ({
 </script>
 
 <template>
-  <div :class="classes">
+  <div :class="classes" role="status">
     <div :class="iconClasses" aria-hidden="true">
       <template v-if="hasCustomIcon">
         <component :is="props.icon" v-if="typeof props.icon === 'function'" />

--- a/packages/ui/src/components/result/Result.vue
+++ b/packages/ui/src/components/result/Result.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, useSlots } from 'vue'
+import { computed, isVNode, useSlots, type Component } from 'vue'
 import type { ResultProps, ResultSlots } from './types'
 import { resultDefaultProps } from './types'
 import SuccessIcon from './icons/SuccessIcon.vue'
@@ -15,7 +15,9 @@ const props = withDefaults(defineProps<ResultProps>(), resultDefaultProps)
 defineSlots<ResultSlots>()
 const slots = useSlots()
 
-const iconComponents: Record<string, any> = {
+const exceptionStatuses = new Set(['403', '404', '500'])
+
+const iconComponents: Record<string, Component> = {
   success: SuccessIcon,
   error: ErrorIcon,
   info: InfoIcon,
@@ -25,9 +27,12 @@ const iconComponents: Record<string, any> = {
   500: ServerErrorIcon,
 }
 
-const iconComponent = computed(() => {
+const defaultIconComponent = computed(() => {
   return iconComponents[String(props.status)] || InfoIcon
 })
+
+const hasCustomIcon = computed(() => !!props.icon)
+const isExceptionStatus = computed(() => exceptionStatuses.has(String(props.status)))
 
 const statusClass = computed(() => {
   return `ant-result-${props.status}`
@@ -39,29 +44,57 @@ const classes = computed(() => ({
 }))
 
 const hasTitle = computed(() => {
-  return !!props.title || !!slots.title
+  return props.title !== undefined || !!slots.title
 })
 
 const hasSubTitle = computed(() => {
-  return !!props.subTitle || !!slots.subTitle
+  return props.subTitle !== undefined || !!slots.subTitle
 })
+
+const hasExtra = computed(() => {
+  return !!props.extra || !!slots.extra
+})
+
+const iconClasses = computed(() => ({
+  'ant-result-icon': true,
+  'ant-result-image': isExceptionStatus.value,
+}))
 </script>
 
 <template>
-  <div :class="classes" role="status">
-    <div class="ant-result-icon" aria-hidden="true">
-      <slot name="icon">
-        <component :is="iconComponent" />
+  <div :class="classes">
+    <div :class="iconClasses" aria-hidden="true">
+      <template v-if="hasCustomIcon">
+        <component :is="props.icon" v-if="typeof props.icon === 'function'" />
+        <component :is="props.icon" v-else-if="isVNode(props.icon)" />
+      </template>
+      <slot v-else name="icon">
+        <component :is="defaultIconComponent" />
       </slot>
     </div>
     <div v-if="hasTitle" class="ant-result-title">
-      <slot name="title">{{ title }}</slot>
+      <template v-if="props.title !== undefined">
+        <component :is="props.title" v-if="typeof props.title === 'function'" />
+        <component :is="props.title" v-else-if="isVNode(props.title)" />
+        <template v-else>{{ props.title }}</template>
+      </template>
+      <slot v-else name="title" />
     </div>
     <div v-if="hasSubTitle" class="ant-result-subtitle">
-      <slot name="subTitle">{{ subTitle }}</slot>
+      <template v-if="props.subTitle !== undefined">
+        <component :is="props.subTitle" v-if="typeof props.subTitle === 'function'" />
+        <component :is="props.subTitle" v-else-if="isVNode(props.subTitle)" />
+        <template v-else>{{ props.subTitle }}</template>
+      </template>
+      <slot v-else name="subTitle" />
     </div>
-    <div v-if="$slots.extra" class="ant-result-extra">
-      <slot name="extra" />
+    <div v-if="hasExtra" class="ant-result-extra">
+      <template v-if="props.extra">
+        <component :is="props.extra" v-if="typeof props.extra === 'function'" />
+        <component :is="props.extra" v-else-if="isVNode(props.extra)" />
+        <template v-else>{{ props.extra }}</template>
+      </template>
+      <slot v-else name="extra" />
     </div>
     <div v-if="$slots.default" class="ant-result-content">
       <slot />

--- a/packages/ui/src/components/result/__tests__/__snapshots__/demo.test.ts.snap
+++ b/packages/ui/src/components/result/__tests__/__snapshots__/demo.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Result demos > demo: Basic 1`] = `
-"<div class="ant-result ant-result-success">
+"<div class="ant-result ant-result-success" role="status">
   <div class="ant-result-icon" aria-hidden="true"><svg viewBox="64 64 896 896" width="1em" height="1em" fill="currentColor">
       <path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"></path>
     </svg></div>
@@ -19,11 +19,11 @@ exports[`Result demos > demo: Basic 1`] = `
 `;
 
 exports[`Result demos > demo: CustomIcon 1`] = `
-"<div class="ant-result ant-result-info">
-  <div class="ant-result-icon" aria-hidden="true"><span class="ant-result-demo-custom-icon" aria-hidden="true">OK</span></div>
+"<div data-v-05e05b52="" class="ant-result ant-result-info" role="status">
+  <div class="ant-result-icon" aria-hidden="true"><span data-v-05e05b52="" class="ant-result-demo-custom-icon" aria-hidden="true">OK</span></div>
   <div class="ant-result-title">Great, we have done all the operations!</div>
   <!--v-if-->
-  <div class="ant-result-extra"><button class="ant-btn ant-btn-solid ant-btn-md" type="button">
+  <div class="ant-result-extra"><button data-v-05e05b52="" class="ant-btn ant-btn-solid ant-btn-md" type="button">
       <!--v-if-->
       <!--v-if--><span class="ant-btn-content">Next</span>
     </button></div>
@@ -32,31 +32,31 @@ exports[`Result demos > demo: CustomIcon 1`] = `
 `;
 
 exports[`Result demos > demo: Error 1`] = `
-"<div class="ant-result ant-result-error">
+"<div data-v-0a752da5="" class="ant-result ant-result-error" role="status">
   <div class="ant-result-icon" aria-hidden="true"><svg viewBox="64 64 896 896" width="1em" height="1em" fill="currentColor">
       <path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"></path>
     </svg></div>
   <div class="ant-result-title">Submission Failed</div>
   <div class="ant-result-subtitle">Please check and modify the following information before resubmitting.</div>
-  <div class="ant-result-extra"><button class="ant-btn ant-btn-solid ant-btn-md" type="button">
+  <div class="ant-result-extra"><button data-v-0a752da5="" class="ant-btn ant-btn-solid ant-btn-md" type="button">
       <!--v-if-->
       <!--v-if--><span class="ant-btn-content">Go Console</span>
-    </button><button class="ant-btn ant-btn-solid ant-btn-md" type="button">
+    </button><button data-v-0a752da5="" class="ant-btn ant-btn-solid ant-btn-md" type="button">
       <!--v-if-->
       <!--v-if--><span class="ant-btn-content">Buy Again</span>
     </button></div>
   <div class="ant-result-content">
-    <div class="desc">
-      <p class="ant-result-demo-error-heading"><strong>The content you submitted has the following error:</strong></p>
-      <p class="ant-result-demo-error-item"><span class="ant-result-demo-error-icon" aria-hidden="true">!</span> Your account has been frozen <a class="ant-result-demo-link" href="https://www.antdv.com/" target="_blank" rel="noreferrer"> Thaw immediately &gt; </a></p>
-      <p class="ant-result-demo-error-item"><span class="ant-result-demo-error-icon" aria-hidden="true">!</span> Your account is not yet eligible to apply <a class="ant-result-demo-link" href="https://www.antdv.com/" target="_blank" rel="noreferrer"> Apply Unlock &gt; </a></p>
+    <div data-v-0a752da5="" class="desc">
+      <p data-v-0a752da5="" class="ant-result-demo-error-heading"><strong data-v-0a752da5="">The content you submitted has the following error:</strong></p>
+      <p data-v-0a752da5="" class="ant-result-demo-error-item"><span data-v-0a752da5="" class="ant-result-demo-error-icon" aria-hidden="true">!</span> Your account has been frozen <a data-v-0a752da5="" class="ant-result-demo-link" href="https://www.antdv.com/" target="_blank" rel="noreferrer"> Thaw immediately &gt; </a></p>
+      <p data-v-0a752da5="" class="ant-result-demo-error-item"><span data-v-0a752da5="" class="ant-result-demo-error-icon" aria-hidden="true">!</span> Your account is not yet eligible to apply <a data-v-0a752da5="" class="ant-result-demo-link" href="https://www.antdv.com/" target="_blank" rel="noreferrer"> Apply Unlock &gt; </a></p>
     </div>
   </div>
 </div>"
 `;
 
 exports[`Result demos > demo: Forbidden 1`] = `
-"<div class="ant-result ant-result-403">
+"<div class="ant-result ant-result-403" role="status">
   <div class="ant-result-icon ant-result-image" aria-hidden="true"><svg viewBox="0 0 251 294" width="250" height="294">
       <!-- 403 Unauthorized illustration -->
       <g fill="none" fill-rule="evenodd">
@@ -81,7 +81,7 @@ exports[`Result demos > demo: Forbidden 1`] = `
 `;
 
 exports[`Result demos > demo: Info 1`] = `
-"<div class="ant-result ant-result-info">
+"<div class="ant-result ant-result-info" role="status">
   <div class="ant-result-icon" aria-hidden="true"><svg viewBox="64 64 896 896" width="1em" height="1em" fill="currentColor">
       <path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm32 664c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V456c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272zm-32-344a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"></path>
     </svg></div>
@@ -96,7 +96,7 @@ exports[`Result demos > demo: Info 1`] = `
 `;
 
 exports[`Result demos > demo: NotFound 1`] = `
-"<div class="ant-result ant-result-404">
+"<div class="ant-result ant-result-404" role="status">
   <div class="ant-result-icon ant-result-image" aria-hidden="true"><svg viewBox="0 0 252 294" width="250" height="294">
       <!-- 404 Not Found illustration -->
       <g fill="none" fill-rule="evenodd">
@@ -124,7 +124,7 @@ exports[`Result demos > demo: NotFound 1`] = `
 `;
 
 exports[`Result demos > demo: ServerError 1`] = `
-"<div class="ant-result ant-result-500">
+"<div class="ant-result ant-result-500" role="status">
   <div class="ant-result-icon ant-result-image" aria-hidden="true"><svg viewBox="0 0 252 294" width="250" height="294">
       <!-- 500 Server Error illustration -->
       <g fill="none" fill-rule="evenodd">
@@ -161,7 +161,7 @@ exports[`Result demos > demo: ServerError 1`] = `
 `;
 
 exports[`Result demos > demo: Success 1`] = `
-"<div class="ant-result ant-result-success">
+"<div class="ant-result ant-result-success" role="status">
   <div class="ant-result-icon" aria-hidden="true"><svg viewBox="64 64 896 896" width="1em" height="1em" fill="currentColor">
       <path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"></path>
     </svg></div>
@@ -179,7 +179,7 @@ exports[`Result demos > demo: Success 1`] = `
 `;
 
 exports[`Result demos > demo: Warning 1`] = `
-"<div class="ant-result ant-result-warning">
+"<div class="ant-result ant-result-warning" role="status">
   <div class="ant-result-icon" aria-hidden="true"><svg viewBox="64 64 896 896" width="1em" height="1em" fill="currentColor">
       <path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"></path>
     </svg></div>

--- a/packages/ui/src/components/result/__tests__/__snapshots__/demo.test.ts.snap
+++ b/packages/ui/src/components/result/__tests__/__snapshots__/demo.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Result demos > demo: Basic 1`] = `
-"<div class="ant-result ant-result-success" role="status">
+"<div class="ant-result ant-result-success">
   <div class="ant-result-icon" aria-hidden="true"><svg viewBox="64 64 896 896" width="1em" height="1em" fill="currentColor">
       <path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"></path>
     </svg></div>
@@ -19,8 +19,8 @@ exports[`Result demos > demo: Basic 1`] = `
 `;
 
 exports[`Result demos > demo: CustomIcon 1`] = `
-"<div class="ant-result ant-result-info" role="status">
-  <div class="ant-result-icon" aria-hidden="true"><span role="img" aria-label="smile" class="anticon anticon-smile"><svg focusable="false" class="" data-icon="smile" width="1em" height="1em" fill="currentColor" aria-hidden="true" viewBox="64 64 896 896"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z" fill="#1890ff"></path><path d="M512 140c-205.4 0-372 166.6-372 372s166.6 372 372 372 372-166.6 372-372-166.6-372-372-372zM288 421a48.01 48.01 0 0196 0 48.01 48.01 0 01-96 0zm224 272c-85.5 0-155.6-67.3-160-151.6a8 8 0 018-8.4h48.1c4.2 0 7.8 3.2 8.1 7.4C420 589.9 461.5 629 512 629s92.1-39.1 95.8-88.6c.3-4.2 3.9-7.4 8.1-7.4H664a8 8 0 018 8.4C667.6 625.7 597.5 693 512 693zm176-224a48.01 48.01 0 010-96 48.01 48.01 0 010 96z" fill="#e6f7ff"></path><path d="M288 421a48 48 0 1096 0 48 48 0 10-96 0zm376 112h-48.1c-4.2 0-7.8 3.2-8.1 7.4-3.7 49.5-45.3 88.6-95.8 88.6s-92-39.1-95.8-88.6c-.3-4.2-3.9-7.4-8.1-7.4H360a8 8 0 00-8 8.4c4.4 84.3 74.5 151.6 160 151.6s155.6-67.3 160-151.6a8 8 0 00-8-8.4zm-24-112a48 48 0 1096 0 48 48 0 10-96 0z" fill="#1890ff"></path></svg></span></div>
+"<div class="ant-result ant-result-info">
+  <div class="ant-result-icon" aria-hidden="true"><span class="ant-result-demo-custom-icon" aria-hidden="true">OK</span></div>
   <div class="ant-result-title">Great, we have done all the operations!</div>
   <!--v-if-->
   <div class="ant-result-extra"><button class="ant-btn ant-btn-solid ant-btn-md" type="button">
@@ -32,32 +32,32 @@ exports[`Result demos > demo: CustomIcon 1`] = `
 `;
 
 exports[`Result demos > demo: Error 1`] = `
-"<div data-v-0a752da5="" class="ant-result ant-result-error" role="status">
+"<div class="ant-result ant-result-error">
   <div class="ant-result-icon" aria-hidden="true"><svg viewBox="64 64 896 896" width="1em" height="1em" fill="currentColor">
       <path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm165.4 618.2l-66-.3L512 563.4l-99.3 118.4-66.1.3c-4.4 0-8-3.5-8-8 0-1.9.7-3.7 1.9-5.2l130.1-155L340.5 359a8.32 8.32 0 01-1.9-5.2c0-4.4 3.6-8 8-8l66.1.3L512 464.6l99.3-118.4 66-.3c4.4 0 8 3.5 8 8 0 1.9-.7 3.7-1.9 5.2L553.5 514l130 155c1.2 1.5 1.9 3.3 1.9 5.2 0 4.4-3.6 8-8 8z"></path>
     </svg></div>
   <div class="ant-result-title">Submission Failed</div>
   <div class="ant-result-subtitle">Please check and modify the following information before resubmitting.</div>
-  <div class="ant-result-extra"><button data-v-0a752da5="" class="ant-btn ant-btn-solid ant-btn-md" type="button">
+  <div class="ant-result-extra"><button class="ant-btn ant-btn-solid ant-btn-md" type="button">
       <!--v-if-->
       <!--v-if--><span class="ant-btn-content">Go Console</span>
-    </button><button data-v-0a752da5="" class="ant-btn ant-btn-solid ant-btn-md" type="button">
+    </button><button class="ant-btn ant-btn-solid ant-btn-md" type="button">
       <!--v-if-->
       <!--v-if--><span class="ant-btn-content">Buy Again</span>
     </button></div>
   <div class="ant-result-content">
-    <div data-v-0a752da5="" class="desc">
-      <p data-v-0a752da5="" style="font-size: 16px;"><strong data-v-0a752da5="">The content you submitted has the following error:</strong></p>
-      <p data-v-0a752da5=""><span data-v-0a752da5="" role="img" aria-label="close-circle" style="color: red;" class="anticon anticon-close-circle"><svg focusable="false" class="" data-icon="close-circle" width="1em" height="1em" fill="currentColor" aria-hidden="true" fill-rule="evenodd" viewBox="64 64 896 896"><path d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm0 76c-205.4 0-372 166.6-372 372s166.6 372 372 372 372-166.6 372-372-166.6-372-372-372zm128.01 198.83c.03 0 .05.01.09.06l45.02 45.01a.2.2 0 01.05.09.12.12 0 010 .07c0 .02-.01.04-.05.08L557.25 512l127.87 127.86a.27.27 0 01.05.06v.02a.12.12 0 010 .07c0 .03-.01.05-.05.09l-45.02 45.02a.2.2 0 01-.09.05.12.12 0 01-.07 0c-.02 0-.04-.01-.08-.05L512 557.25 384.14 685.12c-.04.04-.06.05-.08.05a.12.12 0 01-.07 0c-.03 0-.05-.01-.09-.05l-45.02-45.02a.2.2 0 01-.05-.09.12.12 0 010-.07c0-.02.01-.04.06-.08L466.75 512 338.88 384.14a.27.27 0 01-.05-.06l-.01-.02a.12.12 0 010-.07c0-.03.01-.05.05-.09l45.02-45.02a.2.2 0 01.09-.05.12.12 0 01.07 0c.02 0 .04.01.08.06L512 466.75l127.86-127.86c.04-.05.06-.06.08-.06a.12.12 0 01.07 0z"></path></svg></span> Your account has been frozen <a data-v-0a752da5="">Thaw immediately &gt;</a></p>
-      <p data-v-0a752da5=""><span data-v-0a752da5="" role="img" aria-label="close-circle" style="color: red;" class="anticon anticon-close-circle"><svg focusable="false" class="" data-icon="close-circle" width="1em" height="1em" fill="currentColor" aria-hidden="true" fill-rule="evenodd" viewBox="64 64 896 896"><path d="M512 64c247.4 0 448 200.6 448 448S759.4 960 512 960 64 759.4 64 512 264.6 64 512 64zm0 76c-205.4 0-372 166.6-372 372s166.6 372 372 372 372-166.6 372-372-166.6-372-372-372zm128.01 198.83c.03 0 .05.01.09.06l45.02 45.01a.2.2 0 01.05.09.12.12 0 010 .07c0 .02-.01.04-.05.08L557.25 512l127.87 127.86a.27.27 0 01.05.06v.02a.12.12 0 010 .07c0 .03-.01.05-.05.09l-45.02 45.02a.2.2 0 01-.09.05.12.12 0 01-.07 0c-.02 0-.04-.01-.08-.05L512 557.25 384.14 685.12c-.04.04-.06.05-.08.05a.12.12 0 01-.07 0c-.03 0-.05-.01-.09-.05l-45.02-45.02a.2.2 0 01-.05-.09.12.12 0 010-.07c0-.02.01-.04.06-.08L466.75 512 338.88 384.14a.27.27 0 01-.05-.06l-.01-.02a.12.12 0 010-.07c0-.03.01-.05.05-.09l45.02-45.02a.2.2 0 01.09-.05.12.12 0 01.07 0c.02 0 .04.01.08.06L512 466.75l127.86-127.86c.04-.05.06-.06.08-.06a.12.12 0 01.07 0z"></path></svg></span> Your account is not yet eligible to apply <a data-v-0a752da5="">Apply Unlock &gt;</a></p>
+    <div class="desc">
+      <p class="ant-result-demo-error-heading"><strong>The content you submitted has the following error:</strong></p>
+      <p class="ant-result-demo-error-item"><span class="ant-result-demo-error-icon" aria-hidden="true">!</span> Your account has been frozen <a class="ant-result-demo-link" href="https://www.antdv.com/" target="_blank" rel="noreferrer"> Thaw immediately &gt; </a></p>
+      <p class="ant-result-demo-error-item"><span class="ant-result-demo-error-icon" aria-hidden="true">!</span> Your account is not yet eligible to apply <a class="ant-result-demo-link" href="https://www.antdv.com/" target="_blank" rel="noreferrer"> Apply Unlock &gt; </a></p>
     </div>
   </div>
 </div>"
 `;
 
 exports[`Result demos > demo: Forbidden 1`] = `
-"<div class="ant-result ant-result-403" role="status">
-  <div class="ant-result-icon" aria-hidden="true"><svg viewBox="0 0 251 294" width="250" height="294">
+"<div class="ant-result ant-result-403">
+  <div class="ant-result-icon ant-result-image" aria-hidden="true"><svg viewBox="0 0 251 294" width="250" height="294">
       <!-- 403 Unauthorized illustration -->
       <g fill="none" fill-rule="evenodd">
         <!-- Lock body -->
@@ -81,7 +81,7 @@ exports[`Result demos > demo: Forbidden 1`] = `
 `;
 
 exports[`Result demos > demo: Info 1`] = `
-"<div class="ant-result ant-result-info" role="status">
+"<div class="ant-result ant-result-info">
   <div class="ant-result-icon" aria-hidden="true"><svg viewBox="64 64 896 896" width="1em" height="1em" fill="currentColor">
       <path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm32 664c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V456c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272zm-32-344a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"></path>
     </svg></div>
@@ -96,8 +96,8 @@ exports[`Result demos > demo: Info 1`] = `
 `;
 
 exports[`Result demos > demo: NotFound 1`] = `
-"<div class="ant-result ant-result-404" role="status">
-  <div class="ant-result-icon" aria-hidden="true"><svg viewBox="0 0 252 294" width="250" height="294">
+"<div class="ant-result ant-result-404">
+  <div class="ant-result-icon ant-result-image" aria-hidden="true"><svg viewBox="0 0 252 294" width="250" height="294">
       <!-- 404 Not Found illustration -->
       <g fill="none" fill-rule="evenodd">
         <!-- Page background -->
@@ -124,8 +124,8 @@ exports[`Result demos > demo: NotFound 1`] = `
 `;
 
 exports[`Result demos > demo: ServerError 1`] = `
-"<div class="ant-result ant-result-500" role="status">
-  <div class="ant-result-icon" aria-hidden="true"><svg viewBox="0 0 252 294" width="250" height="294">
+"<div class="ant-result ant-result-500">
+  <div class="ant-result-icon ant-result-image" aria-hidden="true"><svg viewBox="0 0 252 294" width="250" height="294">
       <!-- 500 Server Error illustration -->
       <g fill="none" fill-rule="evenodd">
         <!-- Server rack top -->
@@ -161,7 +161,7 @@ exports[`Result demos > demo: ServerError 1`] = `
 `;
 
 exports[`Result demos > demo: Success 1`] = `
-"<div class="ant-result ant-result-success" role="status">
+"<div class="ant-result ant-result-success">
   <div class="ant-result-icon" aria-hidden="true"><svg viewBox="64 64 896 896" width="1em" height="1em" fill="currentColor">
       <path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm193.5 301.7l-210.6 292a31.8 31.8 0 01-51.7 0L318.5 484.9c-3.8-5.3 0-12.7 6.5-12.7h46.9c10.2 0 19.9 4.9 25.9 13.3l71.2 98.8 157.2-218c6-8.3 15.6-13.3 25.9-13.3H699c6.5 0 10.3 7.4 6.5 12.7z"></path>
     </svg></div>
@@ -179,7 +179,7 @@ exports[`Result demos > demo: Success 1`] = `
 `;
 
 exports[`Result demos > demo: Warning 1`] = `
-"<div class="ant-result ant-result-warning" role="status">
+"<div class="ant-result ant-result-warning">
   <div class="ant-result-icon" aria-hidden="true"><svg viewBox="64 64 896 896" width="1em" height="1em" fill="currentColor">
       <path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm-32 232c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V296zm32 440a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"></path>
     </svg></div>

--- a/packages/ui/src/components/result/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/ui/src/components/result/__tests__/__snapshots__/index.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Result > should render correctly with default props 1`] = `
-"<div class="ant-result ant-result-info">
+"<div class="ant-result ant-result-info" role="status">
   <div class="ant-result-icon" aria-hidden="true"><svg viewBox="64 64 896 896" width="1em" height="1em" fill="currentColor">
       <path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm32 664c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V456c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272zm-32-344a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"></path>
     </svg></div>

--- a/packages/ui/src/components/result/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/ui/src/components/result/__tests__/__snapshots__/index.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Result > should render correctly with default props 1`] = `
-"<div class="ant-result ant-result-info" role="status">
+"<div class="ant-result ant-result-info">
   <div class="ant-result-icon" aria-hidden="true"><svg viewBox="64 64 896 896" width="1em" height="1em" fill="currentColor">
       <path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm32 664c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V456c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v272zm-32-344a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"></path>
     </svg></div>

--- a/packages/ui/src/components/result/__tests__/index.test.ts
+++ b/packages/ui/src/components/result/__tests__/index.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { Result } from '@ant-design-vue/ui'
+import Result from '..'
+import UnauthorizedIcon from '../icons/UnauthorizedIcon.vue'
+import NotFoundIcon from '../icons/NotFoundIcon.vue'
+import ServerErrorIcon from '../icons/ServerErrorIcon.vue'
 import { mount } from '@vue/test-utils'
 import { h } from 'vue'
 
@@ -12,6 +15,10 @@ describe('Result', () => {
   it('renders with ant-result class', () => {
     const wrapper = mount(Result)
     expect(wrapper.classes('ant-result')).toBe(true)
+  })
+
+  it('exposes the expected component name', () => {
+    expect(Result.name).toBe('AResult')
   })
 
   it('renders info status by default', () => {
@@ -60,6 +67,14 @@ describe('Result', () => {
       props: { status: 500 },
     })
     expect(wrapper.classes('ant-result-500')).toBe(true)
+  })
+
+  it('renders string exception statuses', () => {
+    const wrapper = mount(Result, {
+      props: { status: '404' },
+    })
+    expect(wrapper.classes('ant-result-404')).toBe(true)
+    expect(wrapper.find('.ant-result-image').exists()).toBe(true)
   })
 
   it('shows title prop', () => {
@@ -129,7 +144,7 @@ describe('Result', () => {
     const wrapper = mount(Result, {
       props: { status: 403 },
     })
-    const icon = wrapper.find('.ant-result-icon')
+    const icon = wrapper.find('.ant-result-image')
     expect(icon.find('svg').exists()).toBe(true)
   })
 
@@ -137,7 +152,7 @@ describe('Result', () => {
     const wrapper = mount(Result, {
       props: { status: 404 },
     })
-    const icon = wrapper.find('.ant-result-icon')
+    const icon = wrapper.find('.ant-result-image')
     expect(icon.find('svg').exists()).toBe(true)
   })
 
@@ -145,8 +160,19 @@ describe('Result', () => {
     const wrapper = mount(Result, {
       props: { status: 500 },
     })
-    const icon = wrapper.find('.ant-result-icon')
+    const icon = wrapper.find('.ant-result-image')
     expect(icon.find('svg').exists()).toBe(true)
+  })
+
+  it('renders VNode title and subTitle props', () => {
+    const wrapper = mount(Result, {
+      props: {
+        title: h('span', { class: 'title-node' }, 'VNode Title'),
+        subTitle: h('span', { class: 'subtitle-node' }, 'VNode Subtitle'),
+      },
+    })
+    expect(wrapper.find('.title-node').text()).toBe('VNode Title')
+    expect(wrapper.find('.subtitle-node').text()).toBe('VNode Subtitle')
   })
 
   it('renders extra slot', () => {
@@ -160,6 +186,15 @@ describe('Result', () => {
     expect(extra.exists()).toBe(true)
     expect(extra.find('.action-btn').exists()).toBe(true)
     expect(extra.text()).toBe('Go Back')
+  })
+
+  it('renders extra prop content', () => {
+    const wrapper = mount(Result, {
+      props: {
+        extra: h('button', { class: 'extra-prop' }, 'From Prop'),
+      },
+    })
+    expect(wrapper.find('.ant-result-extra .extra-prop').exists()).toBe(true)
   })
 
   it('hides extra section when no extra slot', () => {
@@ -199,6 +234,21 @@ describe('Result', () => {
     const icon = wrapper.find('.ant-result-icon')
     expect(icon.find('.custom-icon').exists()).toBe(true)
     expect(icon.find('.custom-icon').text()).toBe('ICON')
+  })
+
+  it('renders custom icon prop', () => {
+    const wrapper = mount(Result, {
+      props: {
+        icon: h('span', { class: 'icon-prop' }, 'ICON PROP'),
+      },
+    })
+    expect(wrapper.find('.ant-result-icon .icon-prop').text()).toBe('ICON PROP')
+  })
+
+  it('preserves presented image convenience exports', () => {
+    expect((Result as any).PRESENTED_IMAGE_403).toBe(UnauthorizedIcon)
+    expect((Result as any).PRESENTED_IMAGE_404).toBe(NotFoundIcon)
+    expect((Result as any).PRESENTED_IMAGE_500).toBe(ServerErrorIcon)
   })
 
   it('renders all sections together', () => {

--- a/packages/ui/src/components/result/demo/customIcon.vue
+++ b/packages/ui/src/components/result/demo/customIcon.vue
@@ -8,3 +8,18 @@
     </template>
   </a-result>
 </template>
+
+<style scoped>
+.ant-result-demo-custom-icon {
+  display: inline-flex;
+  height: 72px;
+  width: 72px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  font-size: 24px;
+  font-weight: 600;
+  color: #fff;
+  background: radial-gradient(circle at top, var(--color-accent-hover, #4096ff), var(--color-accent, #1677ff));
+}
+</style>

--- a/packages/ui/src/components/result/demo/customIcon.vue
+++ b/packages/ui/src/components/result/demo/customIcon.vue
@@ -1,13 +1,10 @@
 <template>
   <a-result title="Great, we have done all the operations!">
     <template #icon>
-      <smile-twoTone />
+      <span class="ant-result-demo-custom-icon" aria-hidden="true">OK</span>
     </template>
     <template #extra>
       <a-button type="primary">Next</a-button>
     </template>
   </a-result>
 </template>
-<script lang="ts" setup>
-import { SmileTwoTone } from '@ant-design/icons-vue';
-</script>

--- a/packages/ui/src/components/result/demo/error.vue
+++ b/packages/ui/src/components/result/demo/error.vue
@@ -10,27 +10,23 @@
     </template>
 
     <div class="desc">
-      <p style="font-size: 16px">
+      <p class="ant-result-demo-error-heading">
         <strong>The content you submitted has the following error:</strong>
       </p>
-      <p>
-        <close-circle-outlined :style="{ color: 'red' }" />
+      <p class="ant-result-demo-error-item">
+        <span class="ant-result-demo-error-icon" aria-hidden="true">!</span>
         Your account has been frozen
-        <a>Thaw immediately &gt;</a>
+        <a class="ant-result-demo-link" href="https://www.antdv.com/" target="_blank" rel="noreferrer">
+          Thaw immediately &gt;
+        </a>
       </p>
-      <p>
-        <close-circle-outlined :style="{ color: 'red' }" />
+      <p class="ant-result-demo-error-item">
+        <span class="ant-result-demo-error-icon" aria-hidden="true">!</span>
         Your account is not yet eligible to apply
-        <a>Apply Unlock &gt;</a>
+        <a class="ant-result-demo-link" href="https://www.antdv.com/" target="_blank" rel="noreferrer">
+          Apply Unlock &gt;
+        </a>
       </p>
     </div>
   </a-result>
 </template>
-<script lang="ts" setup>
-import { CloseCircleOutlined } from '@ant-design/icons-vue';
-</script>
-<style scoped>
-.desc p {
-  margin-bottom: 1em;
-}
-</style>

--- a/packages/ui/src/components/result/demo/error.vue
+++ b/packages/ui/src/components/result/demo/error.vue
@@ -30,3 +30,31 @@
     </div>
   </a-result>
 </template>
+
+<style scoped>
+.ant-result-demo-error-heading {
+  margin-bottom: 16px;
+  font-size: 16px;
+}
+.ant-result-demo-error-item {
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.ant-result-demo-error-icon {
+  display: inline-flex;
+  height: 20px;
+  width: 20px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #fff;
+  background-color: var(--color-error, #ff4d4f);
+}
+.ant-result-demo-link {
+  color: var(--color-accent, #1677ff);
+}
+</style>

--- a/packages/ui/src/components/result/index.ts
+++ b/packages/ui/src/components/result/index.ts
@@ -1,13 +1,27 @@
 import type { App, Plugin } from 'vue'
 import Result from './Result.vue'
+import UnauthorizedIcon from './icons/UnauthorizedIcon.vue'
+import NotFoundIcon from './icons/NotFoundIcon.vue'
+import ServerErrorIcon from './icons/ServerErrorIcon.vue'
 import './style/index.css'
 
 export { default as Result } from './Result.vue'
 export * from './types'
 
-Result.install = function (app: App) {
+const ResultWithExtras = Result as typeof Result &
+  Plugin & {
+    PRESENTED_IMAGE_403: typeof UnauthorizedIcon
+    PRESENTED_IMAGE_404: typeof NotFoundIcon
+    PRESENTED_IMAGE_500: typeof ServerErrorIcon
+  }
+
+ResultWithExtras.PRESENTED_IMAGE_403 = UnauthorizedIcon
+ResultWithExtras.PRESENTED_IMAGE_404 = NotFoundIcon
+ResultWithExtras.PRESENTED_IMAGE_500 = ServerErrorIcon
+
+ResultWithExtras.install = function (app: App) {
   app.component('AResult', Result)
   return app
 }
 
-export default Result as typeof Result & Plugin
+export default ResultWithExtras

--- a/packages/ui/src/components/result/style/index.css
+++ b/packages/ui/src/components/result/style/index.css
@@ -16,33 +16,33 @@
 
 :where(.ant-result).ant-result-success .ant-result-icon > svg,
 :where(.ant-result).ant-result-success .ant-result-icon > span {
-  color: var(--color-success, #52c41a);
+  color: var(--color-success);
 }
 
 :where(.ant-result).ant-result-error .ant-result-icon > svg,
 :where(.ant-result).ant-result-error .ant-result-icon > span {
-  color: var(--color-error, #ff4d4f);
+  color: var(--color-error);
 }
 
 :where(.ant-result).ant-result-info .ant-result-icon > svg,
 :where(.ant-result).ant-result-info .ant-result-icon > span {
-  color: var(--color-info, #1677ff);
+  color: var(--color-info);
 }
 
 :where(.ant-result).ant-result-warning .ant-result-icon > svg,
 :where(.ant-result).ant-result-warning .ant-result-icon > span {
-  color: var(--color-warning, #faad14);
+  color: var(--color-warning);
 }
 
 :where(.ant-result) .ant-result-title {
   @apply text-center text-2xl font-semibold;
-  color: var(--color-neutral, rgba(0, 0, 0, 0.88));
+  color: var(--color-neutral);
 }
 
 :where(.ant-result) .ant-result-subtitle {
   @apply text-center mt-2;
   font-size: var(--ant-font-size);
-  color: var(--color-neutral-secondary, rgba(0, 0, 0, 0.45));
+  color: var(--color-neutral-secondary);
 }
 
 :where(.ant-result) .ant-result-extra {
@@ -59,13 +59,40 @@
 
 :where(.ant-result) .ant-result-content {
   @apply mt-6 py-6 px-10;
-  background-color: var(--color-neutral-bg, #fafafa);
+  background-color: var(--color-neutral-bg);
   border-radius: var(--ant-border-radius, 6px);
 }
 
 /* Exception pages (403, 404, 500) */
-:where(.ant-result).ant-result-403 .ant-result-icon > svg,
-:where(.ant-result).ant-result-404 .ant-result-icon > svg,
-:where(.ant-result).ant-result-500 .ant-result-icon > svg {
+:where(.ant-result).ant-result-403 .ant-result-image > svg,
+:where(.ant-result).ant-result-404 .ant-result-image > svg,
+:where(.ant-result).ant-result-500 .ant-result-image > svg {
+  /* 295px/250px match the legacy exception illustration artboard ratio */
   @apply h-[295px] w-[250px] mx-auto text-7xl;
+}
+
+:where(.ant-result) .ant-result-demo-error-heading {
+  @apply mb-4;
+  font-size: 16px;
+}
+
+:where(.ant-result) .ant-result-demo-error-item {
+  @apply mb-4 flex items-center gap-2;
+}
+
+:where(.ant-result) .ant-result-demo-error-icon {
+  @apply inline-flex h-5 w-5 items-center justify-center rounded-full text-xs font-semibold;
+  color: var(--color-accent-content);
+  background-color: var(--color-error);
+}
+
+:where(.ant-result) .ant-result-demo-link {
+  color: var(--color-accent);
+}
+
+:where(.ant-result) .ant-result-demo-custom-icon {
+  @apply inline-flex h-18 w-18 items-center justify-center rounded-full text-2xl font-semibold;
+  color: var(--color-accent-content);
+  background:
+    radial-gradient(circle at top, var(--color-accent-hover), var(--color-accent));
 }

--- a/packages/ui/src/components/result/style/index.css
+++ b/packages/ui/src/components/result/style/index.css
@@ -71,28 +71,3 @@
   @apply h-[295px] w-[250px] mx-auto text-7xl;
 }
 
-:where(.ant-result) .ant-result-demo-error-heading {
-  @apply mb-4;
-  font-size: 16px;
-}
-
-:where(.ant-result) .ant-result-demo-error-item {
-  @apply mb-4 flex items-center gap-2;
-}
-
-:where(.ant-result) .ant-result-demo-error-icon {
-  @apply inline-flex h-5 w-5 items-center justify-center rounded-full text-xs font-semibold;
-  color: var(--color-accent-content);
-  background-color: var(--color-error);
-}
-
-:where(.ant-result) .ant-result-demo-link {
-  color: var(--color-accent);
-}
-
-:where(.ant-result) .ant-result-demo-custom-icon {
-  @apply inline-flex h-18 w-18 items-center justify-center rounded-full text-2xl font-semibold;
-  color: var(--color-accent-content);
-  background:
-    radial-gradient(circle at top, var(--color-accent-hover), var(--color-accent));
-}

--- a/packages/ui/src/components/result/types.ts
+++ b/packages/ui/src/components/result/types.ts
@@ -1,14 +1,20 @@
 import type { Slot } from '@/utils/types'
+import type { VNode } from 'vue'
 
 export type ResultStatus = 'success' | 'error' | 'info' | 'warning' | 403 | 404 | 500 | '403' | '404' | '500'
+export type ResultContent = string | number | VNode | (() => VNode)
 
 export interface ResultProps {
   /** Result status, decides icon and color */
   status?: ResultStatus
-  /** Title text */
-  title?: string
-  /** Subtitle text */
-  subTitle?: string
+  /** Title content */
+  title?: ResultContent
+  /** Subtitle content */
+  subTitle?: ResultContent
+  /** Custom icon */
+  icon?: VNode | (() => VNode)
+  /** Extra action area */
+  extra?: ResultContent
 }
 
 export const resultDefaultProps = {


### PR DESCRIPTION


  ### What's the background?

  This review focuses on the `result` component in `feat/vapor`.

  During review, `result` had several issues against the current SFC component standards and legacy compatibility expectations:

  1. Public API compatibility regressed from the legacy component.
  2. Demo files used scoped styles, inline styles, and direct icon imports.
  3. The exception result variants did not preserve the legacy `Result.PRESENTED_IMAGE_*` static helpers.
  4. The root container used a fixed `role="status"` even for static result pages.
  5. Tests did not cover the restored compatibility surface.

  ### API Realization

  This PR restores the intended legacy-compatible `Result` surface without introducing new top-level package exports.

  Final behavior:

  - `Result` supports `title` and `subTitle` as renderable content, not string-only values.
  - `Result` supports `icon` and `extra` props again, while still supporting the existing slots.
  - `Result` preserves the legacy static helpers:
    - `Result.PRESENTED_IMAGE_403`
    - `Result.PRESENTED_IMAGE_404`
    - `Result.PRESENTED_IMAGE_500`
  - Exception states (`403`, `404`, `500`) consistently render with the image-style class.
  - The component root no longer forces `role="status"` for all usages.

  ### What's the effect?

  This PR affects the `result` component only.

  Detailed changes:

  1. Restored legacy-compatible renderable props in `Result`.
     - Expanded `title` and `subTitle` types to support renderable content.
     - Restored `icon` and `extra` prop support.
     - Kept slot support for `title`, `subTitle`, `icon`, `extra`, and default content.

  2. Restored legacy static helper compatibility.
     - Re-attached `PRESENTED_IMAGE_403`, `PRESENTED_IMAGE_404`, and `PRESENTED_IMAGE_500` to the `Result` component object.
     - Did not add new package-level named exports for these helpers.

  3. Fixed demo implementation issues.
     - Removed `<style scoped>` usage from `result` demos.
     - Removed inline styles from the error demo.
     - Removed direct icon imports from the updated result demos.
     - Moved demo-supporting styles into `style/index.css`.

  4. Improved style consistency.
     - Switched result semantic colors to CSS variables in the component stylesheet.
     - Added an explanatory comment for the exception illustration size magic numbers.
     - Added explicit styles for the updated demo content and custom icon presentation.

  5. Fixed accessibility issues.
     - Removed the fixed `role="status"` from the root result container.
     - Replaced non-functional pseudo-links in the error demo with real links.

  6. Expanded test coverage.
     - Added coverage for string exception statuses.
     - Added coverage for renderable `title` and `subTitle` props.
     - Added coverage for `extra` prop rendering.
     - Added coverage for `icon` prop rendering.
     - Added coverage for the `Result.PRESENTED_IMAGE_*` static helpers.
     - Updated snapshots to reflect the corrected markup and demo output.

  This PR is intended to restore compatibility and align the component with the repo’s review requirements. It should not introduce a breaking change for `result`.

  ### Changelog description

  - English: Fix Result legacy compatibility, demo conventions, and accessibility issues

  ### Self Check before Merge

  - [x] Doc is updated/provided or not needed
  - [x] Demo is updated/provided or not needed
  - [x] TypeScript definition is updated/provided or not needed
  - [ ] Changelog is provided or not needed

  ### Additional Plan?

  Manual verification completed with component-level tests and updated demo snapshots.

  Tests run:

  - `npm run test --workspace @ant-design-vue/ui -- result -u`

  Note:
  - `npm run tsc --workspace @ant-design-vue/ui` still fails in this repo because of unrelated pre-existing type errors in other components and demos.
  - After filtering the output, there were no remaining `result`-specific TypeScript errors from this change set.