### PR TITLE
fix: 修复 Space 组件 wrap 模式下与同级元素垂直对齐问题

### DIFF
--- a/components/space/index.tsx
+++ b/components/space/index.tsx
@@ -84,7 +84,10 @@ const Space = defineComponent({
       }
       return {
         ...gapStyle,
-        ...(props.wrap && { flexWrap: 'wrap', marginBottom: `${-verticalSize.value}px` }),
+        ...(props.wrap && {
+          flexWrap: 'wrap',
+          ...(!supportFlexGap.value && { marginBottom: `${-verticalSize.value}px` }),
+        }),
       } as CSSProperties;
     });
     return () => {


### PR DESCRIPTION
## 问题描述
当 Space 组件使用 `wrap` 属性时，在支持 flex-gap 的现代浏览器中，Space 组件与同级元素在垂直方向上有对齐偏差。

## 根本原因
Space 组件在 wrap 模式下无条件添加了负的 `margin-bottom`，用于处理旧浏览器不支持 flex-gap 时的行间距问题。但这个负 margin 导致了容器本身的垂直偏移。

## 修复方案
仅当浏览器不支持 flex-gap 时才应用负 margin，支持 flex-gap 的浏览器使用 `row-gap` 处理间距。

## 修改内容
- 修改 [components/space/index.tsx](file:///workspace/components/space/index.tsx#L87-L90)
- 将负 margin 限制在 `!supportFlexGap` 条件下

## 验证
- 在支持 flex-gap 的浏览器中，Space 组件与同级元素现在可以正确对齐
- 旧浏览器兼容性保持不变