### PR TITLE
fix(popconfirm): restore compatibility and popup rendering

### DIFF
--- a/apps/playground/src/views/EditorView.vue
+++ b/apps/playground/src/views/EditorView.vue
@@ -116,7 +116,7 @@ function compileSFC(source: string) {
   const template = templateMatch[1]
 
   const scriptSetupMatch = source.match(
-    /<script\s+setup(?:\s+lang="ts")?\s*>([\s\S]*?)<\/script>/,
+    /<script\b(?=[^>]*\bsetup\b)[^>]*>([\s\S]*?)<\/script>/,
   )
   if (!scriptSetupMatch) return markRaw(defineComponent({ template }))
 

--- a/apps/playground/src/views/EditorView.vue
+++ b/apps/playground/src/views/EditorView.vue
@@ -116,7 +116,7 @@ function compileSFC(source: string) {
   const template = templateMatch[1]
 
   const scriptSetupMatch = source.match(
-    /<script\b(?=[^>]*\bsetup\b)[^>]*>([\s\S]*?)<\/script>/,
+    /<script\b(?=[^>]*\ssetup(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+))?(?=\s|>))[^>]*>([\s\S]*?)<\/script>/,
   )
   if (!scriptSetupMatch) return markRaw(defineComponent({ template }))
 

--- a/packages/ui/src/_internal/trigger/Trigger.vue
+++ b/packages/ui/src/_internal/trigger/Trigger.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, shallowRef, computed, watch, onBeforeUnmount, nextTick, getCurrentInstance, type CSSProperties } from 'vue'
+import { ref, shallowRef, computed, watch, onBeforeUnmount, nextTick, getCurrentInstance } from 'vue'
 import {
   useFloating,
   autoUpdate,
@@ -106,22 +106,15 @@ const { floatingStyles, placement: actualPlacement, middlewareData, update } = u
 )
 
 const popupStyles = computed(() => {
-  const baseStyles = floatingStyles.value as CSSProperties
-
   if (props.zIndex == null && !props.popupStyle) {
-    return baseStyles
+    return floatingStyles.value
   }
 
-  const styles: CSSProperties[] = [baseStyles]
-
-  if (props.zIndex != null) {
-    styles.push({ zIndex: props.zIndex })
+  return {
+    ...floatingStyles.value,
+    ...(props.zIndex != null ? { zIndex: props.zIndex } : {}),
+    ...(props.popupStyle ?? {}),
   }
-  if (props.popupStyle) {
-    styles.push(props.popupStyle as CSSProperties)
-  }
-
-  return styles
 })
 
 const arrowStyles = computed(() => {

--- a/packages/ui/src/_internal/trigger/Trigger.vue
+++ b/packages/ui/src/_internal/trigger/Trigger.vue
@@ -13,7 +13,7 @@
         v-show="mergedOpen"
         ref="floatingRef"
         :class="popupClasses"
-        :style="floatingStyles"
+        :style="popupStyles"
         role="tooltip"
         v-bind="popupListeners"
       >
@@ -22,7 +22,9 @@
           ref="arrowRef"
           class="ant-trigger-arrow"
           :style="arrowStyles"
-        />
+        >
+          <span class="ant-trigger-arrow-content" />
+        </div>
         <slot name="popup" />
       </div>
     </Transition>
@@ -30,7 +32,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, shallowRef, computed, watch, onBeforeUnmount, nextTick, getCurrentInstance } from 'vue'
+import { ref, shallowRef, computed, watch, onBeforeUnmount, nextTick, getCurrentInstance, type CSSProperties } from 'vue'
 import {
   useFloating,
   autoUpdate,
@@ -38,7 +40,6 @@ import {
   flip,
   shift,
   arrow as arrowMiddleware,
-  type Placement,
 } from '@floating-ui/vue'
 import { Portal } from '../portal'
 import type { TriggerProps, TriggerEmits, TriggerSlots, TriggerType } from './types'
@@ -56,6 +57,13 @@ const floatingRef = shallowRef<HTMLElement | null>(null)
 const arrowRef = shallowRef<HTMLElement | null>(null)
 
 const internalOpen = ref(props.defaultOpen ?? false)
+
+const STATIC_SIDE_MAP = {
+  top: 'bottom',
+  right: 'left',
+  bottom: 'top',
+  left: 'right',
+} as const
 
 // Detect controlled mode: check if parent passed the `open` prop in vnode.props
 // (Vue boolean casting makes props.open always false when absent, so we can't check that)
@@ -93,29 +101,42 @@ const { floatingStyles, placement: actualPlacement, middlewareData, update } = u
         : []),
     ]),
     whileElementsMounted: autoUpdate,
-    transform: true,
+    transform: false,
   },
 )
+
+const popupStyles = computed(() => {
+  const baseStyles = floatingStyles.value as CSSProperties
+
+  if (props.zIndex == null && !props.popupStyle) {
+    return baseStyles
+  }
+
+  const styles: CSSProperties[] = [baseStyles]
+
+  if (props.zIndex != null) {
+    styles.push({ zIndex: props.zIndex })
+  }
+  if (props.popupStyle) {
+    styles.push(props.popupStyle as CSSProperties)
+  }
+
+  return styles
+})
 
 const arrowStyles = computed(() => {
   const arrowData = middlewareData.value?.arrow
   if (!arrowData) return {}
 
   const { x, y } = arrowData
-  const side = actualPlacement.value.split('-')[0]
-  const staticSide: Record<string, string> = {
-    top: 'bottom',
-    right: 'left',
-    bottom: 'top',
-    left: 'right',
-  }
+  const side = actualPlacement.value.split('-')[0] as keyof typeof STATIC_SIDE_MAP
 
   return {
     left: x != null ? `${x}px` : '',
     top: y != null ? `${y}px` : '',
     right: '',
     bottom: '',
-    [staticSide[side]]: '-4px',
+    [STATIC_SIDE_MAP[side]]: '0px',
   }
 })
 

