### PR TITLE
fix(config-provider): 修复嵌套主题配置泄漏

### DIFF
--- a/components/config-provider/__tests__/index.test.js
+++ b/components/config-provider/__tests__/index.test.js
@@ -1,8 +1,20 @@
 import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
 import ConfigProvider from '..';
 import Button from '../../button';
+import theme from '../../theme';
 import mountTest from '../../../tests/shared/mountTest';
 import { sleep } from '../../../tests/utils';
+
+const TokenProbe = defineComponent({
+  props: {
+    name: String,
+  },
+  setup(props) {
+    const { token } = theme.useToken();
+    return () => <span class={`token-probe-${props.name}`}>{token.value.colorPrimary}</span>;
+  },
+});
 
 describe('ConfigProvider', () => {
   mountTest({
@@ -51,5 +63,28 @@ describe('ConfigProvider', () => {
     wrapper.vm.autoInsertSpaceInButton = true;
     await sleep();
     expect(wrapper.find('.ant-btn').text()).toBe('确 定');
+  });
+
+  it('should not leak nested theme token to sibling components', async () => {
+    const customColor = '#ff0000';
+    const wrapper = mount({
+      render() {
+        return (
+          <>
+            <TokenProbe name="outside-before" />
+            <ConfigProvider theme={{ token: { colorPrimary: customColor } }}>
+              <TokenProbe name="inside" />
+            </ConfigProvider>
+            <TokenProbe name="outside-after" />
+          </>
+        );
+      },
+    });
+
+    await sleep();
+
+    expect(wrapper.find('.token-probe-inside').text()).toBe(customColor);
+    expect(wrapper.find('.token-probe-outside-before').text()).toBe(theme.defaultSeed.colorPrimary);
+    expect(wrapper.find('.token-probe-outside-after').text()).toBe(theme.defaultSeed.colorPrimary);
   });
 });

--- a/components/theme/internal.ts
+++ b/components/theme/internal.ts
@@ -21,16 +21,7 @@ import statisticToken, { merge as mergeToken, statistic } from './util/statistic
 import type { VueNode } from '../_util/type';
 import { objectType } from '../_util/type';
 import type { ComputedRef, InjectionKey, Ref } from 'vue';
-import {
-  triggerRef,
-  unref,
-  defineComponent,
-  provide,
-  computed,
-  inject,
-  watch,
-  shallowRef,
-} from 'vue';
+import { defineComponent, provide, computed, inject, shallowRef } from 'vue';
 
 const defaultTheme = createTheme(defaultDerivative);
 
@@ -76,14 +67,6 @@ export const globalDesignTokenApi = shallowRef<DesignTokenContext>();
 
 export const useDesignTokenProvider = (value: ComputedRef<DesignTokenContext>) => {
   provide(DesignTokenContextKey, value);
-  watch(
-    value,
-    () => {
-      globalDesignTokenApi.value = unref(value);
-      triggerRef(globalDesignTokenApi);
-    },
-    { immediate: true, deep: true },
-  );
 };
 
 export const useDesignTokenInject = () => {


### PR DESCRIPTION
## 描述

### 背景

Fixes #7885

嵌套使用 `ConfigProvider theme` 时，局部主题 token 会写入全局 `globalDesignTokenApi` fallback，导致不在该 `ConfigProvider` 包裹范围内的兄弟组件也可能读取到局部主题配置。

### 改动

- 移除 `DesignTokenProvider` 对 `globalDesignTokenApi` 的局部主题写入，仅通过 Vue `provide` 向后代组件传递 token。
- 新增回归测试，覆盖嵌套 `ConfigProvider` 内部组件使用自定义 `colorPrimary`，外部兄弟组件保持默认 `colorPrimary` 的场景。

### 验证

- `npx eslint components/theme/internal.ts components/config-provider/__tests__/index.test.js`
- `npm test -- components/config-provider/__tests__/index.test.js -t "should not leak nested theme token|autoInsertSpaceInButton|mount and unmount" --runInBand`

### 备注

完整 `components/config-provider/__tests__/index.test.js` 当前仍有既有 CSP 用例失败，原因是旧测试读取 `Button` 内部 `$refs.wave.csp.nonce`，与本次主题作用域修复无关。