### PR TITLE
docs: fix custom date library registration order

### DIFF
--- a/site/src/vueDocs/replace-date.en-US.md
+++ b/site/src/vueDocs/replace-date.en-US.md
@@ -16,7 +16,7 @@ import { createApp } from 'vue';
 import App from './App.vue';
 import antd from 'ant-design-vue';
 const app = createApp(App);
-app.use(DatePicker).use(TimePicker).use(Calendar).use(antd).mount('#app');
+app.use(antd).use(DatePicker).use(TimePicker).use(Calendar).mount('#app');
 ```
 
-> Note: If you need to register the ant-design-vue component library globally, then `use(DatePicker)` `use(TimePicker)` `use(Calendar)` must be executed before `use(antd)`, otherwise the default cannot be overridden dayjs version.
+> Note: If you need to register the ant-design-vue component library globally, `use(DatePicker)`, `use(TimePicker)`, and `use(Calendar)` must be executed after `use(antd)` to override the default dayjs-based components.

--- a/site/src/vueDocs/replace-date.zh-CN.md
+++ b/site/src/vueDocs/replace-date.zh-CN.md
@@ -16,7 +16,7 @@ import { createApp } from 'vue';
 import App from './App.vue';
 import antd from 'ant-design-vue';
 const app = createApp(App);
-app.use(DatePicker).use(TimePicker).use(Calendar).use(antd).mount('#app');
+app.use(antd).use(DatePicker).use(TimePicker).use(Calendar).mount('#app');
 ```
 
-> 注意: 如果你需要全局注册 ant-design-vue 组件库，那么 `use(DatePicker)` `use(TimePicker)` `use(Calendar)` 必须在 `use(antd)` 之前执行，否则无法覆盖默认的 dayjs 版本。
+> 注意: 如果你需要全局注册 ant-design-vue 组件库，那么 `use(DatePicker)` `use(TimePicker)` `use(Calendar)` 必须在 `use(antd)` 之后执行，才能覆盖默认的 dayjs 版本。


### PR DESCRIPTION
## Description of Problem

The custom date library documentation registers the Moment.js or date-fns
components before the full ant-design-vue plugin. The full plugin then
registers the default dayjs-based components with the same component names,
overriding the custom implementations.

Fixes #8567.

## Proposed Solution

Register the full ant-design-vue plugin first, followed by DatePicker,
TimePicker, and Calendar from the selected custom date library.

Update both the Chinese and English notes to describe the correct order.

## Additional Information

Verified the component installation flow and ran `git diff --check`.