### PR TITLE
fix(mentions): ignore the Enter that confirms an IME composition

### DIFF
--- a/components/mentions/__tests__/index.test.js
+++ b/components/mentions/__tests__/index.test.js
@@ -100,4 +100,47 @@ describe('Mentions', () => {
 
     expect(wrapper.find('textarea').element.value).toBe('@notExist');
   });
+
+  it('does not select the active option when Enter only confirms an IME composition', async () => {
+    jest.useRealTimers();
+    const onSelect = jest.fn();
+    const wrapper = mount(
+      {
+        render() {
+          return (
+            <Mentions onSelect={onSelect}>
+              <Option value="bamboo">Bamboo</Option>
+              <Option value="cat">Cat</Option>
+            </Mentions>
+          );
+        },
+      },
+      { sync: false, attachTo: 'body' },
+    );
+    await sleep();
+    triggerInput(wrapper, '@');
+    await sleep();
+
+    const textarea = wrapper.find('textarea').element;
+    // BaseInput flags the element as composing on compositionstart. Some browsers
+    // (e.g. Safari) still report `which === ENTER` for the keydown that confirms it.
+    textarea.composing = true;
+    const composingEnter = new KeyboardEvent('keydown', { bubbles: true, cancelable: true });
+    Object.defineProperty(composingEnter, 'which', { get: () => KeyCode.ENTER });
+    textarea.dispatchEvent(composingEnter);
+    await sleep();
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(wrapper.find('textarea').element.value).toBe('@');
+
+    // A normal Enter still selects the active option.
+    textarea.composing = false;
+    const normalEnter = new KeyboardEvent('keydown', { bubbles: true, cancelable: true });
+    Object.defineProperty(normalEnter, 'which', { get: () => KeyCode.ENTER });
+    textarea.dispatchEvent(normalEnter);
+    await sleep();
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(wrapper.find('textarea').element.value).toBe('@bamboo ');
+  });
 });

--- a/components/vc-mentions/src/Mentions.tsx
+++ b/components/vc-mentions/src/Mentions.tsx
@@ -99,6 +99,11 @@ export default defineComponent({
       } else if (which === KeyCode.ESC) {
         stopMeasure();
       } else if (which === KeyCode.ENTER) {
+        // Ignore the Enter that only confirms an IME composition, the same case
+        // `onKeyUp` and vc-select's Selector already guard against.
+        if ((event.target as any).composing) {
+          return;
+        }
         // Measure hit
         event.preventDefault();
         if (!options.value.length) {


### PR DESCRIPTION
### Nature of this change

- [x] Daily bug fix

### Background

When the mention dropdown is open, pressing Enter to confirm an IME composition selects the active option instead of just committing the composed text. A CJK user typing a `@` mention and confirming their composition with Enter inserts the highlighted suggestion by accident.

On browsers such as Safari, the keydown that confirms an IME composition still reports `which === ENTER` while the input is composing, so it reaches the `KeyCode.ENTER` branch in `onKeyDown` and runs `selectOption`. Chromium and Firefox report `keyCode 229` for that keydown and are not affected.

### Implementation

`onKeyUp` in the same component already returns early when `(target).composing` is set, and `vc-select`'s `SingleSelector`/`MultipleSelector` guard their input the same way. This mirrors that guard in the `onKeyDown` `ENTER` branch, before `preventDefault`, so the composing Enter is left to commit the text.

### Impact and risk

Only affects the Enter keydown while the input is composing. A normal Enter still selects the active option. Added a test in `components/mentions/__tests__/index.test.js` covering both cases.

### Changelog

- EN: Mentions: do not select the active option for the Enter that only confirms an IME composition.
- CN: Mentions: 输入法组合输入时确认用的回车不再误选当前候选项。
