### PR TITLE
fix(message): refresh notices on theme change to prevent style loss

### DIFF
--- a/components/message/useMessage.tsx
+++ b/components/message/useMessage.tsx
@@ -1,4 +1,4 @@
-import { shallowRef, computed, defineComponent } from 'vue';
+import { shallowRef, computed, defineComponent, watch } from 'vue';
 import { useNotification as useVcNotification } from '../vc-notification';
 import type { NotificationAPI } from '../vc-notification';
 import CloseOutlined from '@ant-design/icons-vue/CloseOutlined';
@@ -117,6 +117,9 @@ export function useInternalMessage(
 ): readonly [MessageInstance, () => VNode] {
   const holderRef = shallowRef<HolderRef>(null);
   const holderKey = Symbol('messageHolderKey');
+  // Store notice configs to refresh when theme changes (hashId update)
+  const noticeConfigs = new Map<Key, ArgsProps>();
+
   // ================================ API ================================
 
   // Wrap with notification content
@@ -143,6 +146,9 @@ export function useInternalMessage(
       mergedKey = `antd-message-${keyIndex}`;
     }
 
+    // Store config for theme-change refresh
+    noticeConfigs.set(mergedKey, { ...config, key: mergedKey });
+
     return wrapPromiseFn(resolve => {
       originOpen({
         ...restConfig,
@@ -160,6 +166,7 @@ export function useInternalMessage(
         // @ts-ignore
         class: classNames(type && `${noticePrefixCls}-${type}`, hashId, className),
         onClose: () => {
+          noticeConfigs.delete(mergedKey);
           onClose?.();
           resolve();
         },
@@ -175,8 +182,10 @@ export function useInternalMessage(
   // >>> destroy
   const destroy = (key?: Key) => {
     if (key !== undefined) {
+      noticeConfigs.delete(key);
       close(key);
     } else {
+      noticeConfigs.clear();
       holderRef.value?.destroy();
     }
   };
@@ -220,6 +229,20 @@ export function useInternalMessage(
 
     wrapAPI[type] = typeOpen;
   });
+
+  // Watch for theme changes (hashId changes) and refresh all notices
+  watch(
+    () => holderRef.value?.hashId,
+    (newHashId, oldHashId) => {
+      if (oldHashId && newHashId !== oldHashId) {
+        const entries = Array.from(noticeConfigs.entries());
+        entries.forEach(([, config]) => {
+          // Re-open with same config to get new hashId
+          open(config);
+        });
+      }
+    },
+  );
 
   // ============================== Return ===============================
   return [wrapAPI, () => <Holder key={holderKey} {...messageConfig} ref={holderRef} />] as const;


### PR DESCRIPTION
## Problem

When switching between dark/light theme while messages are displayed via `useMessage` hooks API, the existing message notices lose their styles (background, icon, text color).

Root cause: The CSS-in-JS `hashId` changes when the theme switches. New CSS rules are injected with the new `hashId`, while old rules are removed. Existing notices still have the old `hashId` class, so they no longer match any CSS rules.

## Solution

Store notice configs in a `Map<Key, ArgsProps>` and watch for `hashId` changes on `holderRef.value`. When `hashId` changes (theme switch), re-create all existing notices by calling `open()` again with the same configs. The vc-notification `add()` method replaces notices with the same key, so existing notices are updated in-place without animation flash.

## Changes

- Import `watch` from Vue
- Add `noticeConfigs` Map to store notice configs with their keys
- Update `onClose` callback to clean up `noticeConfigs` when a notice is closed
- Update `destroy()` to clean up `noticeConfigs` when destroying notices
- Add `watch` on `holderRef.value?.hashId` to detect theme changes and re-create all notices

## Testing

- [x] Existing message component tests pass (12/12)
- [x] Manual test: displayed message via `useMessage`, switched theme, message styles updated correctly

Closes #8419