### PR TITLE
docs(input-number): only group the integer part in formatter demo

### DIFF
--- a/components/input-number/demo/formatter.vue
+++ b/components/input-number/demo/formatter.vue
@@ -20,7 +20,7 @@ Display value within it's situation with `formatter`, and we usually use `parser
   <a-space>
     <a-input-number
       v-model:value="value1"
-      :formatter="value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')"
+      :formatter="formatter"
       :parser="value => value.replace(/\$\s?|(,*)/g, '')"
     />
     <a-input-number
@@ -36,4 +36,9 @@ Display value within it's situation with `formatter`, and we usually use `parser
 import { ref } from 'vue';
 const value1 = ref<number>(1000);
 const value2 = ref<number>(100);
+const formatter = (value: number | string | undefined) => {
+  const [int, decimal] = `${value}`.split('.');
+  const groupedInt = int.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return `$ ${decimal ? `${groupedInt}.${decimal}` : groupedInt}`;
+};
 </script>


### PR DESCRIPTION
The formatter demo applies the thousands separator regex to the whole number, so the decimal part gets commas as well. `1.0445` renders as `$ 1.0,445`.

Split the value on the decimal point and group only the integer part, the way the antd demo and `Statistic` already do.

Fixes #8576

### Change Log
| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Fix the InputNumber formatter demo inserting separators inside the decimal part. |
| 🇨🇳 Chinese | 修复 InputNumber 格式化演示中小数部分被插入千分位分隔符的问题。 |