### PR TITLE
fix(select): 修复 Select tags 模式下自动分词后输入框残留粘贴内容的问题

### DIFF
--- a/components/select/__tests__/index.test.js
+++ b/components/select/__tests__/index.test.js
@@ -205,6 +205,51 @@ describe('Select', () => {
     }, 200);
   });
 
+  it('should clear pasted token text after tokenizing tags', async () => {
+    const wrapper = mount(
+      {
+        render() {
+          return (
+            <Select
+              mode="tags"
+              tokenSeparators={[',']}
+              options={[{ value: 'a1', label: 'a1' }]}
+              allowClear
+            />
+          );
+        },
+      },
+      {
+        sync: false,
+        attachTo: 'body',
+      },
+    );
+
+    const input = wrapper.find('.ant-select-selection-search-input');
+    input.element.value = 'Lucy,Jack';
+
+    await input.trigger('paste', {
+      clipboardData: {
+        getData: () => 'Lucy,Jack',
+      },
+    });
+    await input.trigger('input');
+
+    await asyncExpect(() => {
+      expect(
+        wrapper.findAll('.ant-select-selection-item-content').map(item => item.text()),
+      ).toEqual(['Lucy', 'Jack']);
+      expect(wrapper.find('.ant-select-selection-search-input').element.value).toBe('');
+    });
+
+    await wrapper.find('.ant-select-clear').trigger('mousedown');
+
+    await asyncExpect(() => {
+      expect(wrapper.findAll('.ant-select-selection-item-content')).toHaveLength(0);
+      expect(wrapper.find('.ant-select-selection-search-input').element.value).toBe('');
+    });
+  });
+
   describe('Select Custom Icons', () => {
     it('should support customized icons', () => {
       const wrapper = mount({

--- a/components/vc-select/Selector/MultipleSelector.tsx
+++ b/components/vc-select/Selector/MultipleSelector.tsx
@@ -211,7 +211,11 @@ const SelectSelector = defineComponent<SelectorProps>({
       const composing = (e.target as any).composing;
       targetValue.value = (e.target as any).value;
       if (!composing) {
-        props.onInputChange(e);
+        const ret = props.onInputChange(e);
+
+        if (ret === false) {
+          targetValue.value = inputValue.value;
+        }
       }
     };
 

--- a/components/vc-select/Selector/index.tsx
+++ b/components/vc-select/Selector/index.tsx
@@ -168,9 +168,13 @@ const Selector = defineComponent<SelectorProps>({
     let pastedText = null;
 
     const triggerOnSearch = (value: string) => {
-      if (props.onSearch(value, true, compositionStatus.value) !== false) {
+      const ret = props.onSearch(value, true, compositionStatus.value);
+
+      if (ret !== false) {
         props.onToggleOpen(true);
       }
+
+      return ret;
     };
 
     const onInputCompositionStart = () => {
@@ -202,7 +206,7 @@ const Selector = defineComponent<SelectorProps>({
 
       pastedText = null;
 
-      triggerOnSearch(value);
+      return triggerOnSearch(value);
     };
 
     const onInputPaste = (e: ClipboardEvent) => {

--- a/components/vc-select/Selector/interface.ts
+++ b/components/vc-select/Selector/interface.ts
@@ -21,7 +21,7 @@ export interface InnerSelectorProps {
   tabindex?: number | string;
   onInputKeyDown: EventHandler;
   onInputMouseDown: EventHandler;
-  onInputChange: EventHandler;
+  onInputChange: (...args: any[]) => boolean | void;
   onInputPaste: EventHandler;
   onInputCompositionStart: EventHandler;
   onInputCompositionEnd: EventHandler;


### PR DESCRIPTION
## 变更说明

修复 Select 在 `tags` 模式下使用 `tokenSeparators` 自动分词时，粘贴内容残留在输入框中的问题。

当粘贴 `Lucy,Jack` 这类逗号分隔内容时，组件会正确生成标签，但原始粘贴文本仍会显示在输入框中；清空已选标签后，残留文本也可能继续浮在选择框里。

## 问题原因

分词命中后，父级搜索逻辑会返回 `false`，表示当前输入已被消费；但 `MultipleSelector` 内部仍保留了 DOM 输入事件中的本地 `targetValue`。当父级 `searchValue` 原本就是空字符串时，不会触发额外的响应式更新，导致输入框本地值没有被清空。

## 修改内容

- 将 `Selector` 中 `onSearch` 的返回值继续传递给子选择器。
- 当搜索处理返回 `false` 时，`MultipleSelector` 将本地输入值同步回父级 `searchValue`。
- 调整内部 `onInputChange` 类型，允许返回 `boolean | void`。
- 新增回归测试，覆盖粘贴自动分词后输入框清空、再清空标签不残留文本的场景。

## 测试

- `jest --config .jest.js components/select/__tests__/index.test.js -t "should clear pasted token text after tokenizing tags" --runInBand`
- `eslint components/vc-select/Selector/index.tsx components/vc-select/Selector/MultipleSelector.tsx components/vc-select/Selector/interface.ts components/select/__tests__/index.test.js --max-warnings=0`
- `git diff --check`

## 关联 Issue

Fixes #8564