### PR TITLE
fix(select): clear tokenized search text in tags mode

### DIFF
--- a/components/select/__tests__/index.test.js
+++ b/components/select/__tests__/index.test.js
@@ -4,6 +4,7 @@ import Select from '..';
 import CloseOutlined from '@ant-design/icons-vue/CloseOutlined';
 import focusTest from '../../../tests/shared/focusTest';
 import mountTest from '../../../tests/shared/mountTest';
+import KeyCode from '../../_util/KeyCode';
 function $$(className) {
   return document.body.querySelectorAll(className);
 }
@@ -203,6 +204,44 @@ describe('Select', () => {
       const el = wrapper.find('.ant-select');
       expect(el.classes()).not.toContain('ant-select-focused');
     }, 200);
+  });
+
+  it('should clear tokenized search text after split', async () => {
+    const wrapper = mount(
+      {
+        render() {
+          return <Select mode="tags" tokenSeparators={[',']} />;
+        },
+      },
+      {
+        sync: false,
+        attachTo: 'body',
+      },
+    );
+    const input = wrapper.find('input');
+
+    input.element.value = 'Lucy,Jack,';
+    await input.trigger('input');
+
+    await asyncExpect(() => {
+      expect(input.element.value).toBe('');
+      expect(wrapper.findAll('.ant-select-selection-item').length).toBe(2);
+    });
+
+    const backspaceEvent = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Backspace',
+    });
+    Object.defineProperty(backspaceEvent, 'which', { get: () => KeyCode.BACKSPACE });
+    Object.defineProperty(backspaceEvent, 'keyCode', { get: () => KeyCode.BACKSPACE });
+    input.element.dispatchEvent(backspaceEvent);
+
+    await asyncExpect(() => {
+      const items = wrapper.findAll('.ant-select-selection-item');
+      expect(items.length).toBe(1);
+      expect(items[0].text()).toBe('Lucy');
+    });
   });
 
   describe('Select Custom Icons', () => {

--- a/components/vc-select/Selector/MultipleSelector.tsx
+++ b/components/vc-select/Selector/MultipleSelector.tsx
@@ -211,7 +211,10 @@ const SelectSelector = defineComponent<SelectorProps>({
       const composing = (e.target as any).composing;
       targetValue.value = (e.target as any).value;
       if (!composing) {
-        props.onInputChange(e);
+        const ret = props.onInputChange(e);
+        if (ret === false) {
+          targetValue.value = '';
+        }
       }
     };
 

--- a/components/vc-select/Selector/index.tsx
+++ b/components/vc-select/Selector/index.tsx
@@ -168,9 +168,12 @@ const Selector = defineComponent<SelectorProps>({
     let pastedText = null;
 
     const triggerOnSearch = (value: string) => {
-      if (props.onSearch(value, true, compositionStatus.value) !== false) {
+      const ret = props.onSearch(value, true, compositionStatus.value);
+      if (ret !== false) {
         props.onToggleOpen(true);
       }
+
+      return ret;
     };
 
     const onInputCompositionStart = () => {
@@ -185,10 +188,9 @@ const Selector = defineComponent<SelectorProps>({
       }
     };
 
-    const onInputChange = (event: { target: { value: any } }) => {
-      let {
-        target: { value },
-      } = event;
+    const onInputChange = (event: Event) => {
+      const target = event.target as HTMLInputElement;
+      let { value } = target;
 
       // Pasted text should replace back to origin content
       if (props.tokenWithEnter && pastedText && /[\r\n]/.test(pastedText)) {
@@ -202,7 +204,12 @@ const Selector = defineComponent<SelectorProps>({
 
       pastedText = null;
 
-      triggerOnSearch(value);
+      const ret = triggerOnSearch(value);
+      if (ret === false) {
+        target.value = '';
+      }
+
+      return ret;
     };
 
     const onInputPaste = (e: ClipboardEvent) => {

--- a/components/vc-select/Selector/interface.ts
+++ b/components/vc-select/Selector/interface.ts
@@ -21,7 +21,7 @@ export interface InnerSelectorProps {
   tabindex?: number | string;
   onInputKeyDown: EventHandler;
   onInputMouseDown: EventHandler;
-  onInputChange: EventHandler;
+  onInputChange: (event: Event) => boolean | void;
   onInputPaste: EventHandler;
   onInputCompositionStart: EventHandler;
   onInputCompositionEnd: EventHandler;


### PR DESCRIPTION
This PR fixes Select tags mode behavior when `tokenSeparators` is used, ensuring tokenized input text is cleared correctly and Backspace can remove the last tag after automatic tokenization.

Fixes #8076.

### What Changed

**Selector/index.tsx:**

- Return the result of `onSearch` from the internal search trigger
- Clear the real input value when token splitting interrupts the normal input flow
- Keep token separator behavior aligned with the existing `onSearch` return contract

**MultipleSelector.tsx:**

- Clear the internal `targetValue` when parent search handling returns `false`
- Prevent stale tokenized text from remaining in the selector input after split

**interface.ts:**

- Updated `onInputChange` typing to allow returning `boolean | void`

**Tests:**

- Added a regression test for `Select` with `mode="tags"` and `tokenSeparators`
- Covered automatic tokenization followed by Backspace removal of the last tag

### Validation

```bash
npx jest components/select/__tests__/index.test.js --config .jest.js --runInBand -t "should clear tokenized search text after split"
