### PR TITLE
fix(select): use value as fallback key for missing options

### DIFF
--- a/components/select/__tests__/index.test.js
+++ b/components/select/__tests__/index.test.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { asyncExpect } from '../../../tests/utils';
+import { nextTick, ref } from 'vue';
 import Select from '..';
 import CloseOutlined from '@ant-design/icons-vue/CloseOutlined';
 import focusTest from '../../../tests/shared/focusTest';
@@ -203,6 +204,34 @@ describe('Select', () => {
       const el = wrapper.find('.ant-select');
       expect(el.classes()).not.toContain('ant-select-focused');
     }, 200);
+  });
+
+  it('should use value as key when selected option is missing', async () => {
+    const wrapper = mount(
+      {
+        setup() {
+          const options = ref([]);
+          return { options };
+        },
+        render() {
+          return <Select mode="multiple" value={[1, 0]} options={this.options} />;
+        },
+      },
+      {
+        sync: false,
+        attachTo: 'body',
+      },
+    );
+    wrapper.vm.options = [
+      {
+        value: 1,
+        label: 'one',
+      },
+    ];
+    await nextTick();
+
+    const baseSelect = wrapper.findComponent({ name: 'BaseSelect' });
+    expect(baseSelect.props('displayValues').map(item => item.key)).toEqual([1, 0]);
   });
 
   describe('Select Custom Icons', () => {

--- a/components/vc-select/Select.tsx
+++ b/components/vc-select/Select.tsx
@@ -240,6 +240,8 @@ export default defineComponent({
           //     warning(false, '`label` of `value` is not same as `label` in Select options.');
           //   }
           // }
+        } else if (rawKey === undefined) {
+          rawKey = rawValue;
         }
 
         return {


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?

When `Select` is used in `multiple` mode with remotely loaded options, selected values can exist before their corresponding options are available.

In this case, `convert2LabelValues` kept the selected item `key` as `undefined`. `vc-overflow` then fell back to the item index as the rendered key. If another selected item has a numeric option key equal to that index after options load, duplicate keys can be generated and removing selected tags may behave incorrectly.

This PR uses the raw selected value as the fallback key when the option is not available yet.

Related previous PR: https://github.com/vueComponent/ant-design-vue/pull/8042

### API Realization (Optional if not new feature)

No API changes.

Implementation:

- Keep existing behavior when an option is found: use `option.key ?? rawValue`.
- When no option is found and `rawKey` is still missing, use `rawValue` as the selected item key.
- Add a regression test for dynamically loaded options with numeric selected values.

### What's the effect? (Optional if not new feature)

This fixes unstable selected tag keys when options are loaded asynchronously. It avoids duplicate keys in `vc-overflow` and keeps selected tag removal behavior stable.

No breaking change is expected.

### Changelog description (Optional if not new feature)

1. Fix Select selected tag keys when selected options are missing during async option loading.
2. 修复 Select 远程加载选项时已选项 key 可能缺失导致的标签删除异常问题。

### Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Test

```bash
./node_modules/.bin/jest components/select/__tests__/index.test.js --config .jest.js --runInBand -t "should use value as key when selected option is missing"
```