### PR TITLE
fix(select): 将 role=option 从隐藏容器移至可见列表项

### DIFF
--- a/components/select/__tests__/index.test.js
+++ b/components/select/__tests__/index.test.js
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils';
-import { asyncExpect } from '../../../tests/utils';
+import { asyncExpect, sleep } from '../../../tests/utils';
 import Select from '..';
 import CloseOutlined from '@ant-design/icons-vue/CloseOutlined';
 import focusTest from '../../../tests/shared/focusTest';
@@ -221,6 +221,44 @@ describe('Select', () => {
         },
       });
       expect(wrapper.html()).toMatchSnapshot();
+    });
+  });
+
+  // Regression test for https://github.com/vueComponent/ant-design-vue/issues/8537
+  // role="option" elements should be on the actual clickable items, not hidden elements.
+  // The bug: role="option" is placed inside a zero-height hidden container, so clicking
+  // any element found by [role="option"] does not trigger onChange.
+  describe('Select accessibility: role="option" should be on interactable elements', () => {
+    it('clicking element found by [role="option"] should trigger onChange', async () => {
+      const onChange = jest.fn();
+      mount(
+        {
+          render() {
+            return (
+              <Select style="width:200px" onChange={onChange}>
+                <Select.Option value="1">Option A</Select.Option>
+                <Select.Option value="2">Option B</Select.Option>
+              </Select>
+            );
+          },
+        },
+        { attachTo: 'body' },
+      );
+
+      // Open the dropdown
+      $$('.ant-select-selector')[0].dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      await sleep(100);
+
+      // Simulate what a test author (or AT tool) does: query by ARIA role, then click.
+      const optionElements = Array.from($$('[role="option"]'));
+      expect(optionElements.length).toBeGreaterThan(0);
+      // Click the first option found by role — this is the element AT users interact with.
+      optionElements[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await sleep(0);
+
+      // If role="option" is on a hidden element (the current bug), the click above has no
+      // effect and onChange is never called.
+      expect(onChange).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/components/vc-select/OptionList.tsx
+++ b/components/vc-select/OptionList.tsx
@@ -161,7 +161,6 @@ const OptionList = defineComponent({
           aria-label={typeof mergedLabel === 'string' && !group ? mergedLabel : null}
           {...attrs}
           key={index}
-          role={group ? 'presentation' : 'option'}
           id={`${baseProps.id}_list_${index}`}
           aria-selected={isSelected(value)}
         >
@@ -344,6 +343,7 @@ const OptionList = defineComponent({
                 return (
                   <div
                     {...passedProps}
+                    role="option"
                     aria-selected={selected}
                     class={optionClassName}
                     title={optionTitle}


### PR DESCRIPTION
### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

关联 issue：https://github.com/vueComponent/ant-design-vue/issues/8537

`<a-select>` 存在两套 DOM 结构：

- **隐藏容器**（`height: 0px`）中的 `div` 带有 `role="option"`，但不可见、不可点击
- **可见的虚拟列表**中的 `.ant-select-item` 才是真正可点击的，但没有 `role="option"`

导致两个问题：
1. 屏幕阅读器读出的 `role="option"` 元素用户无法激活
2. 测试工具通过 `[role="option"]` 找到的是隐藏元素，点击无效

### 实现方案

**隐藏容器的设计意图**：虚拟列表会回收不在视口中的 DOM 节点，隐藏容器通过始终保持 activeIndex 前后各一项在 DOM 里，确保 `aria-activedescendant` 指向的 ID 始终存在，供屏幕阅读器键盘导航使用。

**修改内容**（`components/vc-select/OptionList.tsx`，2 行变动）：

1. 隐藏容器的 `renderItem` 去掉 `role` 属性——保留 `id` 和 `aria-selected`，`aria-activedescendant` 引用的 ID 仍然有效，键盘导航行为不受影响
2. 可见虚拟列表的选项 `div` 加上 `role="option"`

### 对用户的影响和可能的风险

- 无 break change
- 屏幕阅读器键盘导航行为不变（`aria-activedescendant` 仍指向隐藏容器中带 `id` 的节点）
- 测试工具和辅助技术现在可以通过 `[role="option"]` 找到真实可点击的元素

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供