### PR TITLE
fix(date-picker): keep typed values on blur and avoid unnecessary ran…

### DIFF
--- a/components/vc-picker/RangePicker.tsx
+++ b/components/vc-picker/RangePicker.tsx
@@ -489,7 +489,12 @@ function RangerPicker<DateType>() {
         }, 0);
       }
 
-      function triggerChange(newValue: RangeValue<DateType>, sourceIndex: 0 | 1) {
+      function triggerChange(
+        newValue: RangeValue<DateType>,
+        sourceIndex: 0 | 1,
+        /** When true (input submit only): skip auto-switch if both ends are valid; panel select omits or passes false */
+        fromInput?: boolean,
+      ) {
         let values = newValue;
         let startValue = getValue(values, 0);
         let endValue = getValue(values, 1);
@@ -589,13 +594,13 @@ function RangerPicker<DateType>() {
           nextOpenIndex = 0;
         }
 
-        // Keep current side when both start & end are already valid,
-        // which aligns with antd behavior for typed range input blur.
-        const hasBothValues = !!getValue(values, 0) && !!getValue(values, 1);
+        // Input submit: do not auto-switch when both ends are valid; panel select always auto-switches like antd.
+        const skipSwitchForFilledRange =
+          !!fromInput && !!getValue(values, 0) && !!getValue(values, 1);
         if (
           nextOpenIndex !== null &&
           nextOpenIndex !== mergedActivePickerIndex.value &&
-          !hasBothValues &&
+          !skipSwitchForFilledRange &&
           (!openRecordsRef.value[nextOpenIndex] || !getValue(values, nextOpenIndex)) &&
           getValue(values, sourceIndex)
         ) {
@@ -722,7 +727,7 @@ function RangerPicker<DateType>() {
           ) {
             return false;
           }
-          triggerChange(selectedValue.value, index);
+          triggerChange(selectedValue.value, index, true);
           resetText();
         },
         onCancel: () => {

--- a/components/vc-picker/RangePicker.tsx
+++ b/components/vc-picker/RangePicker.tsx
@@ -589,9 +589,13 @@ function RangerPicker<DateType>() {
           nextOpenIndex = 0;
         }
 
+        // Keep current side when both start & end are already valid,
+        // which aligns with antd behavior for typed range input blur.
+        const hasBothValues = !!getValue(values, 0) && !!getValue(values, 1);
         if (
           nextOpenIndex !== null &&
           nextOpenIndex !== mergedActivePickerIndex.value &&
+          !hasBothValues &&
           (!openRecordsRef.value[nextOpenIndex] || !getValue(values, nextOpenIndex)) &&
           getValue(values, sourceIndex)
         ) {

--- a/components/vc-picker/hooks/usePickerInput.ts
+++ b/components/vc-picker/hooks/usePickerInput.ts
@@ -162,7 +162,9 @@ export default function usePickerInput({
           raf(() => {
             preventBlurRef.value = false;
           });
-        } else if (!focused.value || clickedOutside) {
+        } else if (!focused.value) {
+          // Keep popup open while input is still focused.
+          // Let blur handler decide submit/cancel for outside clicks.
           triggerOpen(false);
         }
       }


### PR DESCRIPTION
## Summary

This PR fixes two input/blur interaction issues in date pickers:

- **Single Picker**: when users type a valid date and click outside, the typed value is now preserved instead of being reverted.
- **Range Picker**: for manually typed input only, when both start and end values are already valid, blurring one side no longer auto-switches focus to the other side.

The behavior is updated to be consistent with the interaction pattern in **antd** for typed date input blur handling.

## What changed

- Updated `usePickerInput` outside-click handling to avoid closing too early while the input is still focused, so blur submit logic can complete.
- Updated `RangePicker` auto-open-next logic:
  - still guides users to the other side when one side is missing,
  - but for manually typed input, keeps current side when both values are already valid (no auto-switch on blur).

## Why

To improve consistency and predictability of typed date input behavior, this change aligns blur/commit interactions with commonly adopted patterns in both **antd** and **Element UI** date pickers.

## Test plan
- [x] Single picker: type a valid date, click outside, value is preserved.
- [x] Single picker: invalid/disabled date still follows existing validation behavior.
- [x] Range picker: when selecting via the panel, the previous interaction behavior remains unchanged.
- [x] Range picker (manual input only): when both sides are valid, blur does not auto-switch side.
- [x] No new lint errors in modified files.
