### PR TITLE
docs(locale): fill missing nb_NO (Norwegian) keys

### DIFF
--- a/components/locale/nb_NO.ts
+++ b/components/locale/nb_NO.ts
@@ -21,8 +21,12 @@ const localeValues: Locale = {
     filterConfirm: 'OK',
     filterReset: 'Nullstill',
     filterEmptyText: 'Ingen filtre',
+    filterCheckall: 'Velg alle elementer',
+    filterSearchPlaceholder: 'Søk i filtre',
+    emptyText: 'Ingen data',
     selectAll: 'Velg alle',
     selectInvert: 'Inverter gjeldende side',
+    selectNone: 'Fjern all data',
     selectionAll: 'Velg all data',
     sortTitle: 'Sorter',
     expand: 'Utvid rad',
@@ -30,6 +34,11 @@ const localeValues: Locale = {
     triggerDesc: 'Sorter data i synkende rekkefølge',
     triggerAsc: 'Sorterer data i stigende rekkefølge',
     cancelSort: 'Klikk for å avbryte sorteringen',
+  },
+  Tour: {
+    Next: 'Neste',
+    Previous: 'Forrige',
+    Finish: 'Fullfør',
   },
   Modal: {
     okText: 'OK',
@@ -75,6 +84,7 @@ const localeValues: Locale = {
     back: 'Tilbake',
   },
   Form: {
+    optional: '(valgfritt)',
     defaultValidateMessages: {
       default: 'Feltvalideringsfeil ${label}',
       required: 'Vennligst skriv inn ${label}',
@@ -122,6 +132,14 @@ const localeValues: Locale = {
         mismatch: '${label} stemmer ikke overens med mønsteret ${pattern}',
       },
     },
+  },
+  Image: {
+    preview: 'Forhåndsvisning',
+  },
+  QRCode: {
+    expired: 'QR-koden er utløpt',
+    refresh: 'Oppdater',
+    scanned: 'Skannet',
   },
 };
 


### PR DESCRIPTION
Fills the missing keys in the Norwegian Bokmål (`nb_NO`) locale so it matches `en_US`.

Added:
- `Tour` (Next / Previous / Finish)
- `Image.preview`
- `QRCode` (expired / refresh / scanned)
- `Form.optional`
- `Table`: `filterCheckall`, `filterSearchPlaceholder`, `emptyText`, `selectNone`

No existing translations were changed — this only adds the previously-missing keys.

Disclosure: prepared with AI assistance and reviewed by me as a native Norwegian (Bokmål) speaker.

### Change Log
| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Fill missing keys in the Norwegian (`nb_NO`) locale. |
| 🇨🇳 Chinese | 补全挪威语（nb_NO）语言包中缺失的文案。 |