--- a/packages/ui/src/_internal/trigger/style/index.css
+++ b/packages/ui/src/_internal/trigger/style/index.css
@@ -11,11 +11,24 @@
 }
 
 :where(.ant-trigger-arrow) {
+  /*
+   * Ant Design arrow geometry for a 16px box:
+   * - shadow square = 16 / sqrt(2)
+   * - inner corner inset = (16 - 16 / sqrt(2)) / 2
+   * The rounded clip-path matches the legacy Trigger arrow silhouette.
+   */
+  --ant-trigger-arrow-size: 16px;
+  --ant-trigger-arrow-half-size: 8px;
+  --ant-trigger-arrow-shadow-size: 8.9705627485px;
+  --ant-trigger-arrow-corner-inset: 1.6568542495px;
+  --ant-trigger-arrow-shadow-blur: 7px;
+  --ant-trigger-arrow-shadow-offset: 3px;
+  --ant-trigger-arrow-shadow-radius: 2px;
   @apply absolute;
   z-index: 1;
   display: block;
-  width: 16px;
-  height: 16px;
+  width: var(--ant-trigger-arrow-size);
+  height: var(--ant-trigger-arrow-size);
   overflow: hidden;
   background: transparent;
   pointer-events: none;
@@ -24,15 +37,15 @@
 :where(.ant-trigger-arrow)::after {
   content: '';
   position: absolute;
-  width: 8.970562748477143px;
-  height: 8.970562748477143px;
+  width: var(--ant-trigger-arrow-shadow-size);
+  height: var(--ant-trigger-arrow-shadow-size);
   bottom: 0;
   left: 0;
   right: 0;
   margin: auto;
-  border-radius: 0 0 2px 0;
+  border-radius: 0 0 var(--ant-trigger-arrow-shadow-radius) 0;
   transform: translateY(50%) rotate(-135deg);
-  box-shadow: 3px 3px 7px rgba(0, 0, 0, 0.07);
+  box-shadow: var(--ant-trigger-arrow-shadow-offset) var(--ant-trigger-arrow-shadow-offset) var(--ant-trigger-arrow-shadow-blur) rgba(0, 0, 0, 0.07);
   z-index: 0;
   background: transparent;
 }
@@ -47,10 +60,10 @@
   position: absolute;
   bottom: 0;
   left: 0;
-  width: 16px;
-  height: 8px;
+  width: var(--ant-trigger-arrow-size);
+  height: var(--ant-trigger-arrow-half-size);
   background: var(--ant-trigger-arrow-background, #fff);
-  clip-path: polygon(1.6568542494923806px 100%, 50% 1.6568542494923806px, 14.34314575050762px 100%, 1.6568542494923806px 100%);
+  clip-path: polygon(var(--ant-trigger-arrow-corner-inset) 100%, 50% var(--ant-trigger-arrow-corner-inset), calc(var(--ant-trigger-arrow-size) - var(--ant-trigger-arrow-corner-inset)) 100%, var(--ant-trigger-arrow-corner-inset) 100%);
   clip-path: path('M 0 8 A 4 4 0 0 0 2.82842712474619 6.82842712474619 L 6.585786437626905 3.0710678118654755 A 2 2 0 0 1 9.414213562373096 3.0710678118654755 L 13.17157287525381 6.82842712474619 A 4 4 0 0 0 16 8 Z');
   content: '';
 }

--- a/packages/ui/src/_internal/trigger/style/index.css
+++ b/packages/ui/src/_internal/trigger/style/index.css
@@ -11,11 +11,72 @@
 }
 
 :where(.ant-trigger-arrow) {
-  @apply absolute w-2 h-2;
-  background: inherit;
-  transform: rotate(45deg);
+  @apply absolute;
+  z-index: 1;
+  display: block;
+  width: 16px;
+  height: 16px;
+  overflow: hidden;
+  background: transparent;
+  pointer-events: none;
+}
+
+:where(.ant-trigger-arrow)::after {
+  content: '';
+  position: absolute;
+  width: 8.970562748477143px;
+  height: 8.970562748477143px;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: auto;
+  border-radius: 0 0 2px 0;
+  transform: translateY(50%) rotate(-135deg);
   box-shadow: 3px 3px 7px rgba(0, 0, 0, 0.07);
-  z-index: -1;
+  z-index: 0;
+  background: transparent;
+}
+
+:where(.ant-trigger-arrow-content) {
+  position: absolute;
+  inset: 0;
+  display: block;
+}
+
+:where(.ant-trigger-arrow-content)::before {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 16px;
+  height: 8px;
+  background: var(--ant-trigger-arrow-background, #fff);
+  clip-path: polygon(1.6568542494923806px 100%, 50% 1.6568542494923806px, 14.34314575050762px 100%, 1.6568542494923806px 100%);
+  clip-path: path('M 0 8 A 4 4 0 0 0 2.82842712474619 6.82842712474619 L 6.585786437626905 3.0710678118654755 A 2 2 0 0 1 9.414213562373096 3.0710678118654755 L 13.17157287525381 6.82842712474619 A 4 4 0 0 0 16 8 Z');
+  content: '';
+}
+
+:where(.ant-trigger-placement-top) .ant-trigger-arrow,
+:where(.ant-trigger-placement-top-start) .ant-trigger-arrow,
+:where(.ant-trigger-placement-top-end) .ant-trigger-arrow {
+  transform: translateY(100%) rotate(180deg);
+}
+
+:where(.ant-trigger-placement-bottom) .ant-trigger-arrow,
+:where(.ant-trigger-placement-bottom-start) .ant-trigger-arrow,
+:where(.ant-trigger-placement-bottom-end) .ant-trigger-arrow {
+  transform: translateY(-100%);
+}
+
+:where(.ant-trigger-placement-left) .ant-trigger-arrow,
+:where(.ant-trigger-placement-left-start) .ant-trigger-arrow,
+:where(.ant-trigger-placement-left-end) .ant-trigger-arrow {
+  transform: translateX(100%) rotate(90deg);
+}
+
+:where(.ant-trigger-placement-right) .ant-trigger-arrow,
+:where(.ant-trigger-placement-right-start) .ant-trigger-arrow,
+:where(.ant-trigger-placement-right-end) .ant-trigger-arrow {
+  transform: translateX(-100%) rotate(-90deg);
 }
 
 /* Zoom-big-fast transition */

--- a/packages/ui/src/_internal/trigger/types.ts
+++ b/packages/ui/src/_internal/trigger/types.ts
@@ -1,5 +1,6 @@
+import type { CSSProperties } from 'vue'
 import type { Placement, Strategy } from '@floating-ui/vue'
-import type { Slot, ScopedSlot } from '@/utils/types'
+import type { Slot } from '@/utils/types'
 
 export type TriggerType = 'hover' | 'click' | 'focus' | 'contextmenu'
 
@@ -29,7 +30,7 @@ export interface TriggerProps {
   /** Custom class for the popup wrapper */
   popupClass?: string | Record<string, boolean> | (string | Record<string, boolean>)[]
   /** Custom style for the popup wrapper */
-  popupStyle?: Record<string, string>
+  popupStyle?: CSSProperties
   /** Whether the popup is disabled */
   disabled?: boolean
   /** Function returning the container element */

--- a/packages/ui/src/components/dropdown/types.ts
+++ b/packages/ui/src/components/dropdown/types.ts
@@ -1,4 +1,5 @@
-import type { Slot, ScopedSlot } from '@/utils/types'
+import type { CSSProperties } from 'vue'
+import type { Slot } from '@/utils/types'
 import type { TriggerType } from '@/_internal/trigger/types'
 import type { TooltipPlacement } from '../tooltip/types'
 import type { MenuProps, ItemType } from '../menu/types'
@@ -32,7 +33,7 @@ export interface DropdownProps {
   /** Class for the overlay */
   overlayClassName?: string
   /** Style for the overlay */
-  overlayStyle?: Record<string, string>
+  overlayStyle?: CSSProperties
   /** Delay before showing (ms, hover trigger) */
   mouseEnterDelay?: number
   /** Delay before hiding (ms, hover trigger) */
@@ -105,7 +106,7 @@ export interface DropdownButtonProps {
   /** Class for the overlay */
   overlayClassName?: string
   /** Style for the overlay */
-  overlayStyle?: Record<string, string>
+  overlayStyle?: CSSProperties
   /** Destroy popup when hidden */
   destroyPopupOnHide?: boolean
   /** Custom popup container */

--- a/packages/ui/src/components/popconfirm/Popconfirm.vue
+++ b/packages/ui/src/components/popconfirm/Popconfirm.vue
@@ -165,6 +165,21 @@ function getCompatHandlers<T extends (...args: any[]) => unknown>(
   return mergedHandlers
 }
 
+type ButtonClickHandler = (event: MouseEvent) => unknown
+
+function composeButtonClickHandler(
+  userHandler: unknown,
+  internalHandler: (event: MouseEvent) => void,
+) {
+  return (event: MouseEvent) => {
+    try {
+      toFunctionArray<ButtonClickHandler>(userHandler).forEach(handler => handler(event))
+    } finally {
+      internalHandler(event)
+    }
+  }
+}
+
 function normalizeRenderable(content: unknown) {
   if (content == null || content === false) {
     return null
@@ -320,20 +335,34 @@ const popupClasses = computed(() => {
   return classes
 })
 
-const cancelButtonSlotProps = computed(() => ({
-  onClick: onCancel as (event: MouseEvent) => void,
-  size: 'small' as const,
-  ...(props.cancelButtonProps ?? {}),
-  cancel: onCancel as (event: MouseEvent) => void,
-}))
+const cancelButtonSlotProps = computed(() => {
+  const cancelButtonProps = props.cancelButtonProps ?? {}
 
-const okButtonSlotProps = computed(() => ({
-  onClick: onConfirm,
-  type: props.okType,
-  size: 'small' as const,
-  ...(props.okButtonProps ?? {}),
-  confirm: onConfirm,
-}))
+  return {
+    size: 'small' as const,
+    ...cancelButtonProps,
+    onClick: composeButtonClickHandler(
+      (cancelButtonProps as { onClick?: unknown }).onClick,
+      onCancel as (event: MouseEvent) => void,
+    ),
+    cancel: onCancel as (event: MouseEvent) => void,
+  }
+})
+
+const okButtonSlotProps = computed(() => {
+  const okButtonProps = props.okButtonProps ?? {}
+
+  return {
+    type: props.okType,
+    size: 'small' as const,
+    ...okButtonProps,
+    onClick: composeButtonClickHandler(
+      (okButtonProps as { onClick?: unknown }).onClick,
+      onConfirm,
+    ),
+    confirm: onConfirm,
+  }
+})
 
 // --- Handlers ---
 function setOpen(val: boolean, event?: PopconfirmOpenChangeEvent) {

--- a/packages/ui/src/components/popconfirm/Popconfirm.vue
+++ b/packages/ui/src/components/popconfirm/Popconfirm.vue
@@ -37,11 +37,7 @@
         <div class="ant-popconfirm-buttons">
           <template v-if="props.showCancel">
             <slot name="cancelButton" v-bind="cancelButtonSlotProps">
-              <a-button
-                size="sm"
-                v-bind="props.cancelButtonProps"
-                @click="onCancel"
-              >
+              <a-button v-bind="defaultCancelButtonProps">
                 <VNodes :vnodes="cancelTextContent" />
               </a-button>
             </slot>
@@ -49,10 +45,8 @@
           <slot name="okButton" v-bind="okButtonSlotProps">
             <a-button
               :variant="okButtonVariant"
-              size="sm"
-              v-bind="props.okButtonProps"
+              v-bind="defaultOkButtonProps"
               :loading="confirmLoading"
-              @click="onConfirm"
             >
               <VNodes :vnodes="okTextContent" />
             </a-button>
@@ -338,6 +332,11 @@ const cancelButtonSlotProps = computed(() => {
   }
 })
 
+const defaultCancelButtonProps = computed(() => {
+  const { cancel, ...buttonProps } = cancelButtonSlotProps.value
+  return buttonProps
+})
+
 const okButtonSlotProps = computed(() => {
   const okButtonProps = props.okButtonProps ?? {}
 
@@ -351,6 +350,11 @@ const okButtonSlotProps = computed(() => {
     ),
     confirm: onConfirm,
   }
+})
+
+const defaultOkButtonProps = computed(() => {
+  const { confirm, ...buttonProps } = okButtonSlotProps.value
+  return buttonProps
 })
 
 // --- Handlers ---
@@ -465,6 +469,10 @@ function onDocumentKeydown(e: KeyboardEvent) {
 watch(
   mergedOpen,
   open => {
+    if (!open) {
+      confirmLoading.value = false
+    }
+
     if (typeof document === 'undefined') {
       return
     }

--- a/packages/ui/src/components/popconfirm/Popconfirm.vue
+++ b/packages/ui/src/components/popconfirm/Popconfirm.vue
@@ -220,7 +220,7 @@ const isUserControlled = computed(() => {
 })
 
 const mergedOpen = computed(() => {
-  if (hasExplicitProp('open') && props.open !== null) return props.open
+  if (hasExplicitProp('open') && props.open !== null) return props.open ?? false
   if (hasExplicitProp('visible')) return props.visible ?? false
   return internalOpen.value
 })

--- a/packages/ui/src/components/popconfirm/Popconfirm.vue
+++ b/packages/ui/src/components/popconfirm/Popconfirm.vue
@@ -85,6 +85,8 @@ import type {
   PopconfirmProps,
   PopconfirmEmits,
   PopconfirmSlots,
+  PopconfirmConfirmHandler,
+  PopconfirmCancelHandler,
   PopconfirmOpenChangeEvent,
 } from './types'
 import type { ButtonVariant } from '../button/types'
@@ -150,11 +152,9 @@ function toFunctionArray<T extends (...args: any[]) => unknown>(value: unknown):
   return []
 }
 
-function getCompatHandlers<T extends (...args: any[]) => unknown>(handlers: T | T[] | undefined): T[] {
-  return toFunctionArray<T>(handlers)
-}
-
 type ButtonClickHandler = (event: MouseEvent) => unknown
+type CompatRawHandlerName = 'onConfirm' | 'onCancel'
+const firedOnceHandlers = new WeakSet<(...args: any[]) => unknown>()
 
 function composeButtonClickHandler(
   userHandler: unknown,
@@ -222,11 +222,11 @@ function hasRenderableContent(content: unknown) {
 // Popconfirm manages its own open state (for confirm/cancel close behavior)
 // Check raw vnode props to detect user-controlled mode
 const isUserControlled = computed(() => {
-  return hasExplicitProp('open') || hasExplicitProp('visible')
+  return (hasExplicitProp('open') && props.open !== null) || hasExplicitProp('visible')
 })
 
 const mergedOpen = computed(() => {
-  if (hasExplicitProp('open')) return props.open ?? false
+  if (hasExplicitProp('open') && props.open !== null) return props.open
   if (hasExplicitProp('visible')) return props.visible ?? false
   return internalOpen.value
 })
@@ -371,42 +371,60 @@ function onOpenChange(val: boolean) {
   setOpen(val)
 }
 
+function getCompatHandlers<T extends (...args: any[]) => unknown>(rawPropName: CompatRawHandlerName): T[] {
+  return toFunctionArray<T>(rawProps.value[rawPropName])
+}
+
+function getCompatOnceHandlers<T extends (...args: any[]) => unknown>(rawPropName: CompatRawHandlerName): T[] {
+  return toFunctionArray<T>(rawProps.value[`${rawPropName}Once`])
+}
+
+function hasCompatHandlers(rawPropName: CompatRawHandlerName) {
+  return getCompatHandlers(rawPropName).length > 0 || getCompatOnceHandlers(rawPropName).length > 0
+}
+
 function emitCompatEvent(eventName: 'confirm' | 'cancel', event: MouseEvent) {
-  const handlerName = eventName === 'confirm' ? 'onConfirm' : 'onCancel'
-  const vnodeProps = instance.vnode.props as Record<string, unknown> | null
-  const emitEvent = () => {
-    if (eventName === 'confirm') {
+  if (eventName === 'confirm') {
+    if (!hasCompatHandlers('onConfirm')) {
       emit('confirm', event)
-      return
     }
-
-    emit('cancel', event)
-  }
-
-  if (!vnodeProps || !(handlerName in vnodeProps)) {
-    emitEvent()
     return
   }
 
-  const handler = vnodeProps[handlerName]
-
-  try {
-    vnodeProps[handlerName] = undefined
-    emitEvent()
-  } finally {
-    vnodeProps[handlerName] = handler
+  if (!hasCompatHandlers('onCancel')) {
+    emit('cancel', event)
   }
 }
 
+function invokeRawHandlers<T extends (...args: any[]) => unknown>(
+  rawPropName: CompatRawHandlerName,
+  event: MouseEvent,
+) {
+  const results: ReturnType<T>[] = []
+
+  getCompatHandlers<T>(rawPropName).forEach(handler => {
+    results.push(handler(event) as ReturnType<T>)
+  })
+
+  getCompatOnceHandlers<T>(rawPropName).forEach(handler => {
+    if (firedOnceHandlers.has(handler)) {
+      return
+    }
+
+    firedOnceHandlers.add(handler)
+    results.push(handler(event) as ReturnType<T>)
+  })
+
+  return results
+}
+
 function invokeConfirmHandlers(e: MouseEvent) {
-  const handlers = getCompatHandlers(props.onConfirm)
-  const results = handlers.map(handler => handler(e))
+  const results = invokeRawHandlers<PopconfirmConfirmHandler>('onConfirm', e)
   return results.find(isThenable) ?? results.find(result => result !== undefined)
 }
 
 function invokeCancelHandlers(e: MouseEvent) {
-  const handlers = getCompatHandlers(props.onCancel)
-  handlers.forEach(handler => handler(e))
+  invokeRawHandlers<PopconfirmCancelHandler>('onCancel', e)
 }
 
 function onConfirm(e: MouseEvent) {
@@ -420,8 +438,7 @@ function onConfirm(e: MouseEvent) {
     confirmLoading.value = true
     result.then(
       () => {
-        confirmLoading.value = false
-        setOpen(false)
+        setOpen(false, e)
       },
       () => {
         confirmLoading.value = false

--- a/packages/ui/src/components/popconfirm/Popconfirm.vue
+++ b/packages/ui/src/components/popconfirm/Popconfirm.vue
@@ -119,6 +119,8 @@ const { getPopupContainer, locale } = useConfigInject()
 const triggerRef = shallowRef<InstanceType<typeof Trigger> | null>(null)
 const internalOpen = ref(props.defaultOpen ?? false)
 const confirmLoading = ref(false)
+const activeConfirmToken = ref(0)
+let confirmTokenSeed = 0
 const instance = getCurrentInstance()!
 const rawProps = shallowRef<Record<string, unknown>>((instance.vnode.props || {}) as Record<string, unknown>)
 
@@ -364,6 +366,7 @@ function setOpen(val: boolean, event?: PopconfirmOpenChangeEvent) {
   }
   if (!val) {
     confirmLoading.value = false
+    activeConfirmToken.value = 0
   }
   emit('update:open', val)
   emit('openChange', val, event)
@@ -439,12 +442,23 @@ function onConfirm(e: MouseEvent) {
   emitCompatEvent('confirm', e)
   const result = invokeConfirmHandlers(e)
   if (isThenable(result)) {
+    const token = ++confirmTokenSeed
+    activeConfirmToken.value = token
     confirmLoading.value = true
     result.then(
       () => {
+        if (activeConfirmToken.value !== token || !mergedOpen.value) {
+          return
+        }
+
         setOpen(false, e)
       },
       () => {
+        if (activeConfirmToken.value !== token) {
+          return
+        }
+
+        activeConfirmToken.value = 0
         confirmLoading.value = false
       },
     )
@@ -471,6 +485,7 @@ watch(
   open => {
     if (!open) {
       confirmLoading.value = false
+      activeConfirmToken.value = 0
     }
 
     if (typeof document === 'undefined') {

--- a/packages/ui/src/components/popconfirm/Popconfirm.vue
+++ b/packages/ui/src/components/popconfirm/Popconfirm.vue
@@ -20,41 +20,41 @@
   >
     <slot />
     <template #popup>
-      <div class="ant-popconfirm-inner" @keydown.esc="onCancel">
+      <div class="ant-popconfirm-inner">
         <div class="ant-popconfirm-message">
-          <span class="ant-popconfirm-message-icon">
-            <slot name="icon">
-              <ExclamationCircleFilled />
-            </slot>
+          <span v-if="hasIcon" class="ant-popconfirm-message-icon">
+            <VNodes :vnodes="iconContent" />
           </span>
           <div class="ant-popconfirm-message-text">
             <div class="ant-popconfirm-title">
-              <slot name="title">{{ props.title }}</slot>
+              <VNodes :vnodes="titleContent" />
             </div>
             <div v-if="hasDescription" class="ant-popconfirm-description">
-              <slot name="description">{{ props.description }}</slot>
+              <VNodes :vnodes="descriptionContent" />
             </div>
           </div>
         </div>
         <div class="ant-popconfirm-buttons">
-          <slot name="cancelButton" :cancel="onCancel">
+          <template v-if="props.showCancel">
+            <slot name="cancelButton" v-bind="cancelButtonSlotProps">
+              <a-button
+                size="sm"
+                v-bind="props.cancelButtonProps"
+                @click="onCancel"
+              >
+                <VNodes :vnodes="cancelTextContent" />
+              </a-button>
+            </slot>
+          </template>
+          <slot name="okButton" v-bind="okButtonSlotProps">
             <a-button
-              v-if="props.showCancel"
-              size="sm"
-              v-bind="props.cancelButtonProps"
-              @click="onCancel"
-            >
-              <slot name="cancelText">{{ props.cancelText }}</slot>
-            </a-button>
-          </slot>
-          <slot name="okButton" :confirm="onConfirm">
-            <a-button
-              :type="props.okType"
+              :variant="okButtonVariant"
               size="sm"
               v-bind="props.okButtonProps"
+              :loading="confirmLoading"
               @click="onConfirm"
             >
-              <slot name="okText">{{ props.okText }}</slot>
+              <VNodes :vnodes="okTextContent" />
             </a-button>
           </slot>
         </div>
@@ -64,57 +64,234 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, shallowRef, useSlots, getCurrentInstance } from 'vue'
+import {
+  computed,
+  defineComponent,
+  getCurrentInstance,
+  h,
+  isVNode,
+  onBeforeUnmount,
+  onBeforeUpdate,
+  ref,
+  shallowRef,
+  useSlots,
+  watch,
+} from 'vue'
 import { Trigger } from '@/_internal/trigger'
 import { useConfigInject } from '@/hooks'
 import { resolveFloatingPlacement } from '../tooltip/types'
 import ExclamationCircleFilled from '@ant-design/icons-vue/ExclamationCircleFilled'
-import type { PopconfirmProps, PopconfirmEmits, PopconfirmSlots } from './types'
+import type {
+  PopconfirmProps,
+  PopconfirmEmits,
+  PopconfirmSlots,
+  PopconfirmOpenChangeEvent,
+} from './types'
+import type { ButtonVariant } from '../button/types'
 import { popconfirmDefaultProps } from './types'
 
 defineOptions({ name: 'APopconfirm' })
 
-const props = withDefaults(defineProps<PopconfirmProps>(), {
-  trigger: 'click',
-  placement: 'top',
-  mouseEnterDelay: 100,
-  mouseLeaveDelay: 100,
-  destroyTooltipOnHide: false,
-  autoAdjustOverflow: true,
-  disabled: false,
-  okType: 'primary',
-  showCancel: true,
-  okText: 'OK',
-  cancelText: 'Cancel',
+const VNodes = defineComponent({
+  name: 'PopconfirmVNodes',
+  props: {
+    vnodes: {
+      type: null,
+      default: null,
+    },
+  },
+  setup(rendererProps) {
+    return () => rendererProps.vnodes as any
+  },
 })
+
+const LEGACY_OK_TYPE_VARIANT_MAP: Record<NonNullable<PopconfirmProps['okType']>, ButtonVariant> = {
+  primary: 'solid',
+  default: 'outlined',
+  dashed: 'dashed',
+  text: 'text',
+  link: 'link',
+}
+
+const props = withDefaults(defineProps<PopconfirmProps>(), popconfirmDefaultProps)
 const emit = defineEmits<PopconfirmEmits>()
 defineSlots<PopconfirmSlots>()
 const slots = useSlots()
 
-const { getPopupContainer } = useConfigInject()
+const { getPopupContainer, locale } = useConfigInject()
 
 const triggerRef = shallowRef<InstanceType<typeof Trigger> | null>(null)
 const internalOpen = ref(props.defaultOpen ?? false)
+const confirmLoading = ref(false)
+const instance = getCurrentInstance()!
+const rawProps = shallowRef<Record<string, unknown>>((instance.vnode.props || {}) as Record<string, unknown>)
+
+function syncRawProps() {
+  rawProps.value = (instance.vnode.props || {}) as Record<string, unknown>
+}
+
+onBeforeUpdate(syncRawProps)
+
+function hasExplicitProp(propName: string, kebabName?: string) {
+  return propName in rawProps.value || (!!kebabName && kebabName in rawProps.value)
+}
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return !!value && typeof (value as PromiseLike<unknown>).then === 'function'
+}
+
+function toFunctionArray<T extends (...args: any[]) => unknown>(value: unknown): T[] {
+  if (typeof value === 'function') {
+    return [value as T]
+  }
+  if (Array.isArray(value)) {
+    return value.filter((handler): handler is T => typeof handler === 'function')
+  }
+  return []
+}
+
+function getCompatHandlers<T extends (...args: any[]) => unknown>(
+  handlers: T | T[] | undefined,
+  rawPropName: 'onConfirm' | 'onCancel',
+): T[] {
+  const mergedHandlers = toFunctionArray<T>(handlers)
+
+  toFunctionArray<T>(rawProps.value[rawPropName]).forEach(handler => {
+    if (!mergedHandlers.includes(handler)) {
+      mergedHandlers.push(handler)
+    }
+  })
+
+  return mergedHandlers
+}
+
+function normalizeRenderable(content: unknown) {
+  if (content == null || content === false) {
+    return null
+  }
+  if (Array.isArray(content) || isVNode(content)) {
+    return content
+  }
+  if (typeof content === 'string' || typeof content === 'number') {
+    return content
+  }
+  return h(content as any)
+}
+
+function getSlotContent(slotFn: (() => any) | undefined) {
+  const content = slotFn?.()
+  return content?.length ? content : null
+}
+
+function resolveContent(options: {
+  propName: string
+  propValue: unknown
+  slot: (() => any) | undefined
+  kebabName?: string
+  fallbackSlot?: (() => any) | undefined
+  fallbackContent?: unknown
+}) {
+  const {
+    propName,
+    propValue,
+    slot,
+    kebabName,
+    fallbackSlot,
+    fallbackContent,
+  } = options
+
+  if (hasExplicitProp(propName, kebabName)) {
+    return normalizeRenderable(propValue)
+  }
+
+  return getSlotContent(slot) ?? getSlotContent(fallbackSlot) ?? normalizeRenderable(fallbackContent)
+}
+
+function hasRenderableContent(content: unknown) {
+  if (Array.isArray(content)) {
+    return content.length > 0
+  }
+  return content !== null && content !== undefined && content !== false && content !== ''
+}
 
 // --- Open state ---
 // Popconfirm manages its own open state (for confirm/cancel close behavior)
 // Check raw vnode props to detect user-controlled mode
-const instance = getCurrentInstance()!
 const isUserControlled = computed(() => {
-  const rawProps = instance.vnode.props || {}
-  return 'open' in rawProps || 'visible' in rawProps
+  return hasExplicitProp('open') || hasExplicitProp('visible')
 })
 
 const mergedOpen = computed(() => {
-  if (isUserControlled.value) {
-    return props.open ?? props.visible ?? false
-  }
+  if (hasExplicitProp('open')) return props.open ?? false
+  if (hasExplicitProp('visible')) return props.visible ?? false
   return internalOpen.value
+})
+
+const resolvedOkText = computed(() => {
+  return locale.value.Popconfirm?.okText ?? popconfirmDefaultProps.okText
+})
+
+const resolvedCancelText = computed(() => {
+  return locale.value.Popconfirm?.cancelText ?? popconfirmDefaultProps.cancelText
+})
+
+const okButtonVariant = computed(() => {
+  return LEGACY_OK_TYPE_VARIANT_MAP[props.okType ?? popconfirmDefaultProps.okType]
+})
+
+const iconContent = computed(() => {
+  return resolveContent({
+    propName: 'icon',
+    propValue: props.icon,
+    slot: slots.icon,
+    fallbackContent: h(ExclamationCircleFilled),
+  })
+})
+
+const titleContent = computed(() => {
+  return resolveContent({
+    propName: 'title',
+    propValue: props.title,
+    slot: slots.title,
+  })
+})
+
+const descriptionContent = computed(() => {
+  return resolveContent({
+    propName: 'description',
+    propValue: props.description,
+    slot: slots.description,
+  })
+})
+
+const cancelTextContent = computed(() => {
+  return resolveContent({
+    propName: 'cancelText',
+    kebabName: 'cancel-text',
+    propValue: props.cancelText,
+    slot: slots.cancelText,
+    fallbackSlot: slots.cancel,
+    fallbackContent: resolvedCancelText.value,
+  })
+})
+
+const okTextContent = computed(() => {
+  return resolveContent({
+    propName: 'okText',
+    kebabName: 'ok-text',
+    propValue: props.okText,
+    slot: slots.okText,
+    fallbackContent: resolvedOkText.value,
+  })
+})
+
+const hasIcon = computed(() => {
+  return hasRenderableContent(iconContent.value)
 })
 
 // --- Check for description ---
 const hasDescription = computed(() => {
-  return (props.description !== undefined && props.description !== null && props.description !== '') || !!slots.description
+  return hasRenderableContent(descriptionContent.value)
 })
 
 // --- Arrow ---
@@ -143,30 +320,106 @@ const popupClasses = computed(() => {
   return classes
 })
 
+const cancelButtonSlotProps = computed(() => ({
+  onClick: onCancel as (event: MouseEvent) => void,
+  size: 'small' as const,
+  ...(props.cancelButtonProps ?? {}),
+  cancel: onCancel as (event: MouseEvent) => void,
+}))
+
+const okButtonSlotProps = computed(() => ({
+  onClick: onConfirm,
+  type: props.okType,
+  size: 'small' as const,
+  ...(props.okButtonProps ?? {}),
+  confirm: onConfirm,
+}))
+
 // --- Handlers ---
-function setOpen(val: boolean) {
+function setOpen(val: boolean, event?: PopconfirmOpenChangeEvent) {
   if (!isUserControlled.value) {
     internalOpen.value = val
   }
+  if (!val) {
+    confirmLoading.value = false
+  }
   emit('update:open', val)
-  emit('openChange', val)
+  emit('openChange', val, event)
   emit('update:visible', val)
-  emit('visibleChange', val)
+  emit('visibleChange', val, event)
 }
 
 function onOpenChange(val: boolean) {
   setOpen(val)
 }
 
-function onConfirm(e: MouseEvent) {
-  emit('confirm', e)
-  setOpen(false)
+function invokeConfirmHandlers(e: MouseEvent) {
+  const handlers = getCompatHandlers(props.onConfirm, 'onConfirm')
+  const results = handlers.map(handler => handler(e))
+  return results.find(isThenable) ?? results.find(result => result !== undefined)
 }
 
-function onCancel(e: MouseEvent | KeyboardEvent) {
-  emit('cancel', e as MouseEvent)
-  setOpen(false)
+function invokeCancelHandlers(e: MouseEvent) {
+  const handlers = getCompatHandlers(props.onCancel, 'onCancel')
+  handlers.forEach(handler => handler(e))
 }
+
+function onConfirm(e: MouseEvent) {
+  if (confirmLoading.value) {
+    return
+  }
+
+  const result = invokeConfirmHandlers(e)
+  if (isThenable(result)) {
+    confirmLoading.value = true
+    result.then(
+      () => {
+        confirmLoading.value = false
+        setOpen(false)
+      },
+      () => {
+        confirmLoading.value = false
+      },
+    )
+    return
+  }
+
+  setOpen(false, e)
+}
+
+function onCancel(e: MouseEvent) {
+  invokeCancelHandlers(e)
+  setOpen(false, e)
+}
+
+function onDocumentKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape' && mergedOpen.value) {
+    setOpen(false, e)
+  }
+}
+
+watch(
+  mergedOpen,
+  open => {
+    if (typeof document === 'undefined') {
+      return
+    }
+
+    if (open) {
+      document.addEventListener('keydown', onDocumentKeydown)
+      return
+    }
+
+    document.removeEventListener('keydown', onDocumentKeydown)
+  },
+  { flush: 'post', immediate: true },
+)
+
+onBeforeUnmount(() => {
+  if (typeof document !== 'undefined') {
+    document.removeEventListener('keydown', onDocumentKeydown)
+  }
+})
 
 // --- Expose ---
 defineExpose({

--- a/packages/ui/src/components/popconfirm/Popconfirm.vue
+++ b/packages/ui/src/components/popconfirm/Popconfirm.vue
@@ -150,19 +150,8 @@ function toFunctionArray<T extends (...args: any[]) => unknown>(value: unknown):
   return []
 }
 
-function getCompatHandlers<T extends (...args: any[]) => unknown>(
-  handlers: T | T[] | undefined,
-  rawPropName: 'onConfirm' | 'onCancel',
-): T[] {
-  const mergedHandlers = toFunctionArray<T>(handlers)
-
-  toFunctionArray<T>(rawProps.value[rawPropName]).forEach(handler => {
-    if (!mergedHandlers.includes(handler)) {
-      mergedHandlers.push(handler)
-    }
-  })
-
-  return mergedHandlers
+function getCompatHandlers<T extends (...args: any[]) => unknown>(handlers: T | T[] | undefined): T[] {
+  return toFunctionArray<T>(handlers)
 }
 
 type ButtonClickHandler = (event: MouseEvent) => unknown
@@ -382,14 +371,41 @@ function onOpenChange(val: boolean) {
   setOpen(val)
 }
 
+function emitCompatEvent(eventName: 'confirm' | 'cancel', event: MouseEvent) {
+  const handlerName = eventName === 'confirm' ? 'onConfirm' : 'onCancel'
+  const vnodeProps = instance.vnode.props as Record<string, unknown> | null
+  const emitEvent = () => {
+    if (eventName === 'confirm') {
+      emit('confirm', event)
+      return
+    }
+
+    emit('cancel', event)
+  }
+
+  if (!vnodeProps || !(handlerName in vnodeProps)) {
+    emitEvent()
+    return
+  }
+
+  const handler = vnodeProps[handlerName]
+
+  try {
+    vnodeProps[handlerName] = undefined
+    emitEvent()
+  } finally {
+    vnodeProps[handlerName] = handler
+  }
+}
+
 function invokeConfirmHandlers(e: MouseEvent) {
-  const handlers = getCompatHandlers(props.onConfirm, 'onConfirm')
+  const handlers = getCompatHandlers(props.onConfirm)
   const results = handlers.map(handler => handler(e))
   return results.find(isThenable) ?? results.find(result => result !== undefined)
 }
 
 function invokeCancelHandlers(e: MouseEvent) {
-  const handlers = getCompatHandlers(props.onCancel, 'onCancel')
+  const handlers = getCompatHandlers(props.onCancel)
   handlers.forEach(handler => handler(e))
 }
 
@@ -398,6 +414,7 @@ function onConfirm(e: MouseEvent) {
     return
   }
 
+  emitCompatEvent('confirm', e)
   const result = invokeConfirmHandlers(e)
   if (isThenable(result)) {
     confirmLoading.value = true
@@ -417,6 +434,7 @@ function onConfirm(e: MouseEvent) {
 }
 
 function onCancel(e: MouseEvent) {
+  emitCompatEvent('cancel', e)
   invokeCancelHandlers(e)
   setOpen(false, e)
 }

--- a/packages/ui/src/components/popconfirm/__tests__/__snapshots__/demo.test.ts.snap
+++ b/packages/ui/src/components/popconfirm/__tests__/__snapshots__/demo.test.ts.snap
@@ -12,12 +12,12 @@ exports[`Popconfirm demos > demo: Basic 1`] = `
 `;
 
 exports[`Popconfirm demos > demo: Condition 1`] = `
-"<div style="display: flex; flex-direction: column; gap: 16px; padding: 40px;"><span class="ant-trigger-wrapper"><button class="ant-btn ant-btn-solid ant-btn-md ant-btn-danger ant-btn-custom-color" style="--color-accent-1: #fff1f0; --color-accent-2: #ffccc7; --color-accent-3: #ffa39e; --color-accent-4: #ff7875; --color-accent-5: #ff4d4f; --color-accent-6: #f5222d; --color-accent-7: #cf1322; --color-accent-8: #a8071a; --color-accent-9: #820014; --color-accent-10: #5c0011; --color-accent: #f5222d; --color-accent-hover: #ff4d4f; --color-accent-active: #cf1322; --color-accent-content: #ffffff; --color-error: #ff4d4f; --color-warning: #ffec3d; --color-success: #73d13d; --color-info: #4096ff; --color-neutral: #000000e0; --color-neutral-secondary: #000000a6; --color-neutral-disabled: #00000040; --color-neutral-disabled-bg: #0000000a; --color-neutral-border: #d9d9d9; --color-neutral-separator: #0505050f; --color-neutral-bg: #f5f5f5;" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Delete a task (controlled)</span></button></span>
+"<div style="display: flex; flex-direction: column; gap: 16px; padding: 40px;"><span class="ant-trigger-wrapper"><button class="ant-btn ant-btn-outlined ant-btn-md ant-btn-danger ant-btn-custom-color" style="--color-accent-1: #fff1f0; --color-accent-2: #ffccc7; --color-accent-3: #ffa39e; --color-accent-4: #ff7875; --color-accent-5: #ff4d4f; --color-accent-6: #f5222d; --color-accent-7: #cf1322; --color-accent-8: #a8071a; --color-accent-9: #820014; --color-accent-10: #5c0011; --color-accent: #f5222d; --color-accent-hover: #ff4d4f; --color-accent-active: #cf1322; --color-accent-content: #ffffff; --color-error: #ff4d4f; --color-warning: #ffec3d; --color-success: #73d13d; --color-info: #4096ff; --color-neutral: #000000e0; --color-neutral-secondary: #000000a6; --color-neutral-disabled: #00000040; --color-neutral-disabled-bg: #0000000a; --color-neutral-border: #d9d9d9; --color-neutral-separator: #0505050f; --color-neutral-bg: #f5f5f5;" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Delete a task (controlled)</span></button></span>
   <!--teleport start-->
   <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
     <!--v-if-->
   </transition-stub>
-  <!--teleport end--><span class="ant-trigger-wrapper"><button class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Disabled</span></button></span>
+  <!--teleport end--><span class="ant-trigger-wrapper"><button class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Disabled</span></button></span>
   <!--teleport start-->
   <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
     <!--v-if-->
@@ -28,68 +28,68 @@ exports[`Popconfirm demos > demo: Condition 1`] = `
 
 exports[`Popconfirm demos > demo: Placement 1`] = `
 "<div data-v-0307ad59="" id="components-a-popconfirm-demo-placement">
-  <div data-v-0307ad59="" style="margin-left: 70px; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">TL</span></button></span>
+  <div data-v-0307ad59="" style="margin-left: 70px; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">TL</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Top</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Top</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">TR</span></button></span>
-    <!--teleport start-->
-    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
-      <!--v-if-->
-    </transition-stub>
-    <!--teleport end-->
-  </div>
-  <div data-v-0307ad59="" style="width: 70px; float: left;"><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">LT</span></button></span>
-    <!--teleport start-->
-    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
-      <!--v-if-->
-    </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Left</span></button></span>
-    <!--teleport start-->
-    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
-      <!--v-if-->
-    </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">LB</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">TR</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
     <!--teleport end-->
   </div>
-  <div data-v-0307ad59="" style="width: 70px; margin-left: 304px;"><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">RT</span></button></span>
+  <div data-v-0307ad59="" style="width: 70px; float: left;"><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">LT</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Right</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Left</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">RB</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">LB</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
     <!--teleport end-->
   </div>
-  <div data-v-0307ad59="" style="margin-left: 70px; clear: both; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">BL</span></button></span>
+  <div data-v-0307ad59="" style="width: 70px; margin-left: 304px;"><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">RT</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Bottom</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Right</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">BR</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">RB</span></button></span>
+    <!--teleport start-->
+    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <!--teleport end-->
+  </div>
+  <div data-v-0307ad59="" style="margin-left: 70px; clear: both; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">BL</span></button></span>
+    <!--teleport start-->
+    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Bottom</span></button></span>
+    <!--teleport start-->
+    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-0307ad59="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">BR</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->

--- a/packages/ui/src/components/popconfirm/__tests__/index.test.ts
+++ b/packages/ui/src/components/popconfirm/__tests__/index.test.ts
@@ -593,6 +593,50 @@ describe('Popconfirm', () => {
     expect(wrapper.emitted('visibleChange')?.at(-1)?.[1]).toBeInstanceOf(MouseEvent)
   })
 
+  it('ignores stale async confirm resolution after popup closes and reopens', async () => {
+    let resolveConfirm!: () => void
+    const confirm = vi.fn(
+      () => new Promise<void>(resolve => {
+        resolveConfirm = resolve
+      }),
+    )
+    const wrapper = trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: { title: 'Are you sure?', trigger: 'click', onConfirm: confirm },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+
+    await wrapper.find('.ant-trigger-wrapper').trigger('click')
+    await flushPopup()
+
+    getButtons()[1]?.click()
+    await flushPopup()
+
+    expect(confirm).toHaveBeenCalledTimes(1)
+    expect(getButtons()[1]?.className).toContain('ant-btn-loading')
+
+    await wrapper.find('.ant-trigger-wrapper').trigger('click')
+    await flushPopup()
+
+    expect(getPopup()?.style.display).toBe('none')
+
+    await wrapper.find('.ant-trigger-wrapper').trigger('click')
+    await flushPopup()
+
+    expect(getPopup()?.style.display).not.toBe('none')
+    expect(getButtons()[1]?.className ?? '').not.toContain('ant-btn-loading')
+
+    resolveConfirm()
+    await Promise.resolve()
+    await flushPopup()
+
+    const closedEvents = (wrapper.emitted('update:open') ?? []).filter(args => args[0] === false)
+
+    expect(closedEvents).toHaveLength(1)
+    expect(wrapper.emitted('update:open')?.at(-1)).toEqual([true])
+    expect(getPopup()?.style.display).not.toBe('none')
+  })
+
   it('passes legacy-compatible props into custom button slots', async () => {
     let receivedCancelSlotProps: PopconfirmCancelButtonSlotProps | undefined
     let receivedOkSlotProps: PopconfirmOkButtonSlotProps | undefined

--- a/packages/ui/src/components/popconfirm/__tests__/index.test.ts
+++ b/packages/ui/src/components/popconfirm/__tests__/index.test.ts
@@ -1,62 +1,122 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
-import { nextTick, h } from 'vue'
+import { defineComponent, h, nextTick, ref } from 'vue'
+import QuestionCircleOutlined from '@ant-design/icons-vue/QuestionCircleOutlined'
 import Popconfirm from '../Popconfirm.vue'
+import ConfigProvider from '../../config-provider/ConfigProvider.vue'
+import type {
+  PopconfirmCancelButtonSlotProps,
+  PopconfirmOkButtonSlotProps,
+} from '../types'
+
+const mountedWrappers: Array<{ unmount: () => void }> = []
+
+function trackMount<T extends { unmount: () => void }>(wrapper: T) {
+  mountedWrappers.push(wrapper)
+  return wrapper
+}
+
+async function flushPopup() {
+  await nextTick()
+  await nextTick()
+}
+
+function getPopup() {
+  return document.body.querySelector('.ant-popconfirm') as HTMLElement | null
+}
+
+function getButtons() {
+  return Array.from(document.body.querySelectorAll('.ant-popconfirm-buttons .ant-btn')) as HTMLElement[]
+}
+
+afterEach(() => {
+  mountedWrappers.splice(0).reverse().forEach(wrapper => wrapper.unmount())
+  vi.useRealTimers()
+  document.body.innerHTML = ''
+})
 
 describe('Popconfirm', () => {
   it('should render correctly', () => {
-    const wrapper = mount(Popconfirm, {
+    const wrapper = trackMount(mount(Popconfirm, {
       props: { title: 'Are you sure?' },
       slots: { default: () => h('span', 'Delete') },
-    })
+    }))
     expect(wrapper.html()).toMatchSnapshot()
   })
 
   it('renders the trigger element', () => {
-    const wrapper = mount(Popconfirm, {
+    const wrapper = trackMount(mount(Popconfirm, {
       props: { title: 'Are you sure?' },
       slots: { default: () => h('span', 'Delete') },
-    })
+    }))
     expect(wrapper.text()).toContain('Delete')
   })
 
-  it('shows confirmation content when open', () => {
-    const wrapper = mount(Popconfirm, {
+  it('shows confirmation content when open', async () => {
+    trackMount(mount(Popconfirm, {
+      attachTo: document.body,
       props: { title: 'Are you sure?', open: true },
       slots: { default: () => h('span', 'Delete') },
-    })
-    expect(wrapper.find('.ant-popconfirm-title').text()).toBe('Are you sure?')
-    expect(wrapper.find('.ant-popconfirm-buttons').exists()).toBe(true)
+    }))
+
+    await flushPopup()
+    expect(getPopup()?.querySelector('.ant-popconfirm-title')?.textContent).toBe('Are you sure?')
+    expect(getPopup()?.querySelector('.ant-popconfirm-buttons')).not.toBeNull()
   })
 
-  it('shows description when provided', () => {
-    const wrapper = mount(Popconfirm, {
+  it('shows description when provided', async () => {
+    trackMount(mount(Popconfirm, {
+      attachTo: document.body,
       props: { title: 'Are you sure?', description: 'This cannot be undone.', open: true },
       slots: { default: () => h('span', 'Delete') },
-    })
-    expect(wrapper.find('.ant-popconfirm-description').text()).toBe('This cannot be undone.')
+    }))
+
+    await flushPopup()
+    expect(getPopup()?.querySelector('.ant-popconfirm-description')?.textContent).toBe('This cannot be undone.')
   })
 
-  it('does not show description when not provided', () => {
-    const wrapper = mount(Popconfirm, {
+  it('does not show description when not provided', async () => {
+    trackMount(mount(Popconfirm, {
+      attachTo: document.body,
       props: { title: 'Are you sure?', open: true },
       slots: { default: () => h('span', 'Delete') },
-    })
-    expect(wrapper.find('.ant-popconfirm-description').exists()).toBe(false)
+    }))
+
+    await flushPopup()
+    expect(getPopup()?.querySelector('.ant-popconfirm-description')).toBeNull()
   })
 
-  it('shows default OK and Cancel buttons', () => {
-    const wrapper = mount(Popconfirm, {
+  it('shows default OK and Cancel buttons', async () => {
+    trackMount(mount(Popconfirm, {
+      attachTo: document.body,
       props: { title: 'Are you sure?', open: true },
       slots: { default: () => h('span', 'Delete') },
-    })
-    const buttons = wrapper.find('.ant-popconfirm-buttons')
-    expect(buttons.text()).toContain('OK')
-    expect(buttons.text()).toContain('Cancel')
+    }))
+
+    await flushPopup()
+    expect(getPopup()?.textContent).toContain('OK')
+    expect(getPopup()?.textContent).toContain('Cancel')
   })
 
-  it('supports custom okText and cancelText', () => {
-    const wrapper = mount(Popconfirm, {
+  it('does not warn for the default okType legacy mapping', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: { title: 'Are you sure?', open: true },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+
+    await flushPopup()
+
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('Button: `type="primary"` is deprecated'),
+    )
+  })
+
+  it('supports custom okText and cancelText', async () => {
+    trackMount(mount(Popconfirm, {
+      attachTo: document.body,
       props: {
         title: 'Are you sure?',
         open: true,
@@ -64,68 +124,420 @@ describe('Popconfirm', () => {
         cancelText: 'No',
       },
       slots: { default: () => h('span', 'Delete') },
-    })
-    const buttons = wrapper.find('.ant-popconfirm-buttons')
-    expect(buttons.text()).toContain('Yes')
-    expect(buttons.text()).toContain('No')
+    }))
+
+    await flushPopup()
+    expect(getPopup()?.textContent).toContain('Yes')
+    expect(getPopup()?.textContent).toContain('No')
   })
 
-  it('hides cancel button when showCancel is false', () => {
-    const wrapper = mount(Popconfirm, {
+  it('uses Popconfirm locale defaults when button text props are not provided', async () => {
+    trackMount(mount(ConfigProvider, {
+      attachTo: document.body,
+      props: {
+        locale: {
+          locale: 'zh-CN',
+          Popconfirm: {
+            okText: '确定',
+            cancelText: '取消',
+          },
+        },
+      },
+      slots: {
+        default: () => h(Popconfirm, { title: 'Are you sure?', open: true }, {
+          default: () => h('span', 'Delete'),
+        }),
+      },
+    }))
+
+    await flushPopup()
+    expect(getPopup()?.textContent).toContain('确定')
+    expect(getPopup()?.textContent).toContain('取消')
+  })
+
+  it('supports legacy cancel text slot alias', async () => {
+    trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: { title: 'Are you sure?', open: true },
+      slots: {
+        default: () => h('span', 'Delete'),
+        cancel: () => 'Abort',
+      },
+    }))
+
+    await flushPopup()
+    expect(getPopup()?.textContent).toContain('Abort')
+  })
+
+  it('renders title slot content from template setup scope', async () => {
+    trackMount(mount(defineComponent({
+      components: { Popconfirm },
+      setup() {
+        const text = 'Are you sure to delete this task?'
+        return { text }
+      },
+      template: `
+        <Popconfirm :open="true">
+          <template #title>
+            <p>{{ text }}</p>
+            <p>{{ text }}</p>
+          </template>
+          <span>Delete</span>
+        </Popconfirm>
+      `,
+    }), {
+      attachTo: document.body,
+    }))
+
+    await flushPopup()
+    expect(getPopup()?.querySelector('.ant-popconfirm-title')?.textContent)
+      .toContain('Are you sure to delete this task?Are you sure to delete this task?')
+  })
+
+  it('hides cancel button when showCancel is false', async () => {
+    trackMount(mount(Popconfirm, {
+      attachTo: document.body,
       props: { title: 'Are you sure?', open: true, showCancel: false },
       slots: { default: () => h('span', 'Delete') },
-    })
-    const buttons = wrapper.findAll('.ant-popconfirm-buttons .ant-btn')
-    // Only the OK button
-    expect(buttons.length).toBe(1)
+    }))
+
+    await flushPopup()
+    expect(getButtons()).toHaveLength(1)
   })
 
-  it('renders the default warning icon', () => {
-    const wrapper = mount(Popconfirm, {
-      props: { title: 'Are you sure?', open: true },
-      slots: { default: () => h('span', 'Delete') },
-    })
-    expect(wrapper.find('.ant-popconfirm-message-icon svg').exists()).toBe(true)
+  it('hides custom cancelButton slot when showCancel is false', async () => {
+    trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: { title: 'Are you sure?', open: true, showCancel: false },
+      slots: {
+        default: () => h('span', 'Delete'),
+        cancelButton: () => h('button', { class: 'custom-cancel' }, 'Cancel'),
+      },
+    }))
+
+    await flushPopup()
+    expect(getPopup()?.querySelector('.custom-cancel')).toBeNull()
+    expect(getButtons()).toHaveLength(1)
   })
 
-  it('emits confirm event', async () => {
-    const wrapper = mount(Popconfirm, {
+  it('renders the default warning icon', async () => {
+    trackMount(mount(Popconfirm, {
+      attachTo: document.body,
       props: { title: 'Are you sure?', open: true },
       slots: { default: () => h('span', 'Delete') },
-    })
-    const buttons = wrapper.findAll('.ant-popconfirm-buttons .ant-btn')
-    const okBtn = buttons[buttons.length - 1]
-    await okBtn.trigger('click')
-    expect(wrapper.emitted('confirm')).toBeTruthy()
+    }))
+
+    await flushPopup()
+    expect(getPopup()?.querySelector('.ant-popconfirm-message-icon svg')).not.toBeNull()
   })
 
-  it('emits cancel event', async () => {
-    const wrapper = mount(Popconfirm, {
+  it('renders the legacy arrow content structure', async () => {
+    trackMount(mount(Popconfirm, {
+      attachTo: document.body,
       props: { title: 'Are you sure?', open: true },
       slots: { default: () => h('span', 'Delete') },
-    })
-    const buttons = wrapper.findAll('.ant-popconfirm-buttons .ant-btn')
-    const cancelBtn = buttons[0]
-    await cancelBtn.trigger('click')
-    expect(wrapper.emitted('cancel')).toBeTruthy()
+    }))
+
+    await flushPopup()
+    expect(getPopup()?.querySelector('.ant-trigger-arrow-content')).not.toBeNull()
+  })
+
+  it('keeps explicit title, description and text props ahead of slots', async () => {
+    trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: {
+        title: 'Prop title',
+        description: 'Prop description',
+        okText: 'Prop OK',
+        cancelText: 'Prop Cancel',
+        open: true,
+      },
+      slots: {
+        default: () => h('span', 'Delete'),
+        title: () => 'Slot title',
+        description: () => 'Slot description',
+        okText: () => 'Slot OK',
+        cancel: () => 'Slot Cancel',
+        cancelText: () => 'Slot Cancel Text',
+      },
+    }))
+
+    await flushPopup()
+
+    const popupText = getPopup()?.textContent ?? ''
+    expect(getPopup()?.querySelector('.ant-popconfirm-title')?.textContent).toContain('Prop title')
+    expect(getPopup()?.querySelector('.ant-popconfirm-title')?.textContent).not.toContain('Slot title')
+    expect(getPopup()?.querySelector('.ant-popconfirm-description')?.textContent).toContain('Prop description')
+    expect(getPopup()?.querySelector('.ant-popconfirm-description')?.textContent).not.toContain('Slot description')
+    expect(popupText).toContain('Prop OK')
+    expect(popupText).toContain('Prop Cancel')
+    expect(popupText).not.toContain('Slot OK')
+    expect(popupText).not.toContain('Slot Cancel')
+    expect(popupText).not.toContain('Slot Cancel Text')
+  })
+
+  it('calls confirm handler and closes popup', async () => {
+    const confirm = vi.fn()
+    const wrapper = trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: { title: 'Are you sure?', trigger: 'click' },
+      attrs: { onConfirm: confirm },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+    await wrapper.find('.ant-trigger-wrapper').trigger('click')
+    await flushPopup()
+
+    getButtons()[1]?.click()
+    await flushPopup()
+
+    expect(confirm).toHaveBeenCalledTimes(1)
+    expect((wrapper.vm as { getPopupDomNode: () => HTMLElement | null }).getPopupDomNode()?.style.display).toBe('none')
+  })
+
+  it('calls cancel handler and closes popup', async () => {
+    const cancel = vi.fn()
+    const wrapper = trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: { title: 'Are you sure?', open: true },
+      attrs: { onCancel: cancel },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+
+    await flushPopup()
+    getButtons()[0]?.click()
+    await flushPopup()
+
+    expect(cancel).toHaveBeenCalledTimes(1)
+    expect(wrapper.emitted('openChange')?.at(-1)?.[0]).toBe(false)
+    expect(wrapper.emitted('openChange')?.at(-1)?.[1]).toBeInstanceOf(MouseEvent)
+    expect(wrapper.emitted('visibleChange')?.at(-1)?.[1]).toBeInstanceOf(MouseEvent)
+  })
+
+  it('keeps template confirm and cancel listeners working in controlled mode', async () => {
+    const confirm = vi.fn()
+    const cancel = vi.fn()
+
+    trackMount(mount(defineComponent({
+      components: { Popconfirm },
+      setup() {
+        const open = ref(false)
+
+        const handleOpenChange = (value: boolean) => {
+          open.value = value
+        }
+
+        const handleConfirm = () => {
+          confirm()
+          open.value = false
+        }
+
+        const handleCancel = () => {
+          cancel()
+          open.value = false
+        }
+
+        return {
+          open,
+          handleOpenChange,
+          handleConfirm,
+          handleCancel,
+        }
+      },
+      template: `
+        <Popconfirm
+          :open="open"
+          title="Are you sure?"
+          trigger="click"
+          @openChange="handleOpenChange"
+          @confirm="handleConfirm"
+          @cancel="handleCancel"
+        >
+          <span>Delete</span>
+        </Popconfirm>
+      `,
+    }), {
+      attachTo: document.body,
+    }))
+
+    const trigger = document.body.querySelector('.ant-trigger-wrapper') as HTMLElement | null
+    trigger?.click()
+    await flushPopup()
+
+    getButtons()[1]?.click()
+    await flushPopup()
+
+    expect(confirm).toHaveBeenCalledTimes(1)
+    expect(getPopup()?.style.display).toBe('none')
+
+    trigger?.click()
+    await flushPopup()
+
+    getButtons()[0]?.click()
+    await flushPopup()
+
+    expect(cancel).toHaveBeenCalledTimes(1)
+    expect(getPopup()?.style.display).toBe('none')
   })
 
   it('is disabled when disabled prop is true', () => {
-    const wrapper = mount(Popconfirm, {
+    const wrapper = trackMount(mount(Popconfirm, {
       props: { title: 'Are you sure?', disabled: true },
       slots: { default: () => h('span', 'Delete') },
-    })
+    }))
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('supports icon slot', () => {
-    const wrapper = mount(Popconfirm, {
+  it('supports icon prop', async () => {
+    trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: { title: 'Are you sure?', open: true, icon: QuestionCircleOutlined },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+
+    await flushPopup()
+    expect(document.body.querySelector('[data-icon="question-circle"]')).not.toBeNull()
+  })
+
+  it('opens on click and exposes popup dom node', async () => {
+    const wrapper = trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: { title: 'Are you sure?', trigger: 'click' },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+
+    expect(getPopup()).toBeNull()
+
+    await wrapper.find('.ant-trigger-wrapper').trigger('click')
+    await flushPopup()
+
+    const popup = getPopup()
+    expect(popup).not.toBeNull()
+    expect(popup?.style.display).not.toBe('none')
+    expect((wrapper.vm as { getPopupDomNode: () => HTMLElement | null }).getPopupDomNode()).toBe(popup)
+    expect(wrapper.emitted('update:open')?.[0]).toEqual([true])
+    expect(wrapper.emitted('openChange')?.[0]).toEqual([true, undefined])
+    expect(wrapper.emitted('update:visible')?.[0]).toEqual([true])
+    expect(wrapper.emitted('visibleChange')?.[0]).toEqual([true, undefined])
+  })
+
+  it('does not open when disabled', async () => {
+    const wrapper = trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: { title: 'Are you sure?', trigger: 'click', disabled: true },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+
+    await wrapper.find('.ant-trigger-wrapper').trigger('click')
+    await flushPopup()
+
+    expect(getPopup()).toBeNull()
+    expect(wrapper.emitted('update:open')).toBeUndefined()
+  })
+
+  it('closes on escape without emitting cancel', async () => {
+    const wrapper = trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: { title: 'Are you sure?', defaultOpen: true },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+
+    await flushPopup()
+    expect(getPopup()?.style.display).not.toBe('none')
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await flushPopup()
+
+    expect(getPopup()?.style.display).toBe('none')
+    expect(wrapper.emitted('cancel')).toBeUndefined()
+    expect(wrapper.emitted('update:open')?.at(-1)).toEqual([false])
+    expect(wrapper.emitted('openChange')?.at(-1)?.[1]).toBeInstanceOf(KeyboardEvent)
+    expect(wrapper.emitted('visibleChange')?.at(-1)?.[1]).toBeInstanceOf(KeyboardEvent)
+  })
+
+  it('keeps popup open and shows loading until async confirm resolves', async () => {
+    vi.useFakeTimers()
+    const confirm = vi.fn(
+      () => new Promise(resolve => {
+        setTimeout(resolve, 100)
+      }),
+    )
+    const wrapper = trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: { title: 'Are you sure?', trigger: 'click' },
+      attrs: { onConfirm: confirm },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+    await wrapper.find('.ant-trigger-wrapper').trigger('click')
+    await flushPopup()
+
+    const okButton = getButtons()[1]
+    expect(okButton).toBeDefined()
+
+    okButton?.click()
+    await flushPopup()
+
+    expect(confirm).toHaveBeenCalledTimes(1)
+    expect((wrapper.vm as { getPopupDomNode: () => HTMLElement | null }).getPopupDomNode()?.style.display).not.toBe('none')
+    expect(getButtons()[1]?.className).toContain('ant-btn-loading')
+
+    await vi.advanceTimersByTimeAsync(100)
+    await Promise.resolve()
+    await nextTick()
+    await flushPopup()
+
+    expect(wrapper.emitted('update:open')?.at(-1)).toEqual([false])
+    expect(wrapper.emitted('visibleChange')?.at(-1)).toEqual([false, undefined])
+  })
+
+  it('passes legacy-compatible props into custom button slots', async () => {
+    let receivedCancelSlotProps: PopconfirmCancelButtonSlotProps | undefined
+    let receivedOkSlotProps: PopconfirmOkButtonSlotProps | undefined
+
+    trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: {
+        title: 'Are you sure?',
+        open: true,
+        cancelButtonProps: { shape: 'round' },
+        okButtonProps: { danger: true },
+      },
+      slots: {
+        default: () => h('span', 'Delete'),
+        cancelButton: slotProps => {
+          receivedCancelSlotProps = slotProps
+          return h('button', { class: 'custom-cancel', onClick: slotProps.onClick }, 'Cancel')
+        },
+        okButton: slotProps => {
+          receivedOkSlotProps = slotProps
+          return h('button', { class: 'custom-ok', onClick: slotProps.onClick }, 'OK')
+        },
+      },
+    }))
+
+    await flushPopup()
+
+    expect(receivedCancelSlotProps?.size).toBe('small')
+    expect(receivedCancelSlotProps?.shape).toBe('round')
+    expect(typeof receivedCancelSlotProps?.onClick).toBe('function')
+    expect(typeof receivedCancelSlotProps?.cancel).toBe('function')
+    expect(receivedOkSlotProps?.size).toBe('small')
+    expect(receivedOkSlotProps?.type).toBe('primary')
+    expect(receivedOkSlotProps?.danger).toBe(true)
+    expect(typeof receivedOkSlotProps?.onClick).toBe('function')
+    expect(typeof receivedOkSlotProps?.confirm).toBe('function')
+  })
+
+  it('supports icon slot', async () => {
+    trackMount(mount(Popconfirm, {
+      attachTo: document.body,
       props: { title: 'Are you sure?', open: true },
       slots: {
         default: () => h('span', 'Delete'),
         icon: () => h('span', { class: 'custom-icon' }, '?'),
       },
-    })
-    expect(wrapper.find('.custom-icon').exists()).toBe(true)
+    }))
+
+    await flushPopup()
+    expect(getPopup()?.querySelector('.custom-icon')).not.toBeNull()
   })
 })

--- a/packages/ui/src/components/popconfirm/__tests__/index.test.ts
+++ b/packages/ui/src/components/popconfirm/__tests__/index.test.ts
@@ -469,6 +469,20 @@ describe('Popconfirm', () => {
     expect(wrapper.emitted('update:open')?.[0]).toEqual([true])
   })
 
+  it('treats explicit open=undefined as controlled false', async () => {
+    const wrapper = trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: { title: 'Are you sure?', trigger: 'click', open: undefined },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+
+    await wrapper.find('.ant-trigger-wrapper').trigger('click')
+    await flushPopup()
+
+    expect(getPopup()).toBeNull()
+    expect(wrapper.emitted('update:open')?.[0]).toEqual([true])
+  })
+
   it('is disabled when disabled prop is true', () => {
     const wrapper = trackMount(mount(Popconfirm, {
       props: { title: 'Are you sure?', disabled: true },

--- a/packages/ui/src/components/popconfirm/__tests__/index.test.ts
+++ b/packages/ui/src/components/popconfirm/__tests__/index.test.ts
@@ -281,8 +281,7 @@ describe('Popconfirm', () => {
     const confirm = vi.fn()
     const wrapper = trackMount(mount(Popconfirm, {
       attachTo: document.body,
-      props: { title: 'Are you sure?', trigger: 'click' },
-      attrs: { onConfirm: confirm },
+      props: { title: 'Are you sure?', trigger: 'click', onConfirm: confirm },
       slots: { default: () => h('span', 'Delete') },
     }))
     await wrapper.find('.ant-trigger-wrapper').trigger('click')
@@ -292,6 +291,7 @@ describe('Popconfirm', () => {
     await flushPopup()
 
     expect(confirm).toHaveBeenCalledTimes(1)
+    expect(wrapper.emitted('confirm')?.at(-1)?.[0]).toBeInstanceOf(MouseEvent)
     expect((wrapper.vm as { getPopupDomNode: () => HTMLElement | null }).getPopupDomNode()?.style.display).toBe('none')
   })
 
@@ -299,8 +299,7 @@ describe('Popconfirm', () => {
     const cancel = vi.fn()
     const wrapper = trackMount(mount(Popconfirm, {
       attachTo: document.body,
-      props: { title: 'Are you sure?', open: true },
-      attrs: { onCancel: cancel },
+      props: { title: 'Are you sure?', open: true, onCancel: cancel },
       slots: { default: () => h('span', 'Delete') },
     }))
 
@@ -309,6 +308,7 @@ describe('Popconfirm', () => {
     await flushPopup()
 
     expect(cancel).toHaveBeenCalledTimes(1)
+    expect(wrapper.emitted('cancel')?.at(-1)?.[0]).toBeInstanceOf(MouseEvent)
     expect(wrapper.emitted('openChange')?.at(-1)?.[0]).toBe(false)
     expect(wrapper.emitted('openChange')?.at(-1)?.[1]).toBeInstanceOf(MouseEvent)
     expect(wrapper.emitted('visibleChange')?.at(-1)?.[1]).toBeInstanceOf(MouseEvent)
@@ -378,6 +378,54 @@ describe('Popconfirm', () => {
 
     expect(cancel).toHaveBeenCalledTimes(1)
     expect(getPopup()?.style.display).toBe('none')
+  })
+
+  it('supports once modifiers on confirm listeners', async () => {
+    const confirm = vi.fn()
+
+    trackMount(mount(defineComponent({
+      components: { Popconfirm },
+      setup() {
+        const open = ref(false)
+
+        const handleOpenChange = (value: boolean) => {
+          open.value = value
+        }
+
+        return {
+          open,
+          confirm,
+          handleOpenChange,
+        }
+      },
+      template: `
+        <Popconfirm
+          :open="open"
+          title="Are you sure?"
+          trigger="click"
+          @openChange="handleOpenChange"
+          @confirm.once="confirm"
+        >
+          <span>Delete</span>
+        </Popconfirm>
+      `,
+    }), {
+      attachTo: document.body,
+    }))
+
+    const trigger = document.body.querySelector('.ant-trigger-wrapper') as HTMLElement | null
+
+    trigger?.click()
+    await flushPopup()
+    getButtons()[1]?.click()
+    await flushPopup()
+
+    trigger?.click()
+    await flushPopup()
+    getButtons()[1]?.click()
+    await flushPopup()
+
+    expect(confirm).toHaveBeenCalledTimes(1)
   })
 
   it('is disabled when disabled prop is true', () => {
@@ -464,8 +512,7 @@ describe('Popconfirm', () => {
     )
     const wrapper = trackMount(mount(Popconfirm, {
       attachTo: document.body,
-      props: { title: 'Are you sure?', trigger: 'click' },
-      attrs: { onConfirm: confirm },
+      props: { title: 'Are you sure?', trigger: 'click', onConfirm: confirm },
       slots: { default: () => h('span', 'Delete') },
     }))
     await wrapper.find('.ant-trigger-wrapper').trigger('click')

--- a/packages/ui/src/components/popconfirm/__tests__/index.test.ts
+++ b/packages/ui/src/components/popconfirm/__tests__/index.test.ts
@@ -658,6 +658,31 @@ describe('Popconfirm', () => {
     expect(getPopup()?.style.display).toBe('none')
   })
 
+  it('keeps default cancel button prop click handlers', async () => {
+    const firstCancelClick = vi.fn()
+    const secondCancelClick = vi.fn()
+    const wrapper = trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: {
+        title: 'Are you sure?',
+        defaultOpen: true,
+        cancelButtonProps: {
+          onClick: [firstCancelClick, secondCancelClick],
+        } as any,
+      },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+
+    await flushPopup()
+
+    getButtons()[0]?.click()
+    await flushPopup()
+
+    expect(firstCancelClick).toHaveBeenCalledTimes(1)
+    expect(secondCancelClick).toHaveBeenCalledTimes(1)
+    expect((wrapper.vm as { getPopupDomNode: () => HTMLElement | null }).getPopupDomNode()?.style.display).toBe('none')
+  })
+
   it('keeps custom ok button prop click handlers when slot props invoke confirm', async () => {
     const okButtonClick = vi.fn()
 
@@ -695,6 +720,60 @@ describe('Popconfirm', () => {
 
     expect(okButtonClick).toHaveBeenCalledTimes(1)
     expect(getPopup()?.style.display).toBe('none')
+  })
+
+  it('keeps default ok button prop click handlers', async () => {
+    const firstOkClick = vi.fn()
+    const secondOkClick = vi.fn()
+    const wrapper = trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: {
+        title: 'Are you sure?',
+        defaultOpen: true,
+        okButtonProps: {
+          onClick: [firstOkClick, secondOkClick],
+        } as any,
+      },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+
+    await flushPopup()
+
+    getButtons()[1]?.click()
+    await flushPopup()
+
+    expect(firstOkClick).toHaveBeenCalledTimes(1)
+    expect(secondOkClick).toHaveBeenCalledTimes(1)
+    expect((wrapper.vm as { getPopupDomNode: () => HTMLElement | null }).getPopupDomNode()?.style.display).toBe('none')
+  })
+
+  it('resets confirm loading when controlled open closes externally', async () => {
+    const confirm = vi.fn(() => new Promise(() => {}))
+    const wrapper = trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: {
+        title: 'Are you sure?',
+        open: true,
+        onConfirm: confirm,
+      },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+
+    await flushPopup()
+
+    getButtons()[1]?.click()
+    await flushPopup()
+
+    expect(confirm).toHaveBeenCalledTimes(1)
+    expect(getButtons()[1]?.className).toContain('ant-btn-loading')
+
+    await wrapper.setProps({ open: false })
+    await flushPopup()
+
+    await wrapper.setProps({ open: true })
+    await flushPopup()
+
+    expect(getButtons()[1]?.className ?? '').not.toContain('ant-btn-loading')
   })
 
   it('supports icon slot', async () => {

--- a/packages/ui/src/components/popconfirm/__tests__/index.test.ts
+++ b/packages/ui/src/components/popconfirm/__tests__/index.test.ts
@@ -527,6 +527,86 @@ describe('Popconfirm', () => {
     expect(typeof receivedOkSlotProps?.confirm).toBe('function')
   })
 
+  it('keeps custom cancel button prop click handlers when slot props invoke cancel', async () => {
+    const cancelButtonClick = vi.fn()
+
+    trackMount(mount(defineComponent({
+      components: { Popconfirm },
+      setup() {
+        const open = ref(true)
+
+        return {
+          open,
+          cancelButtonClick,
+        }
+      },
+      template: `
+        <div>
+          <Popconfirm
+            :open="open"
+            title="Are you sure?"
+            :cancelButtonProps="{ onClick: cancelButtonClick }"
+            @openChange="open = $event"
+          >
+            <template #cancelButton="slotProps">
+              <button class="custom-cancel" @click="slotProps.onClick">Cancel</button>
+            </template>
+            <span>Delete</span>
+          </Popconfirm>
+        </div>
+      `,
+    }), {
+      attachTo: document.body,
+    }))
+
+    await flushPopup()
+
+    ;(document.body.querySelector('.custom-cancel') as HTMLButtonElement | null)?.click()
+    await flushPopup()
+
+    expect(cancelButtonClick).toHaveBeenCalledTimes(1)
+    expect(getPopup()?.style.display).toBe('none')
+  })
+
+  it('keeps custom ok button prop click handlers when slot props invoke confirm', async () => {
+    const okButtonClick = vi.fn()
+
+    trackMount(mount(defineComponent({
+      components: { Popconfirm },
+      setup() {
+        const open = ref(true)
+
+        return {
+          open,
+          okButtonClick,
+        }
+      },
+      template: `
+        <Popconfirm
+          :open="open"
+          title="Are you sure?"
+          :okButtonProps="{ onClick: okButtonClick }"
+          @openChange="open = $event"
+        >
+          <template #okButton="slotProps">
+            <button class="custom-ok" @click="slotProps.onClick">OK</button>
+          </template>
+          <span>Delete</span>
+        </Popconfirm>
+      `,
+    }), {
+      attachTo: document.body,
+    }))
+
+    await flushPopup()
+
+    ;(document.body.querySelector('.custom-ok') as HTMLButtonElement | null)?.click()
+    await flushPopup()
+
+    expect(okButtonClick).toHaveBeenCalledTimes(1)
+    expect(getPopup()?.style.display).toBe('none')
+  })
+
   it('supports icon slot', async () => {
     trackMount(mount(Popconfirm, {
       attachTo: document.body,

--- a/packages/ui/src/components/popconfirm/__tests__/index.test.ts
+++ b/packages/ui/src/components/popconfirm/__tests__/index.test.ts
@@ -291,7 +291,6 @@ describe('Popconfirm', () => {
     await flushPopup()
 
     expect(confirm).toHaveBeenCalledTimes(1)
-    expect(wrapper.emitted('confirm')?.at(-1)?.[0]).toBeInstanceOf(MouseEvent)
     expect((wrapper.vm as { getPopupDomNode: () => HTMLElement | null }).getPopupDomNode()?.style.display).toBe('none')
   })
 
@@ -308,10 +307,38 @@ describe('Popconfirm', () => {
     await flushPopup()
 
     expect(cancel).toHaveBeenCalledTimes(1)
-    expect(wrapper.emitted('cancel')?.at(-1)?.[0]).toBeInstanceOf(MouseEvent)
     expect(wrapper.emitted('openChange')?.at(-1)?.[0]).toBe(false)
     expect(wrapper.emitted('openChange')?.at(-1)?.[1]).toBeInstanceOf(MouseEvent)
     expect(wrapper.emitted('visibleChange')?.at(-1)?.[1]).toBeInstanceOf(MouseEvent)
+  })
+
+  it('emits confirm events on button clicks without explicit handlers', async () => {
+    const confirmWrapper = trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: { title: 'Are you sure?', trigger: 'click' },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+
+    await confirmWrapper.find('.ant-trigger-wrapper').trigger('click')
+    await flushPopup()
+    getButtons()[1]?.click()
+    await flushPopup()
+
+    expect(confirmWrapper.emitted('confirm')?.at(-1)?.[0]).toBeInstanceOf(MouseEvent)
+  })
+
+  it('emits cancel events on button clicks without explicit handlers', async () => {
+    const cancelWrapper = trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: { title: 'Are you sure?', open: true },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+
+    await flushPopup()
+    getButtons()[0]?.click()
+    await flushPopup()
+
+    expect(cancelWrapper.emitted('cancel')?.at(-1)?.[0]).toBeInstanceOf(MouseEvent)
   })
 
   it('keeps template confirm and cancel listeners working in controlled mode', async () => {
@@ -428,6 +455,20 @@ describe('Popconfirm', () => {
     expect(confirm).toHaveBeenCalledTimes(1)
   })
 
+  it('treats open=null as uncontrolled', async () => {
+    const wrapper = trackMount(mount(Popconfirm, {
+      attachTo: document.body,
+      props: { title: 'Are you sure?', trigger: 'click', open: null },
+      slots: { default: () => h('span', 'Delete') },
+    }))
+
+    await wrapper.find('.ant-trigger-wrapper').trigger('click')
+    await flushPopup()
+
+    expect(getPopup()).not.toBeNull()
+    expect(wrapper.emitted('update:open')?.[0]).toEqual([true])
+  })
+
   it('is disabled when disabled prop is true', () => {
     const wrapper = trackMount(mount(Popconfirm, {
       props: { title: 'Are you sure?', disabled: true },
@@ -534,7 +575,8 @@ describe('Popconfirm', () => {
     await flushPopup()
 
     expect(wrapper.emitted('update:open')?.at(-1)).toEqual([false])
-    expect(wrapper.emitted('visibleChange')?.at(-1)).toEqual([false, undefined])
+    expect(wrapper.emitted('openChange')?.at(-1)?.[1]).toBeInstanceOf(MouseEvent)
+    expect(wrapper.emitted('visibleChange')?.at(-1)?.[1]).toBeInstanceOf(MouseEvent)
   })
 
   it('passes legacy-compatible props into custom button slots', async () => {

--- a/packages/ui/src/components/popconfirm/__tests__/index.test.ts
+++ b/packages/ui/src/components/popconfirm/__tests__/index.test.ts
@@ -31,6 +31,7 @@ function getButtons() {
 
 afterEach(() => {
   mountedWrappers.splice(0).reverse().forEach(wrapper => wrapper.unmount())
+  vi.restoreAllMocks()
   vi.useRealTimers()
   document.body.innerHTML = ''
 })

--- a/packages/ui/src/components/popconfirm/style/index.css
+++ b/packages/ui/src/components/popconfirm/style/index.css
@@ -51,5 +51,5 @@
 }
 
 :where(.ant-popconfirm) .ant-trigger-arrow {
-  background: var(--popconfirm-bg);
+  --ant-trigger-arrow-background: var(--popconfirm-bg);
 }

--- a/packages/ui/src/components/popconfirm/types.ts
+++ b/packages/ui/src/components/popconfirm/types.ts
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'vue'
 import type { MaybeArray, Slot, ScopedSlot } from '@/utils/types'
 import type { TooltipPlacement } from '../tooltip/types'
 import type { TriggerType } from '@/_internal/trigger/types'
@@ -60,7 +61,7 @@ export interface PopconfirmProps {
   /** Class for the overlay */
   overlayClassName?: string
   /** Style for the overlay */
-  overlayStyle?: Record<string, string>
+  overlayStyle?: CSSProperties
   /** Destroy popup on hide */
   destroyTooltipOnHide?: boolean
   /** Auto adjust when near edges */

--- a/packages/ui/src/components/popconfirm/types.ts
+++ b/packages/ui/src/components/popconfirm/types.ts
@@ -1,7 +1,24 @@
-import type { Slot, ScopedSlot } from '@/utils/types'
-import type { TooltipPlacement, TooltipEmits } from '../tooltip/types'
+import type { MaybeArray, Slot, ScopedSlot } from '@/utils/types'
+import type { TooltipPlacement } from '../tooltip/types'
 import type { TriggerType } from '@/_internal/trigger/types'
 import type { ButtonProps } from '../button/types'
+
+export type PopconfirmOpenChangeEvent = MouseEvent | KeyboardEvent | undefined
+export type PopconfirmConfirmHandler = (event: MouseEvent) => unknown | Promise<unknown>
+export type PopconfirmCancelHandler = (event: MouseEvent) => void
+
+export interface PopconfirmCancelButtonSlotProps extends Partial<ButtonProps> {
+  onClick?: (event: MouseEvent) => void
+  size?: ButtonProps['size']
+  cancel: (event: MouseEvent) => void
+}
+
+export interface PopconfirmOkButtonSlotProps extends Partial<ButtonProps> {
+  onClick?: (event: MouseEvent) => void
+  size?: ButtonProps['size']
+  type?: ButtonProps['type']
+  confirm: (event: MouseEvent) => void
+}
 
 export interface PopconfirmProps {
   /** The confirmation message */
@@ -52,6 +69,10 @@ export interface PopconfirmProps {
   getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement
   /** Z-index */
   zIndex?: number
+  /** Confirm callback; can return a Promise to delay closing */
+  onConfirm?: MaybeArray<PopconfirmConfirmHandler>
+  /** Cancel callback */
+  onCancel?: MaybeArray<PopconfirmCancelHandler>
 }
 
 export const popconfirmDefaultProps = {
@@ -71,13 +92,11 @@ export const popconfirmDefaultProps = {
 
 export interface PopconfirmEmits {
   (e: 'update:open', open: boolean): void
-  (e: 'openChange', open: boolean): void
-  (e: 'confirm', event: MouseEvent): void
-  (e: 'cancel', event: MouseEvent): void
+  (e: 'openChange', open: boolean, event?: PopconfirmOpenChangeEvent): void
   /** @deprecated */
   (e: 'update:visible', open: boolean): void
   /** @deprecated */
-  (e: 'visibleChange', open: boolean): void
+  (e: 'visibleChange', open: boolean, event?: PopconfirmOpenChangeEvent): void
 }
 
 export interface PopconfirmSlots {
@@ -91,10 +110,12 @@ export interface PopconfirmSlots {
   icon?: Slot
   /** Custom OK button text */
   okText?: Slot
+  /** Legacy custom Cancel button text */
+  cancel?: Slot
   /** Custom Cancel button text */
   cancelText?: Slot
   /** Custom cancel button */
-  cancelButton?: ScopedSlot<{ cancel: (e: MouseEvent) => void }>
+  cancelButton?: ScopedSlot<PopconfirmCancelButtonSlotProps>
   /** Custom OK button */
-  okButton?: ScopedSlot<{ confirm: (e: MouseEvent) => void }>
+  okButton?: ScopedSlot<PopconfirmOkButtonSlotProps>
 }

--- a/packages/ui/src/components/popconfirm/types.ts
+++ b/packages/ui/src/components/popconfirm/types.ts
@@ -93,6 +93,8 @@ export const popconfirmDefaultProps = {
 export interface PopconfirmEmits {
   (e: 'update:open', open: boolean): void
   (e: 'openChange', open: boolean, event?: PopconfirmOpenChangeEvent): void
+  (e: 'confirm', event: MouseEvent): void
+  (e: 'cancel', event: MouseEvent): void
   /** @deprecated */
   (e: 'update:visible', open: boolean): void
   /** @deprecated */

--- a/packages/ui/src/components/popover/__tests__/__snapshots__/demo.test.ts.snap
+++ b/packages/ui/src/components/popover/__tests__/__snapshots__/demo.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Popover demos > demo: Basic 1`] = `
-"<span class="ant-trigger-wrapper"><button class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Hover me</span></button></span>
+"<span class="ant-trigger-wrapper"><button class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Hover me</span></button></span>
 <!--teleport start-->
 
 <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
@@ -13,68 +13,68 @@ exports[`Popover demos > demo: Basic 1`] = `
 
 exports[`Popover demos > demo: Placement 1`] = `
 "<div data-v-a5a37ae6="" id="components-popover-demo-placement">
-  <div data-v-a5a37ae6="" style="margin-left: 70px; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">TL</span></button></span>
+  <div data-v-a5a37ae6="" style="margin-left: 70px; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">TL</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Top</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Top</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">TR</span></button></span>
-    <!--teleport start-->
-    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
-      <!--v-if-->
-    </transition-stub>
-    <!--teleport end-->
-  </div>
-  <div data-v-a5a37ae6="" style="width: 70px; float: left;"><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">LT</span></button></span>
-    <!--teleport start-->
-    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
-      <!--v-if-->
-    </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Left</span></button></span>
-    <!--teleport start-->
-    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
-      <!--v-if-->
-    </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">LB</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">TR</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
     <!--teleport end-->
   </div>
-  <div data-v-a5a37ae6="" style="width: 70px; margin-left: 304px;"><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">RT</span></button></span>
+  <div data-v-a5a37ae6="" style="width: 70px; float: left;"><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">LT</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Right</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Left</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">RB</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">LB</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
     <!--teleport end-->
   </div>
-  <div data-v-a5a37ae6="" style="margin-left: 70px; clear: both; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">BL</span></button></span>
+  <div data-v-a5a37ae6="" style="width: 70px; margin-left: 304px;"><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">RT</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Bottom</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Right</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">BR</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">RB</span></button></span>
+    <!--teleport start-->
+    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <!--teleport end-->
+  </div>
+  <div data-v-a5a37ae6="" style="margin-left: 70px; clear: both; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">BL</span></button></span>
+    <!--teleport start-->
+    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Bottom</span></button></span>
+    <!--teleport start-->
+    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-a5a37ae6="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">BR</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
@@ -85,17 +85,17 @@ exports[`Popover demos > demo: Placement 1`] = `
 `;
 
 exports[`Popover demos > demo: Trigger 1`] = `
-"<div style="display: flex; gap: 16px; padding: 40px;"><span class="ant-trigger-wrapper"><button class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Hover</span></button></span>
+"<div style="display: flex; gap: 16px; padding: 40px;"><span class="ant-trigger-wrapper"><button class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Hover</span></button></span>
   <!--teleport start-->
   <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
     <!--v-if-->
   </transition-stub>
-  <!--teleport end--><span class="ant-trigger-wrapper"><button class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Click</span></button></span>
+  <!--teleport end--><span class="ant-trigger-wrapper"><button class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Click</span></button></span>
   <!--teleport start-->
   <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
     <!--v-if-->
   </transition-stub>
-  <!--teleport end--><span class="ant-trigger-wrapper"><button class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Focus</span></button></span>
+  <!--teleport end--><span class="ant-trigger-wrapper"><button class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Focus</span></button></span>
   <!--teleport start-->
   <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
     <!--v-if-->

--- a/packages/ui/src/components/popover/style/index.css
+++ b/packages/ui/src/components/popover/style/index.css
@@ -39,5 +39,5 @@
 }
 
 :where(.ant-popover) .ant-trigger-arrow {
-  background: var(--popover-bg);
+  --ant-trigger-arrow-background: var(--popover-bg);
 }

--- a/packages/ui/src/components/tooltip/__tests__/__snapshots__/demo.test.ts.snap
+++ b/packages/ui/src/components/tooltip/__tests__/__snapshots__/demo.test.ts.snap
@@ -12,68 +12,68 @@ exports[`Tooltip demos > demo: Arrow 1`] = `
       </div>
     </div>
   </div>
-  <div data-v-bf157145="" style="margin-left: 70px; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">TL</span></button></span>
+  <div data-v-bf157145="" style="margin-left: 70px; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">TL</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Top</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Top</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">TR</span></button></span>
-    <!--teleport start-->
-    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
-      <!--v-if-->
-    </transition-stub>
-    <!--teleport end-->
-  </div>
-  <div data-v-bf157145="" style="width: 70px; float: left;"><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">LT</span></button></span>
-    <!--teleport start-->
-    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
-      <!--v-if-->
-    </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Left</span></button></span>
-    <!--teleport start-->
-    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
-      <!--v-if-->
-    </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">LB</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">TR</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
     <!--teleport end-->
   </div>
-  <div data-v-bf157145="" style="width: 70px; margin-left: 304px;"><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">RT</span></button></span>
+  <div data-v-bf157145="" style="width: 70px; float: left;"><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">LT</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Right</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Left</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">RB</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">LB</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
     <!--teleport end-->
   </div>
-  <div data-v-bf157145="" style="margin-left: 70px; clear: both; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">BL</span></button></span>
+  <div data-v-bf157145="" style="width: 70px; margin-left: 304px;"><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">RT</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Bottom</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Right</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">BR</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">RB</span></button></span>
+    <!--teleport start-->
+    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <!--teleport end-->
+  </div>
+  <div data-v-bf157145="" style="margin-left: 70px; clear: both; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">BL</span></button></span>
+    <!--teleport start-->
+    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Bottom</span></button></span>
+    <!--teleport start-->
+    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-bf157145="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">BR</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
@@ -97,67 +97,67 @@ exports[`Tooltip demos > demo: Basic 1`] = `
 exports[`Tooltip demos > demo: Color 1`] = `
 "<div data-v-6cac8c94="" id="components-a-tooltip-demo-color">
   <div data-v-6cac8c94="" class="ant-divider ant-divider-horizontal ant-divider-with-text ant-divider-with-text-left" role="separator" aria-orientation="horizontal"><span class="ant-divider-inner-text">Presets</span></div>
-  <div data-v-6cac8c94=""><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">pink</span></button></span>
+  <div data-v-6cac8c94=""><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">pink</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">red</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">red</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">yellow</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">yellow</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">orange</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">orange</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">cyan</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">cyan</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">green</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">green</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">blue</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">blue</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">purple</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">purple</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">geekblue</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">geekblue</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">magenta</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">magenta</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">volcano</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">volcano</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">gold</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">gold</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">lime</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">lime</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
@@ -165,22 +165,22 @@ exports[`Tooltip demos > demo: Color 1`] = `
     <!--teleport end-->
   </div>
   <div data-v-6cac8c94="" class="ant-divider ant-divider-horizontal ant-divider-with-text ant-divider-with-text-left" role="separator" aria-orientation="horizontal"><span class="ant-divider-inner-text">Custom</span></div>
-  <div data-v-6cac8c94=""><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">#f50</span></button></span>
+  <div data-v-6cac8c94=""><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">#f50</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">#2db7f5</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">#2db7f5</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">#87d068</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">#87d068</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">#108ee9</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-6cac8c94="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">#108ee9</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
@@ -192,68 +192,68 @@ exports[`Tooltip demos > demo: Color 1`] = `
 
 exports[`Tooltip demos > demo: Placement 1`] = `
 "<div data-v-3f5ce8bf="" id="components-a-tooltip-demo-placement">
-  <div data-v-3f5ce8bf="" style="margin-left: 70px; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">TL</span></button></span>
+  <div data-v-3f5ce8bf="" style="margin-left: 70px; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">TL</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Top</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Top</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">TR</span></button></span>
-    <!--teleport start-->
-    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
-      <!--v-if-->
-    </transition-stub>
-    <!--teleport end-->
-  </div>
-  <div data-v-3f5ce8bf="" style="width: 70px; float: left;"><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">LT</span></button></span>
-    <!--teleport start-->
-    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
-      <!--v-if-->
-    </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Left</span></button></span>
-    <!--teleport start-->
-    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
-      <!--v-if-->
-    </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">LB</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">TR</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
     <!--teleport end-->
   </div>
-  <div data-v-3f5ce8bf="" style="width: 70px; margin-left: 304px;"><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">RT</span></button></span>
+  <div data-v-3f5ce8bf="" style="width: 70px; float: left;"><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">LT</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Right</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Left</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">RB</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">LB</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
     <!--teleport end-->
   </div>
-  <div data-v-3f5ce8bf="" style="margin-left: 70px; clear: both; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">BL</span></button></span>
+  <div data-v-3f5ce8bf="" style="width: 70px; margin-left: 304px;"><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">RT</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">Bottom</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Right</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->
     </transition-stub>
-    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-solid ant-btn-md" type="button"><!--v-if--><!--v-if--><span class="ant-btn-content">BR</span></button></span>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">RB</span></button></span>
+    <!--teleport start-->
+    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <!--teleport end-->
+  </div>
+  <div data-v-3f5ce8bf="" style="margin-left: 70px; clear: both; white-space: nowrap;"><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">BL</span></button></span>
+    <!--teleport start-->
+    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">Bottom</span></button></span>
+    <!--teleport start-->
+    <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <!--teleport end--><span class="ant-trigger-wrapper"><button data-v-3f5ce8bf="" class="ant-btn ant-btn-outlined ant-btn-md" type="button"><!--v-if--><transition-stub appear="false" persisted="false" css="true"><!--v-if--></transition-stub><span class="ant-btn-content">BR</span></button></span>
     <!--teleport start-->
     <transition-stub name="ant-zoom-big-fast" appear="false" persisted="false" css="true">
       <!--v-if-->

--- a/packages/ui/src/components/tooltip/__tests__/index.test.ts
+++ b/packages/ui/src/components/tooltip/__tests__/index.test.ts
@@ -56,6 +56,34 @@ describe('Tooltip', () => {
     expect(wrapper.find('.ant-tooltip').exists()).toBe(true)
   })
 
+  it('positions popup with left/top styles instead of transform', async () => {
+    const wrapper = mount(Tooltip, {
+      attachTo: document.body,
+      props: {
+        title: 'prompt text',
+        open: true,
+        zIndex: 1234,
+        overlayStyle: {
+          maxWidth: '123px',
+        },
+      },
+      slots: { default: () => h('span', 'Trigger') },
+    })
+
+    await nextTick()
+    await nextTick()
+
+    const popup = document.body.querySelector('.ant-trigger-popup') as HTMLElement | null
+    const styleAttr = popup?.getAttribute('style') ?? ''
+
+    expect(popup).not.toBeNull()
+    expect(styleAttr).toContain('left:')
+    expect(styleAttr).toContain('top:')
+    expect(styleAttr).not.toContain('transform:')
+
+    wrapper.unmount()
+  })
+
   it('supports overlayClassName', () => {
     const wrapper = mount(Tooltip, {
       props: {

--- a/packages/ui/src/components/tooltip/__tests__/index.test.ts
+++ b/packages/ui/src/components/tooltip/__tests__/index.test.ts
@@ -65,6 +65,8 @@ describe('Tooltip', () => {
         zIndex: 1234,
         overlayStyle: {
           maxWidth: '123px',
+          opacity: 0.9,
+          '--tooltip-test-color': '#f50',
         },
       },
       slots: { default: () => h('span', 'Trigger') },
@@ -73,13 +75,16 @@ describe('Tooltip', () => {
     await nextTick()
     await nextTick()
 
-    const popup = document.body.querySelector('.ant-trigger-popup') as HTMLElement | null
+    const popup = (wrapper.vm as { getPopupDomNode: () => HTMLElement | null }).getPopupDomNode()
     const styleAttr = popup?.getAttribute('style') ?? ''
 
     expect(popup).not.toBeNull()
     expect(styleAttr).toContain('left:')
     expect(styleAttr).toContain('top:')
     expect(styleAttr).not.toContain('transform:')
+    expect(styleAttr).toContain('max-width: 123px')
+    expect(styleAttr).toContain('opacity: 0.9')
+    expect(styleAttr).toContain('--tooltip-test-color: #f50')
 
     wrapper.unmount()
   })

--- a/packages/ui/src/components/tooltip/style/index.css
+++ b/packages/ui/src/components/tooltip/style/index.css
@@ -25,7 +25,7 @@
 }
 
 :where(.ant-tooltip) .ant-trigger-arrow {
-  background: var(--tooltip-bg);
+  --ant-trigger-arrow-background: var(--tooltip-bg);
 }
 
 /* Preset colors */

--- a/packages/ui/src/components/tooltip/types.ts
+++ b/packages/ui/src/components/tooltip/types.ts
@@ -1,5 +1,6 @@
+import type { CSSProperties } from 'vue'
 import type { Placement } from '@floating-ui/vue'
-import type { Slot, ScopedSlot } from '@/utils/types'
+import type { Slot } from '@/utils/types'
 import type { TriggerType } from '@/_internal/trigger/types'
 
 /** Preset tooltip colors */
@@ -100,7 +101,7 @@ export interface TooltipProps {
   /** Class applied to the overlay element */
   overlayClassName?: string
   /** Style applied to the overlay element */
-  overlayStyle?: Record<string, string>
+  overlayStyle?: CSSProperties
   /** Style applied to the inner content */
   overlayInnerStyle?: Record<string, string>
   /** Whether to destroy the tooltip DOM when hidden */


### PR DESCRIPTION
Summary
- Restore Popconfirm compatibility with previous behavior, including legacy prop and slot precedence, callback compatibility, async confirm loading, and Escape-to-close handling.
- Fix playground preview parsing for script setup blocks so Popconfirm demos render slot content correctly.
- Switch shared popup positioning from transform-based placement to left/top positioning to avoid jumpy placement behavior, and restore the legacy-style arrow structure and styling.
- Add regression coverage for Popconfirm behavior, demo rendering, and tooltip popup positioning.

Testing
- npm exec vitest run index.test.ts demo.test.ts index.test.ts

Related: #8497 